### PR TITLE
feat: Add precedence evaluator for sidecar injection decisions

### DIFF
--- a/kagenti-webhook/internal/webhook/injector/constants.go
+++ b/kagenti-webhook/internal/webhook/injector/constants.go
@@ -1,0 +1,14 @@
+package injector
+
+// Label constants used by the precedence evaluator.
+// These are the per-sidecar workload labels and namespace injection label
+// that control the injection precedence chain.
+const (
+	// Per-sidecar workload labels — set value to "false" to disable injection
+	LabelEnvoyProxyInject         = "kagenti.io/envoy-proxy-inject"
+	LabelSpiffeHelperInject       = "kagenti.io/spiffe-helper-inject"
+	LabelClientRegistrationInject = "kagenti.io/client-registration-inject"
+
+	// Namespace label for injection opt-in (used by precedence evaluator)
+	LabelNamespaceInject = "kagenti-enabled"
+)

--- a/kagenti-webhook/internal/webhook/injector/injection_decision.go
+++ b/kagenti-webhook/internal/webhook/injector/injection_decision.go
@@ -1,0 +1,21 @@
+package injector
+
+// SidecarDecision represents the injection decision for a single sidecar.
+type SidecarDecision struct {
+	Inject bool
+	Reason string // human-readable reason for the decision
+	Layer  string // which precedence layer made the decision
+}
+
+// InjectionDecision holds the per-sidecar injection decisions for a workload.
+type InjectionDecision struct {
+	EnvoyProxy         SidecarDecision
+	ProxyInit          SidecarDecision // follows EnvoyProxy
+	SpiffeHelper       SidecarDecision
+	ClientRegistration SidecarDecision
+}
+
+// AnyInjected returns true if at least one sidecar will be injected.
+func (d InjectionDecision) AnyInjected() bool {
+	return d.EnvoyProxy.Inject || d.SpiffeHelper.Inject || d.ClientRegistration.Inject
+}

