### PR TITLE
feat: Wire PodMutator to PrecedenceEvaluator with hot-reloadable config

### DIFF
--- a/kagenti-webhook/internal/webhook/v1alpha1/authbridge_webhook.go
+++ b/kagenti-webhook/internal/webhook/v1alpha1/authbridge_webhook.go
@@ -168,7 +168,9 @@ func (w *AuthBridgeWebhook) Handle(ctx context.Context, req admission.Request) a
 
 func (w *AuthBridgeWebhook) isAlreadyInjected(podSpec *corev1.PodSpec) bool {
 	for _, container := range podSpec.Containers {
-		if container.Name == injector.SpiffeHelperContainerName || container.Name == injector.ClientRegistrationContainerName {
+		if container.Name == injector.SpiffeHelperContainerName ||
+			container.Name == injector.ClientRegistrationContainerName ||
+			container.Name == injector.EnvoyProxyContainerName {
 			return true
 		}
 	}

--- a/kagenti-webhook/internal/webhook/v1alpha1/webhook_suite_test.go
+++ b/kagenti-webhook/internal/webhook/v1alpha1/webhook_suite_test.go
@@ -29,6 +29,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/kagenti/kagenti-extensions/kagenti-webhook/internal/webhook/config"
 	"github.com/kagenti/kagenti-extensions/kagenti-webhook/internal/webhook/injector"
 	agentsv1alpha1 "github.com/kagenti/operator/api/v1alpha1"
 	toolhivestacklokdevv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
@@ -119,7 +120,12 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	// Create pod mutator for tests
-	podMutator := injector.NewPodMutator(k8sClient, true)
+	podMutator := injector.NewPodMutator(
+		k8sClient,
+		true,
+		func() *config.PlatformConfig { return config.CompiledDefaults() },
+		func() *config.FeatureGates { return config.DefaultFeatureGates() },
+	)
 
 	err = SetupMCPServerWebhookWithManager(mgr, podMutator)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Summary

Phase 4 of 5: Wire PodMutator to use PrecedenceEvaluator and hot-reloadable config loaders.

This PR integrates the precedence evaluator (Phase 2) and container builder (Phase 3) into the webhook's main injection path, replacing hardcoded logic with a multi-layer precedence chain and enabling runtime config updates.

### Changes

**pod_mutator.go:**
- Add `Builder`, `GetPlatformConfig()`, `GetFeatureGates()` fields to PodMutator
- Update `NewPodMutator()` to accept getter functions (not direct config pointers) for hot-reload
- Rewrite `InjectAuthBridge()` to use `PrecedenceEvaluator.Evaluate()` for injection decisions
- Use `ContainerBuilder` with fresh config snapshots for each mutation
- Remove duplicate constants (now in `constants.go` from Phase 2)
- Update `BuildClientRegistrationContainerWithSpireOption` calls to remove `clientID` parameter (integrated upstream PR #95)

**main.go:**
- Add `--config-path` and `--feature-gates-path` CLI flags
- Create `ConfigLoader` and `FeatureGateLoader` with hot-reload via `Watch()`
- Pass getter functions to `NewPodMutator()` for dynamic config access
- Move `ctrl.SetupSignalHandler()` before loaders (shared context for graceful shutdown)
- Add `OnChange()` callbacks for logging config updates

**authbridge_webhook.go:**
- Expand `isAlreadyInjected()` to check for `EnvoyProxyContainerName`

**webhook_suite_test.go:**
- Update `NewPodMutator` calls to pass lambda getters returning compiled defaults

### Part of Epic #109

- ✅ Phase 1: Config Types (PR #110) - Merged
- ✅ Phase 2: Precedence Evaluator (PR #112) - Merged
- ✅ Phase 3: ContainerBuilder Refactor (PR #115) - Merged
- 🔄 **Phase 4: PodMutator Wiring (This PR)**
- ⏳ Phase 5: Helm Chart Support (Next)

### Dependencies

- **Requires:** Phase 1, 2, and 3 (all merged into main)
- **Required by:** Phase 5 (Helm chart ConfigMap templates)

## Test Plan

- [x] `go build ./...` compiles cleanly
- [x] `go vet ./...` passes with no warnings
- [x] `go test ./internal/webhook/injector/...` - All 31 precedence tests pass
- [x] staticcheck finds no issues in changed files
- [x] Pre-commit hooks pass (go-fmt, go-vet, mixed-line-ending)
- [x] Code review completed (go-review skill)

### Integration Testing
- Config hot-reload: Start webhook → update ConfigMap → verify new containers use updated images
- Precedence chain: Verify all 6 layers work (global gate, per-sidecar gate, namespace label, workload label, platform defaults, SPIRE label)
- Backward compatibility: Agent/MCPServer CRs still work with deprecated path

## Breaking Changes

None. Backward compatible with existing Agent/MCPServer CRs (deprecated paths maintained).

## Notes

- Deprecated `InjectSidecars()` method intentionally uses stale config (technical debt, removed when Agent/MCPServer CRs are deleted)
- TokenExchange CR integration stubbed (nil passed to evaluator) - will be implemented post-epic

🤖 Generated with Claude Code