### PR TITLE
fix: Removing dead lua code

### DIFF
--- a/AuthBridge/AuthProxy/k8s/auth-proxy-deployment.yaml
+++ b/AuthBridge/AuthProxy/k8s/auth-proxy-deployment.yaml
@@ -167,34 +167,6 @@ data:
                     route:
                       cluster: original_destination
               http_filters:
-              # Lua filter to inject environment variables as headers
-              - name: envoy.filters.http.lua
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-                  inline_code: |
-                    function envoy_on_request(request_handle)
-                      local token_url = os.getenv("TOKEN_URL")
-                      local client_id = os.getenv("CLIENT_ID")
-                      local client_secret = os.getenv("CLIENT_SECRET")
-                      local target_audience = os.getenv("TARGET_AUDIENCE")
-                      local target_scopes = os.getenv("TARGET_SCOPES")
-
-                      if token_url ~= nil and token_url ~= "" then
-                        request_handle:headers():add("x-token-url", token_url)
-                      end
-                      if client_id ~= nil and client_id ~= "" then
-                        request_handle:headers():add("x-client-id", client_id)
-                      end
-                      if client_secret ~= nil and client_secret ~= "" then
-                        request_handle:headers():add("x-client-secret", client_secret)
-                      end
-                      if target_audience ~= nil and target_audience ~= "" then
-                        request_handle:headers():add("x-target-audience", target_audience)
-                      end
-                      if target_scopes ~= nil and target_scopes ~= "" then
-                        request_handle:headers():add("x-target-scopes", target_scopes)
-                      end
-                    end
               # External processor to mutate headers
               - name: envoy.filters.http.ext_proc
                 typed_config:


### PR DESCRIPTION
Since Envoy and ext proc are now co-located, we can use env vars instead of custom http headers. This PR removes the dead lua code.