--- a/kagenti-webhook/internal/webhook/injector/precedence.go
+++ b/kagenti-webhook/internal/webhook/injector/precedence.go
@@ -1,0 +1,209 @@
+package injector
+
+import (
+	"github.com/kagenti/kagenti-extensions/kagenti-webhook/internal/webhook/config"
+)
+
+// PrecedenceEvaluator determines which sidecars should be injected for a workload
+// by evaluating a multi-layer precedence chain. Each layer can short-circuit with "no".
+//
+// Precedence order (highest to lowest):
+//  1. Global feature gate (kill switch)
+//  2. Per-sidecar feature gate
+//  3. Namespace label (kagenti-enabled=true)
+//  4. Workload label (kagenti.io/<sidecar>-inject=false)
+//  5. TokenExchange CR override (stub — not yet implemented)
+//  6. Platform defaults (sidecars.<sidecar>.enabled)
+type PrecedenceEvaluator struct {
+	featureGates   *config.FeatureGates
+	platformConfig *config.PlatformConfig
+}
+
+// NewPrecedenceEvaluator creates a new evaluator with the given feature gates and platform config.
+func NewPrecedenceEvaluator(fg *config.FeatureGates, pc *config.PlatformConfig) *PrecedenceEvaluator {
+	if fg == nil {
+		fg = config.DefaultFeatureGates()
+	}
+	if pc == nil {
+		pc = config.CompiledDefaults()
+	}
+	return &PrecedenceEvaluator{
+		featureGates:   fg,
+		platformConfig: pc,
+	}
+}
+
+// Evaluate determines which sidecars should be injected for a given workload.
+//
+// Parameters:
+//   - namespaceLabels: labels from the namespace object
+//   - workloadLabels: labels from the pod template or workload metadata
+//   - tokenExchangeOverrides: per-sidecar overrides from TokenExchange CR (nil to skip)
+func (e *PrecedenceEvaluator) Evaluate(
+	namespaceLabels map[string]string,
+	workloadLabels map[string]string,
+	tokenExchangeOverrides *TokenExchangeOverrides,
+) InjectionDecision {
+	namespaceOptedIn := namespaceLabels[LabelNamespaceInject] == "true"
+
+	// Resolve per-sidecar TokenExchange overrides
+	var teEnvoy, teSpiffe, teClientReg *bool
+	if tokenExchangeOverrides != nil {
+		teEnvoy = tokenExchangeOverrides.EnvoyProxy
+		teSpiffe = tokenExchangeOverrides.SpiffeHelper
+		teClientReg = tokenExchangeOverrides.ClientRegistration
+	}
+
+	decision := InjectionDecision{
+		EnvoyProxy: e.evaluateSidecar(
+			"envoy-proxy",
+			e.featureGates.EnvoyProxy,
+			namespaceOptedIn,
+			workloadLabels[LabelEnvoyProxyInject],
+			teEnvoy,
+			e.platformConfig.Sidecars.EnvoyProxy.Enabled,
+		),
+		SpiffeHelper: e.evaluateSpiffeHelper(
+			e.featureGates.SpiffeHelper,
+			namespaceOptedIn,
+			workloadLabels,
+			teSpiffe,
+			e.platformConfig.Sidecars.SpiffeHelper.Enabled,
+		),
+		ClientRegistration: e.evaluateSidecar(
+			"client-registration",
+			e.featureGates.ClientRegistration,
+			namespaceOptedIn,
+			workloadLabels[LabelClientRegistrationInject],
+			teClientReg,
+			e.platformConfig.Sidecars.ClientRegistration.Enabled,
+		),
+	}
+
+	// proxy-init always follows envoy-proxy
+	decision.ProxyInit = SidecarDecision{
+		Inject: decision.EnvoyProxy.Inject,
+		Reason: "follows envoy-proxy decision",
+		Layer:  decision.EnvoyProxy.Layer,
+	}
+
+	return decision
+}
+
+// evaluateSidecar evaluates the precedence chain for a single sidecar.
+func (e *PrecedenceEvaluator) evaluateSidecar(
+	sidecarName string,
+	featureGateEnabled bool,
+	namespaceOptedIn bool,
+	workloadLabelValue string, // "", "true", or "false"
+	crdEnabled *bool, // nil = not specified
+	platformDefaultEnabled bool,
+) SidecarDecision {
+	// Layer 1: Global kill switch
+	if !e.featureGates.GlobalEnabled {
+		return SidecarDecision{
+			Inject: false,
+			Reason: "global kill switch disabled",
+			Layer:  "global-gate",
+		}
+	}
+
+	// Layer 2: Per-sidecar feature gate
+	if !featureGateEnabled {
+		return SidecarDecision{
+			Inject: false,
+			Reason: sidecarName + " feature gate disabled",
+			Layer:  "feature-gate",
+		}
+	}
+
+	// Layer 3: Namespace label
+	if !namespaceOptedIn {
+		return SidecarDecision{
+			Inject: false,
+			Reason: "namespace not opted in (missing " + LabelNamespaceInject + "=true)",
+			Layer:  "namespace",
+		}
+	}
+
+	// Layer 4: Workload label
+	if workloadLabelValue == "false" {
+		return SidecarDecision{
+			Inject: false,
+			Reason: "workload label disabled " + sidecarName,
+			Layer:  "workload-label",
+		}
+	}
+
+	// Layer 5: TokenExchange CR override
+	// If specified, the CR is authoritative and overrides platform defaults
+	if crdEnabled != nil {
+		if *crdEnabled {
+			return SidecarDecision{
+				Inject: true,
+				Reason: "TokenExchange CR enabled " + sidecarName,
+				Layer:  "tokenexchange-cr",
+			}
+		}
+		return SidecarDecision{
+			Inject: false,
+			Reason: "TokenExchange CR disabled " + sidecarName,
+			Layer:  "tokenexchange-cr",
+		}
+	}
+
+	// Layer 6: Platform defaults
+	if !platformDefaultEnabled {
+		return SidecarDecision{
+			Inject: false,
+			Reason: "platform default disabled " + sidecarName,
+			Layer:  "platform-default",
+		}
+	}
+
+	// All gates passed
+	return SidecarDecision{
+		Inject: true,
+		Reason: "all gates passed",
+		Layer:  "default",
+	}
+}
+
+// evaluateSpiffeHelper evaluates the precedence chain for spiffe-helper with an additional SPIRE label requirement.
+// spiffe-helper has a dual requirement: it must pass the standard 6-layer chain AND the workload must have kagenti.io/spire=enabled.
+func (e *PrecedenceEvaluator) evaluateSpiffeHelper(
+	featureGateEnabled bool,
+	namespaceOptedIn bool,
+	workloadLabels map[string]string,
+	crdEnabled *bool,
+	platformDefaultEnabled bool,
+) SidecarDecision {
+	// First, evaluate the standard 6-layer chain
+	decision := e.evaluateSidecar(
+		"spiffe-helper",
+		featureGateEnabled,
+		namespaceOptedIn,
+		workloadLabels[LabelSpiffeHelperInject],
+		crdEnabled,
+		platformDefaultEnabled,
+	)
+
+	// If any layer said "no", short-circuit
+	if !decision.Inject {
+		return decision
+	}
+
+	// Layer 7 (spiffe-helper only): SPIRE label requirement
+	// Check if kagenti.io/spire=enabled
+	spireLabel, exists := workloadLabels[SpireEnableLabel]
+	if !exists || spireLabel != SpireEnabledValue {
+		return SidecarDecision{
+			Inject: false,
+			Reason: "SPIRE not enabled (missing " + SpireEnableLabel + "=" + SpireEnabledValue + ")",
+			Layer:  "spire-label",
+		}
+	}
+
+	// All gates passed including SPIRE label
+	return decision
+}

