### PR TITLE
fix: Change the path to the manager

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,7 +4,7 @@ builds:
 - id: "kagenti-webhook"
   dir: kagenti-webhook
   main: ./cmd
-  binary: ./bin/manager
+  binary: manager
   goos:
   - linux
   - darwin
@@ -30,7 +30,7 @@ kos:
     tags:
       - '{{.Version}}'
       - latest
-    bare: true
+    bare: false
     preserve_import_paths: false
     platforms:
       - linux/amd64


### PR DESCRIPTION
# Description
This PR fixes the goreleaser issue which prevented the container to start in k8s. The bug happened due to the wrong specification for the binary. 
Instead of
 
`binary: bin/manager`

the right spec should be:

`binary: manager`