### PR TITLE
fix: Fix injected sidecar security contexts for runAsNonRoot pods

### DIFF
--- a/kagenti-webhook/internal/webhook/injector/container_builder.go
+++ b/kagenti-webhook/internal/webhook/injector/container_builder.go
@@ -44,6 +44,10 @@ const (
 func BuildSpiffeHelperContainer() corev1.Container {
 	builderLog.Info("building SpiffeHelper Container")
 
+	// SECURITY NOTE: The upstream spiffe-helper image runs as root.
+	// We explicitly set RunAsUser: 0 to satisfy pod-level runAsNonRoot
+	// validation. The spiffe-helper needs root to access the SPIRE
+	// agent socket and write SVID files.
 	return corev1.Container{
 		Name:            SpiffeHelperContainerName,
 		Image:           "ghcr.io/spiffe/spiffe-helper:nightly",
@@ -56,6 +60,14 @@ func BuildSpiffeHelperContainer() corev1.Container {
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("50m"),
 				corev1.ResourceMemory: resource.MustParse("64Mi"),
+			},
+		},
+		SecurityContext: &corev1.SecurityContext{
+			RunAsUser:    ptr.To(int64(0)),
+			RunAsNonRoot: ptr.To(false),
+			AllowPrivilegeEscalation: ptr.To(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
 			},
 		},
 		Command: []string{
@@ -239,6 +251,14 @@ tail -f /dev/null
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("50m"),
 				corev1.ResourceMemory: resource.MustParse("64Mi"),
+			},
+		},
+		SecurityContext: &corev1.SecurityContext{
+			RunAsUser:    ptr.To(int64(65534)),
+			RunAsNonRoot: ptr.To(true),
+			AllowPrivilegeEscalation: ptr.To(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
 			},
 		},
 		Command: []string{


### PR DESCRIPTION
## Summary
- Add `SecurityContext` to injected sidecar containers to fix `CreateContainerConfigError` on pods with `runAsNonRoot: true`
- `kagenti-client-registration`: `runAsUser: 65534` (nobody), `runAsNonRoot: true`, drop all capabilities
- `spiffe-helper`: Explicitly `runAsUser: 0`, `runAsNonRoot: false` (upstream image requires root for SPIRE socket access, documented like proxy-init)

## Problem
When the webhook injects the `kagenti-client-registration` sidecar, it has no `SecurityContext`. If the pod has `runAsNonRoot: true` (set by the webhook itself or security policies), the container fails with:
```
Error: container has runAsNonRoot and image will run as root
```

## Fix
Add explicit `SecurityContext` to both injected sidecars in `container_builder.go`, following the pattern already used by the `envoy-proxy` and `proxy-init` containers.

## Test plan
- [ ] Verify `client-registration` container starts successfully on pods with `runAsNonRoot: true`
- [ ] Verify `spiffe-helper` starts on SPIRE-enabled clusters
- [ ] Run kagenti/kagenti Kind E2E tests with bumped webhook chart

Fixes kagenti/kagenti#611

🤖 Generated with [Claude Code](https://claude.com/claude-code)