--- a/kagenti-webhook/internal/webhook/injector/precedence_test.go
+++ b/kagenti-webhook/internal/webhook/injector/precedence_test.go
@@ -1,0 +1,520 @@
+package injector
+
+import (
+	"testing"
+
+	"github.com/kagenti/kagenti-extensions/kagenti-webhook/internal/webhook/config"
+	"k8s.io/utils/ptr"
+)
+
+func allEnabledGates() *config.FeatureGates {
+	return config.DefaultFeatureGates()
+}
+
+func allEnabledConfig() *config.PlatformConfig {
+	return config.CompiledDefaults()
+}
+
+func optedInNamespace() map[string]string {
+	return map[string]string{LabelNamespaceInject: "true"}
+}
+
+func noLabels() map[string]string {
+	return map[string]string{}
+}
+
+func spireEnabled() map[string]string {
+	return map[string]string{SpireEnableLabel: SpireEnabledValue}
+}
+
+func TestPrecedenceEvaluator(t *testing.T) {
+	tests := []struct {
+		name                   string
+		featureGates           *config.FeatureGates
+		platformConfig         *config.PlatformConfig
+		namespaceLabels        map[string]string
+		workloadLabels         map[string]string
+		tokenExchangeOverrides *TokenExchangeOverrides
+		expectEnvoy            bool
+		expectProxyInit        bool
+		expectSpiffe           bool
+		expectClientReg        bool
+		expectEnvoyLayer       string
+	}{
+		// === Global feature gate tests ===
+		{
+			name: "global kill switch off - all skipped",
+			featureGates: &config.FeatureGates{
+				GlobalEnabled:      false,
+				EnvoyProxy:         true,
+				SpiffeHelper:       true,
+				ClientRegistration: true,
+			},
+			platformConfig:   allEnabledConfig(),
+			namespaceLabels:  optedInNamespace(),
+			workloadLabels:   noLabels(),
+			expectEnvoy:      false,
+			expectProxyInit:  false,
+			expectSpiffe:     false,
+			expectClientReg:  false,
+			expectEnvoyLayer: "global-gate",
+		},
+		{
+			name: "per-sidecar gate off - only envoy skipped",
+			featureGates: &config.FeatureGates{
+				GlobalEnabled:      true,
+				EnvoyProxy:         false,
+				SpiffeHelper:       true,
+				ClientRegistration: true,
+			},
+			platformConfig:   allEnabledConfig(),
+			namespaceLabels:  optedInNamespace(),
+			workloadLabels:   spireEnabled(),
+			expectEnvoy:      false,
+			expectProxyInit:  false, // follows envoy
+			expectSpiffe:     true,
+			expectClientReg:  true,
+			expectEnvoyLayer: "feature-gate",
+		},
+		{
+			name: "per-sidecar gate off - spiffe skipped",
+			featureGates: &config.FeatureGates{
+				GlobalEnabled:      true,
+				EnvoyProxy:         true,
+				SpiffeHelper:       false,
+				ClientRegistration: true,
+			},
+			platformConfig:  allEnabledConfig(),
+			namespaceLabels: optedInNamespace(),
+			workloadLabels:  spireEnabled(),
+			expectEnvoy:     true,
+			expectProxyInit: true,
+			expectSpiffe:    false,
+			expectClientReg: true,
+		},
+
+		// === Namespace tests ===
+		{
+			name:             "namespace not opted in - all skipped",
+			featureGates:     allEnabledGates(),
+			platformConfig:   allEnabledConfig(),
+			namespaceLabels:  noLabels(),
+			workloadLabels:   noLabels(),
+			expectEnvoy:      false,
+			expectProxyInit:  false,
+			expectSpiffe:     false,
+			expectClientReg:  false,
+			expectEnvoyLayer: "namespace",
+		},
+		{
+			name:            "namespace opted in - proceed to next layer",
+			featureGates:    allEnabledGates(),
+			platformConfig:  allEnabledConfig(),
+			namespaceLabels: optedInNamespace(),
+			workloadLabels:  spireEnabled(),
+			expectEnvoy:     true,
+			expectProxyInit: true,
+			expectSpiffe:    true,
+			expectClientReg: true,
+		},
+		{
+			name:             "namespace label wrong value - all skipped",
+			featureGates:     allEnabledGates(),
+			platformConfig:   allEnabledConfig(),
+			namespaceLabels:  map[string]string{LabelNamespaceInject: "false"},
+			workloadLabels:   noLabels(),
+			expectEnvoy:      false,
+			expectProxyInit:  false,
+			expectSpiffe:     false,
+			expectClientReg:  false,
+			expectEnvoyLayer: "namespace",
+		},
+
+		// === Workload label tests ===
+		{
+			name:             "workload label disables envoy - envoy and proxy-init skipped",
+			featureGates:     allEnabledGates(),
+			platformConfig:   allEnabledConfig(),
+			namespaceLabels:  optedInNamespace(),
+			workloadLabels:   map[string]string{LabelEnvoyProxyInject: "false", SpireEnableLabel: SpireEnabledValue},
+			expectEnvoy:      false,
+			expectProxyInit:  false,
+			expectSpiffe:     true,
+			expectClientReg:  true,
+			expectEnvoyLayer: "workload-label",
+		},
+		{
+			name:            "workload label disables spiffe only",
+			featureGates:    allEnabledGates(),
+			platformConfig:  allEnabledConfig(),
+			namespaceLabels: optedInNamespace(),
+			workloadLabels:  map[string]string{LabelSpiffeHelperInject: "false", SpireEnableLabel: SpireEnabledValue},
+			expectEnvoy:     true,
+			expectProxyInit: true,
+			expectSpiffe:    false,
+			expectClientReg: true,
+		},
+		{
+			name:            "workload label disables client-registration only",
+			featureGates:    allEnabledGates(),
+			platformConfig:  allEnabledConfig(),
+			namespaceLabels: optedInNamespace(),
+			workloadLabels:  map[string]string{LabelClientRegistrationInject: "false", SpireEnableLabel: SpireEnabledValue},
+			expectEnvoy:     true,
+			expectProxyInit: true,
+			expectSpiffe:    true,
+			expectClientReg: false,
+		},
+		{
+			name:            "workload label true - no effect (default is inject)",
+			featureGates:    allEnabledGates(),
+			platformConfig:  allEnabledConfig(),
+			namespaceLabels: optedInNamespace(),
+			workloadLabels:  map[string]string{LabelEnvoyProxyInject: "true", SpireEnableLabel: SpireEnabledValue},
+			expectEnvoy:     true,
+			expectProxyInit: true,
+			expectSpiffe:    true,
+			expectClientReg: true,
+		},
+		{
+			name:            "workload label absent - no effect",
+			featureGates:    allEnabledGates(),
+			platformConfig:  allEnabledConfig(),
+			namespaceLabels: optedInNamespace(),
+			workloadLabels:  spireEnabled(),
+			expectEnvoy:     true,
+			expectProxyInit: true,
+			expectSpiffe:    true,
+			expectClientReg: true,
+		},
+
+		// === TokenExchange CRD tests ===
+		{
+			name:                   "CRD overrides nil - no effect",
+			featureGates:           allEnabledGates(),
+			platformConfig:         allEnabledConfig(),
+			namespaceLabels:        optedInNamespace(),
+			workloadLabels:         spireEnabled(),
+			tokenExchangeOverrides: nil,
+			expectEnvoy:            true,
+			expectProxyInit:        true,
+			expectSpiffe:           true,
+			expectClientReg:        true,
+		},
+		{
+			name:            "CRD explicitly disables envoy",
+			featureGates:    allEnabledGates(),
+			platformConfig:  allEnabledConfig(),
+			namespaceLabels: optedInNamespace(),
+			workloadLabels:  spireEnabled(),
+			tokenExchangeOverrides: &TokenExchangeOverrides{
+				EnvoyProxy: ptr.To(false),
+			},
+			expectEnvoy:      false,
+			expectProxyInit:  false,
+			expectSpiffe:     true,
+			expectClientReg:  true,
+			expectEnvoyLayer: "tokenexchange-cr",
+		},
+		{
+			name: "CRD enables sidecar that higher layer disabled - still skipped",
+			featureGates: &config.FeatureGates{
+				GlobalEnabled:      true,
+				EnvoyProxy:         false, // higher layer disables
+				SpiffeHelper:       true,
+				ClientRegistration: true,
+			},
+			platformConfig:  allEnabledConfig(),
+			namespaceLabels: optedInNamespace(),
+			workloadLabels:  spireEnabled(),
+			tokenExchangeOverrides: &TokenExchangeOverrides{
+				EnvoyProxy: ptr.To(true), // CRD tries to enable — should NOT override
+			},
+			expectEnvoy:      false,
+			expectProxyInit:  false,
+			expectSpiffe:     true,
+			expectClientReg:  true,
+			expectEnvoyLayer: "feature-gate",
+		},
+		{
+			name:         "CRD enables sidecar that platform default disabled - injected (CRD wins over platform)",
+			featureGates: allEnabledGates(),
+			platformConfig: func() *config.PlatformConfig {
+				c := allEnabledConfig()
+				c.Sidecars.ClientRegistration.Enabled = false // platform default disables
+				return c
+			}(),
+			namespaceLabels: optedInNamespace(),
+			workloadLabels:  spireEnabled(),
+			tokenExchangeOverrides: &TokenExchangeOverrides{
+				ClientRegistration: ptr.To(true), // CRD explicitly enables — should override platform default
+			},
+			expectEnvoy:      true,
+			expectProxyInit:  true,
+			expectSpiffe:     true,
+			expectClientReg:  true, // CRD wins over platform default
+			expectEnvoyLayer: "default",
+		},
+
+		// === Platform defaults tests ===
+		{
+			name:         "platform default disables envoy",
+			featureGates: allEnabledGates(),
+			platformConfig: func() *config.PlatformConfig {
+				c := allEnabledConfig()
+				c.Sidecars.EnvoyProxy.Enabled = false
+				return c
+			}(),
+			namespaceLabels:  optedInNamespace(),
+			workloadLabels:   spireEnabled(),
+			expectEnvoy:      false,
+			expectProxyInit:  false,
+			expectSpiffe:     true,
+			expectClientReg:  true,
+			expectEnvoyLayer: "platform-default",
+		},
+		{
+			name:         "platform default disables all sidecars",
+			featureGates: allEnabledGates(),
+			platformConfig: func() *config.PlatformConfig {
+				c := allEnabledConfig()
+				c.Sidecars.EnvoyProxy.Enabled = false
+				c.Sidecars.SpiffeHelper.Enabled = false
+				c.Sidecars.ClientRegistration.Enabled = false
+				return c
+			}(),
+			namespaceLabels: optedInNamespace(),
+			workloadLabels:  noLabels(),
+			expectEnvoy:     false,
+			expectProxyInit: false,
+			expectSpiffe:    false,
+			expectClientReg: false,
+		},
+
+		// === Precedence ordering tests ===
+		{
+			name: "global gate off + workload label enables - skipped (global wins)",
+			featureGates: &config.FeatureGates{
+				GlobalEnabled:      false,
+				EnvoyProxy:         true,
+				SpiffeHelper:       true,
+				ClientRegistration: true,
+			},
+			platformConfig:   allEnabledConfig(),
+			namespaceLabels:  optedInNamespace(),
+			workloadLabels:   map[string]string{LabelEnvoyProxyInject: "true"},
+			expectEnvoy:      false,
+			expectProxyInit:  false,
+			expectSpiffe:     false,
+			expectClientReg:  false,
+			expectEnvoyLayer: "global-gate",
+		},
+		{
+			name:            "namespace opted in + workload label disables - skipped (workload wins over namespace)",
+			featureGates:    allEnabledGates(),
+			platformConfig:  allEnabledConfig(),
+			namespaceLabels: optedInNamespace(),
+			workloadLabels: map[string]string{
+				LabelEnvoyProxyInject:         "false",
+				LabelSpiffeHelperInject:       "false",
+				LabelClientRegistrationInject: "false",
+			},
+			expectEnvoy:      false,
+			expectProxyInit:  false,
+			expectSpiffe:     false,
+			expectClientReg:  false,
+			expectEnvoyLayer: "workload-label",
+		},
+		{
+			name:            "CRD disables + platform enables - skipped (CRD wins over platform)",
+			featureGates:    allEnabledGates(),
+			platformConfig:  allEnabledConfig(),
+			namespaceLabels: optedInNamespace(),
+			workloadLabels:  noLabels(),
+			tokenExchangeOverrides: &TokenExchangeOverrides{
+				SpiffeHelper: ptr.To(false),
+			},
+			expectEnvoy:     true,
+			expectProxyInit: true,
+			expectSpiffe:    false,
+			expectClientReg: true,
+		},
+		{
+			name:             "all layers pass - all injected",
+			featureGates:     allEnabledGates(),
+			platformConfig:   allEnabledConfig(),
+			namespaceLabels:  optedInNamespace(),
+			workloadLabels:   spireEnabled(),
+			expectEnvoy:      true,
+			expectProxyInit:  true,
+			expectSpiffe:     true,
+			expectClientReg:  true,
+			expectEnvoyLayer: "default",
+		},
+
+		// === proxy-init coupling tests ===
+		{
+			name:            "envoy injected - proxy-init injected",
+			featureGates:    allEnabledGates(),
+			platformConfig:  allEnabledConfig(),
+			namespaceLabels: optedInNamespace(),
+			workloadLabels:  spireEnabled(),
+			expectEnvoy:     true,
+			expectProxyInit: true,
+			expectSpiffe:    true,
+			expectClientReg: true,
+		},
+		{
+			name:         "envoy skipped via platform default - proxy-init also skipped",
+			featureGates: allEnabledGates(),
+			platformConfig: func() *config.PlatformConfig {
+				c := allEnabledConfig()
+				c.Sidecars.EnvoyProxy.Enabled = false
+				return c
+			}(),
+			namespaceLabels: optedInNamespace(),
+			workloadLabels:  spireEnabled(),
+			expectEnvoy:     false,
+			expectProxyInit: false,
+			expectSpiffe:    true,
+			expectClientReg: true,
+		},
+		{
+			name:            "envoy skipped via workload label - proxy-init also skipped",
+			featureGates:    allEnabledGates(),
+			platformConfig:  allEnabledConfig(),
+			namespaceLabels: optedInNamespace(),
+			workloadLabels:  map[string]string{LabelEnvoyProxyInject: "false", SpireEnableLabel: SpireEnabledValue},
+			expectEnvoy:     false,
+			expectProxyInit: false,
+			expectSpiffe:    true,
+			expectClientReg: true,
+		},
+
+		// === SPIRE label requirement tests (spiffe-helper only) ===
+		{
+			name:            "SPIRE label missing - spiffe-helper skipped",
+			featureGates:    allEnabledGates(),
+			platformConfig:  allEnabledConfig(),
+			namespaceLabels: optedInNamespace(),
+			workloadLabels:  noLabels(),
+			expectEnvoy:     true,
+			expectProxyInit: true,
+			expectSpiffe:    false,
+			expectClientReg: true,
+		},
+		{
+			name:            "SPIRE label wrong value - spiffe-helper skipped",
+			featureGates:    allEnabledGates(),
+			platformConfig:  allEnabledConfig(),
+			namespaceLabels: optedInNamespace(),
+			workloadLabels:  map[string]string{SpireEnableLabel: "disabled"},
+			expectEnvoy:     true,
+			expectProxyInit: true,
+			expectSpiffe:    false,
+			expectClientReg: true,
+		},
+		{
+			name:            "SPIRE enabled - spiffe-helper injected",
+			featureGates:    allEnabledGates(),
+			platformConfig:  allEnabledConfig(),
+			namespaceLabels: optedInNamespace(),
+			workloadLabels:  spireEnabled(),
+			expectEnvoy:     true,
+			expectProxyInit: true,
+			expectSpiffe:    true,
+			expectClientReg: true,
+		},
+		{
+			name: "SPIRE enabled but precedence chain blocks - spiffe-helper still skipped",
+			featureGates: &config.FeatureGates{
+				GlobalEnabled:      true,
+				EnvoyProxy:         true,
+				SpiffeHelper:       false, // blocked at feature gate
+				ClientRegistration: true,
+			},
+			platformConfig:  allEnabledConfig(),
+			namespaceLabels: optedInNamespace(),
+			workloadLabels:  spireEnabled(),
+			expectEnvoy:     true,
+			expectProxyInit: true,
+			expectSpiffe:    false,
+			expectClientReg: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			evaluator := NewPrecedenceEvaluator(tt.featureGates, tt.platformConfig)
+			decision := evaluator.Evaluate(tt.namespaceLabels, tt.workloadLabels, tt.tokenExchangeOverrides)
+
+			if decision.EnvoyProxy.Inject != tt.expectEnvoy {
+				t.Errorf("EnvoyProxy.Inject = %v, want %v (reason: %s, layer: %s)",
+					decision.EnvoyProxy.Inject, tt.expectEnvoy,
+					decision.EnvoyProxy.Reason, decision.EnvoyProxy.Layer)
+			}
+			if decision.ProxyInit.Inject != tt.expectProxyInit {
+				t.Errorf("ProxyInit.Inject = %v, want %v (reason: %s, layer: %s)",
+					decision.ProxyInit.Inject, tt.expectProxyInit,
+					decision.ProxyInit.Reason, decision.ProxyInit.Layer)
+			}
+			if decision.SpiffeHelper.Inject != tt.expectSpiffe {
+				t.Errorf("SpiffeHelper.Inject = %v, want %v (reason: %s, layer: %s)",
+					decision.SpiffeHelper.Inject, tt.expectSpiffe,
+					decision.SpiffeHelper.Reason, decision.SpiffeHelper.Layer)
+			}
+			if decision.ClientRegistration.Inject != tt.expectClientReg {
+				t.Errorf("ClientRegistration.Inject = %v, want %v (reason: %s, layer: %s)",
+					decision.ClientRegistration.Inject, tt.expectClientReg,
+					decision.ClientRegistration.Reason, decision.ClientRegistration.Layer)
+			}
+			if tt.expectEnvoyLayer != "" && decision.EnvoyProxy.Layer != tt.expectEnvoyLayer {
+				t.Errorf("EnvoyProxy.Layer = %q, want %q", decision.EnvoyProxy.Layer, tt.expectEnvoyLayer)
+			}
+		})
+	}
+}
+
+func TestAnyInjected(t *testing.T) {
+	tests := []struct {
+		name     string
+		decision InjectionDecision
+		want     bool
+	}{
+		{
+			name: "all injected",
+			decision: InjectionDecision{
+				EnvoyProxy:         SidecarDecision{Inject: true},
+				SpiffeHelper:       SidecarDecision{Inject: true},
+				ClientRegistration: SidecarDecision{Inject: true},
+			},
+			want: true,
+		},
+		{
+			name: "only envoy injected",
+			decision: InjectionDecision{
+				EnvoyProxy:         SidecarDecision{Inject: true},
+				SpiffeHelper:       SidecarDecision{Inject: false},
+				ClientRegistration: SidecarDecision{Inject: false},
+			},
+			want: true,
+		},
+		{
+			name: "none injected",
+			decision: InjectionDecision{
+				EnvoyProxy:         SidecarDecision{Inject: false},
+				SpiffeHelper:       SidecarDecision{Inject: false},
+				ClientRegistration: SidecarDecision{Inject: false},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.decision.AnyInjected(); got != tt.want {
+				t.Errorf("AnyInjected() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/kagenti-webhook/internal/webhook/injector/tokenexchange_overrides.go
+++ b/kagenti-webhook/internal/webhook/injector/tokenexchange_overrides.go
@@ -1,0 +1,13 @@
+package injector
+
+// TokenExchangeOverrides represents the per-sidecar enable/disable settings
+// extracted from a TokenExchange CR for a specific workload.
+// nil pointer fields mean "not specified" (fall through to lower layers).
+//
+// This is a stub — TokenExchange CR support is not yet implemented.
+// Pass nil for tokenExchangeOverrides to skip this layer entirely.
+type TokenExchangeOverrides struct {
+	EnvoyProxy         *bool
+	SpiffeHelper       *bool
+	ClientRegistration *bool
+}


### PR DESCRIPTION
## Summary
- Add `PrecedenceEvaluator` that determines sidecar injection via 6-layer precedence chain: global gate → per-sidecar gate → namespace label → workload label → TokenExchange CR → platform defaults
- Add `InjectionDecision`, `SidecarDecision`, and `TokenExchangeOverrides` types
- Add label constants for per-sidecar workload opt-out
- proxy-init always follows envoy-proxy decision
- 26 table-driven tests covering all precedence layers and edge cases

Part of #109 (Phase 2 of 5)
Depends on: #110 (Phase 1 — config types & loaders)

## Test plan
- [x] `go test ./internal/webhook/injector/...` — 26 tests pass
- [x] `go test -race ./internal/webhook/injector/...` — no data races
- [x] `go vet ./...` — clean
- [x] `go build -race ./...` — clean
- [x] `golangci-lint run` — 0 findings on new files
- [x] `staticcheck` — clean
- [x] `govulncheck` — 0 vulnerabilities in code

🤖 Generated with [Claude Code](https://claude.com/claude-code)