### PR TITLE
fix: Set privileged=true on proxy-init for OpenShift iptables

### DIFF
--- a/kagenti-webhook/internal/webhook/injector/container_builder.go
+++ b/kagenti-webhook/internal/webhook/injector/container_builder.go
@@ -441,6 +441,7 @@ func BuildProxyInitContainer() corev1.Container {
 		SecurityContext: &corev1.SecurityContext{
 			RunAsUser:    ptr.To(int64(0)),
 			RunAsNonRoot: ptr.To(false),
+			Privileged:   ptr.To(true),
 			Capabilities: &corev1.Capabilities{
 				Add: []corev1.Capability{
 					"NET_ADMIN",


### PR DESCRIPTION
## Summary
- Sets `Privileged: true` on the proxy-init init container's SecurityContext

## Context
On OpenShift/HyperShift, the iptables NAT table requires privileged mode — `NET_ADMIN` and `NET_RAW` capabilities alone are insufficient. Without `privileged: true`, the proxy-init container crashes with:

```
iptables v1.8.9 (legacy): can't initialize iptables table 'nat': Permission denied
```

This causes `Init:CrashLoopBackOff` for any workload that gets AuthBridge sidecar injection on OpenShift.

Tested on HyperShift OCP 4.20 cluster
- Without `privileged: true`: proxy-init crashes with Permission denied
- With `privileged: true`: proxy-init completes successfully, iptables rules configured

## Test plan
- [x] Verified proxy-init runs successfully with privileged=true on HyperShift OCP 4.20
- [ ] CI validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)