### PR TITLE
feat: Add keycloak flags to client registration container

### DIFF
--- a/kagenti-webhook/internal/webhook/injector/container_builder.go
+++ b/kagenti-webhook/internal/webhook/injector/container_builder.go
@@ -138,6 +138,30 @@ func BuildClientRegistrationContainer(clientID, name, namespace string) corev1.C
 				},
 			},
 			{
+				Name: "KEYCLOAK_TOKEN_EXCHANGE_ENABLED",
+				ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "environments",
+						},
+						Key:      "KEYCLOAK_TOKEN_EXCHANGE_ENABLED",
+						Optional: ptr.To(true),
+					},
+				},
+			},
+			{
+				Name: "KEYCLOAK_CLIENT_REGISTRATION_ENABLED",
+				ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "environments",
+						},
+						Key:      "KEYCLOAK_CLIENT_REGISTRATION_ENABLED",
+						Optional: ptr.To(true),
+					},
+				},
+			},
+			{
 				Name:  "CLIENT_NAME",
 				Value: clientId,
 			},


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->

Adds two new environment variables to the client registration container in the container_builder component of the webhook. The changes mimic changes made to the old platform-operator (https://github.com/kagenti/kagenti-operator/pull/136)

Fixes # (issue)
Related to 
- https://github.com/kagenti/kagenti/pull/399
- https://github.com/kagenti/kagenti-operator/pull/136

## Type of Change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] CI/CD update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. -->

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Kubernetes version:
- Toolhive webhook version:
- OS:

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if appropriate)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the pull request here -->
