### PR TITLE
fix: CI go-version from go.mod, gate client-registration injection, improve isAlreadyInjected

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.22'
+          go-version-file: kagenti-webhook/go.mod
 
       - name: Lint
         run: find . -type f -name 'go.mod' -execdir go fmt ./... \;

--- a/kagenti-webhook/internal/webhook/injector/pod_mutator.go
+++ b/kagenti-webhook/internal/webhook/injector/pod_mutator.go
@@ -325,8 +325,12 @@ func (m *PodMutator) InjectSidecarsWithSpireOption(podSpec *corev1.PodSpec, name
 	}
 
 	// Check and inject client-registration sidecar (with SPIRE option)
-	if !containerExists(podSpec.Containers, ClientRegistrationContainerName) {
-		podSpec.Containers = append(podSpec.Containers, m.Builder.BuildClientRegistrationContainerWithSpireOption(crName, namespace, spireEnabled))
+	if m.EnableClientRegistration {
+		if !containerExists(podSpec.Containers, ClientRegistrationContainerName) {
+			podSpec.Containers = append(podSpec.Containers, m.Builder.BuildClientRegistrationContainerWithSpireOption(crName, namespace, spireEnabled))
+		}
+	} else {
+		mutatorLog.Info("Skipping client-registration injection (disabled via --enable-client-registration=false)")
 	}
 
 	// Check and inject envoy-proxy sidecar


### PR DESCRIPTION
## Summary
- **CI**: Use go-version-file instead of hardcoded go-version so CI always matches the Go version in go.mod
- **Webhook**: Gate client-registration sidecar injection behind EnableClientRegistration flag -- previously it was always injected regardless of the flag
- **Webhook**: Improve isAlreadyInjected detection to also check for envoy-proxy (sidecar) and proxy-init (init container), which are always injected by the AuthBridge path even when spiffe-helper and client-registration are disabled

Split out from PR #113 to keep that PR focused on CLAUDE.md files only.

## Test plan
- [ ] Verify CI workflow picks up Go version from go.mod
- [ ] Deploy webhook with --enable-client-registration=false and confirm client-registration sidecar is NOT injected
- [ ] Deploy webhook and confirm isAlreadyInjected correctly detects envoy-proxy and proxy-init containers