### PR TITLE
fix: Use correct Go toolchain version in GoReleaser workflow

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: v1.23
+           go-version-file: kagenti-webhook/go.mod
 
       - name: Delete non-semver tags
         run: 'git tag -d $(git tag -l | grep -v "^v") '


### PR DESCRIPTION
## Summary

This PR fixes a CI failure in the GoReleaser workflow caused by using an older Go version (1.23.x) while one of the modules in the repository (kagenti-webhook) requires Go 1.24.4 or newer.

Changes:
modified goreleaser.yml 
```
...
      - uses: actions/setup-go@v6
        with:
           go-version-file: kagenti-webhook/go.mod
...
```
