### PR TITLE
feat: Inject EXPECTED_AUDIENCE in webhook for inbound token validation

### DIFF
--- a/AuthBridge/demo-webhook.md
+++ b/AuthBridge/demo-webhook.md
@@ -148,7 +148,7 @@ The ConfigMaps include:
 - `authbridge-config` - Token exchange and inbound validation configuration for envoy-proxy:
   - `TOKEN_URL` - Keycloak token endpoint for token exchange
   - `ISSUER` - Expected JWT issuer for inbound validation (required)
-  - `EXPECTED_AUDIENCE` - Expected audience for inbound validation (optional, defaults to team1/agent SPIFFE ID)
+  - `EXPECTED_AUDIENCE` - Expected audience for inbound validation (optional, if not set audience validation is skipped)
   - `TARGET_AUDIENCE` - Target audience for outbound token exchange
   - `TARGET_SCOPES` - Scopes for exchanged tokens
 - `spiffe-helper-config` - SPIFFE helper configuration (for SPIRE mode)

--- a/AuthBridge/demo-webhook.md
+++ b/AuthBridge/demo-webhook.md
@@ -137,10 +137,20 @@ kubectl label namespace team1 kagenti-enabled=true --overwrite
 kubectl apply -f k8s/configmaps-webhook.yaml
 ```
 
+**Note for custom deployments:** If deploying to a different namespace or using a different service account, update the `EXPECTED_AUDIENCE` value in `configmaps-webhook.yaml` to match your agent's SPIFFE ID:
+```yaml
+EXPECTED_AUDIENCE: "spiffe://localtest.me/ns/<your-namespace>/sa/<your-service-account>"
+```
+
 The ConfigMaps include:
 
 - `environments` - Keycloak connection settings for client-registration
-- `authbridge-config` - Token exchange and inbound validation configuration for envoy-proxy (`TOKEN_URL`, `ISSUER`, `TARGET_AUDIENCE`, `TARGET_SCOPES`)
+- `authbridge-config` - Token exchange and inbound validation configuration for envoy-proxy:
+  - `TOKEN_URL` - Keycloak token endpoint for token exchange
+  - `ISSUER` - Expected JWT issuer for inbound validation (required)
+  - `EXPECTED_AUDIENCE` - Expected audience for inbound validation (optional, defaults to team1/agent SPIFFE ID)
+  - `TARGET_AUDIENCE` - Target audience for outbound token exchange
+  - `TARGET_SCOPES` - Scopes for exchanged tokens
 - `spiffe-helper-config` - SPIFFE helper configuration (for SPIRE mode)
 - `envoy-config` - Envoy proxy configuration
 

--- a/AuthBridge/k8s/configmaps-webhook.yaml
+++ b/AuthBridge/k8s/configmaps-webhook.yaml
@@ -24,7 +24,7 @@ data:
   KEYCLOAK_ADMIN_PASSWORD: "admin"
 
 ---
-# authbridge-config ConfigMap - Used by envoy-proxy for token exchange
+# authbridge-config ConfigMap - Used by envoy-proxy for token exchange and inbound validation
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -35,6 +35,12 @@ data:
   # ISSUER: Required. Keycloak frontend URL used as token issuer for inbound JWT validation.
   # Must match the "iss" claim in tokens (Keycloak's frontend URL).
   ISSUER: "http://keycloak.localtest.me:8080/realms/demo"
+  # EXPECTED_AUDIENCE: Optional. Expected audience for inbound JWT validation.
+  # For SPIFFE-based deployments, this should match the agent's SPIFFE ID.
+  # Format: spiffe://localtest.me/ns/<namespace>/sa/<service-account>
+  # Update this value if deploying to a different namespace or using a different service account.
+  # If not set, audience validation is skipped (issuer and signature validation still occur).
+  EXPECTED_AUDIENCE: "spiffe://localtest.me/ns/team1/sa/agent"
   TARGET_AUDIENCE: "auth-target"
   TARGET_SCOPES: "openid auth-target-aud"
 

--- a/AuthBridge/setup_keycloak-webhook.py
+++ b/AuthBridge/setup_keycloak-webhook.py
@@ -327,6 +327,8 @@ kubectl create configmap environments -n {namespace} \\
 # 2. authbridge-config ConfigMap (for envoy-proxy)
 kubectl create configmap authbridge-config -n {namespace} \\
   --from-literal=TOKEN_URL=http://keycloak-service.keycloak.svc:8080/realms/demo/protocol/openid-connect/token \\
+  --from-literal=ISSUER=http://keycloak.localtest.me:8080/realms/demo \\
+  --from-literal=EXPECTED_AUDIENCE=spiffe://localtest.me/ns/{namespace}/sa/{service_account} \\
   --from-literal=TARGET_AUDIENCE=auth-target \\
   --from-literal=TARGET_SCOPES="openid auth-target-aud"
 

--- a/kagenti-webhook/internal/webhook/injector/container_builder.go
+++ b/kagenti-webhook/internal/webhook/injector/container_builder.go
@@ -328,18 +328,18 @@ func BuildEnvoyProxyContainer() corev1.Container {
 						Optional: ptr.To(false),
 					},
 				},
-		},
-		{
-			Name: "EXPECTED_AUDIENCE",
-			ValueFrom: &corev1.EnvVarSource{
-				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: "authbridge-config",
-					},
-					Key:      "EXPECTED_AUDIENCE",
-					Optional: ptr.To(true),
-				},
 			},
+			{
+				Name: "EXPECTED_AUDIENCE",
+				ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "authbridge-config",
+						},
+						Key:      "EXPECTED_AUDIENCE",
+						Optional: ptr.To(true),
+					},
+				},
 			},
 			{
 				Name: "TARGET_AUDIENCE",

--- a/kagenti-webhook/internal/webhook/injector/container_builder.go
+++ b/kagenti-webhook/internal/webhook/injector/container_builder.go
@@ -328,6 +328,18 @@ func BuildEnvoyProxyContainer() corev1.Container {
 						Optional: ptr.To(false),
 					},
 				},
+		},
+		{
+			Name: "EXPECTED_AUDIENCE",
+			ValueFrom: &corev1.EnvVarSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "authbridge-config",
+					},
+					Key:      "EXPECTED_AUDIENCE",
+					Optional: ptr.To(true),
+				},
+			},
 			},
 			{
 				Name: "TARGET_AUDIENCE",


### PR DESCRIPTION
We introduced EXPECTED_AUDIENCE env var as part of inbound token validation. This PR modifies the webhook and docs to inject this env var into sidecars.