### PR TITLE
fix: Fix inbound validation

### DIFF
--- a/AuthBridge/AuthProxy/Dockerfile.init
+++ b/AuthBridge/AuthProxy/Dockerfile.init
@@ -1,5 +1,7 @@
-FROM alpine:3.18
+FROM docker.io/library/alpine:3.18
 
+# Installs both iptables-legacy and iptables-nft; init-iptables.sh auto-detects
+# the correct backend at runtime (prefers legacy for Kind/kubeadm compatibility)
 RUN apk add --no-cache iptables
 
 COPY init-iptables.sh /usr/local/bin/init-iptables.sh

--- a/AuthBridge/AuthProxy/k8s/auth-proxy-deployment.yaml
+++ b/AuthBridge/AuthProxy/k8s/auth-proxy-deployment.yaml
@@ -228,17 +228,19 @@ data:
                 virtual_hosts:
                 - name: local_app
                   domains: ["*"]
-                  request_headers_to_add:
-                  - header:
-                      key: "x-authbridge-direction"
-                      value: "inbound"
-                    append: false
                   routes:
                   - match:
                       prefix: "/"
                     route:
                       cluster: original_destination
               http_filters:
+              - name: envoy.filters.http.lua
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+                  inline_code: |
+                    function envoy_on_request(request_handle)
+                      request_handle:headers():add("x-authbridge-direction", "inbound")
+                    end
               - name: envoy.filters.http.ext_proc
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor

--- a/AuthBridge/demos/single-target/k8s/authbridge-deployment-no-spiffe.yaml
+++ b/AuthBridge/demos/single-target/k8s/authbridge-deployment-no-spiffe.yaml
@@ -176,17 +176,19 @@ data:
                 virtual_hosts:
                 - name: local_app
                   domains: ["*"]
-                  request_headers_to_add:
-                  - header:
-                      key: "x-authbridge-direction"
-                      value: "inbound"
-                    append: false
                   routes:
                   - match:
                       prefix: "/"
                     route:
                       cluster: original_destination
               http_filters:
+              - name: envoy.filters.http.lua
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+                  inline_code: |
+                    function envoy_on_request(request_handle)
+                      request_handle:headers():add("x-authbridge-direction", "inbound")
+                    end
               - name: envoy.filters.http.ext_proc
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor

--- a/AuthBridge/demos/single-target/k8s/authbridge-deployment.yaml
+++ b/AuthBridge/demos/single-target/k8s/authbridge-deployment.yaml
@@ -200,17 +200,19 @@ data:
                 virtual_hosts:
                 - name: local_app
                   domains: ["*"]
-                  request_headers_to_add:
-                  - header:
-                      key: "x-authbridge-direction"
-                      value: "inbound"
-                    append: false
                   routes:
                   - match:
                       prefix: "/"
                     route:
                       cluster: original_destination
               http_filters:
+              - name: envoy.filters.http.lua
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+                  inline_code: |
+                    function envoy_on_request(request_handle)
+                      request_handle:headers():add("x-authbridge-direction", "inbound")
+                    end
               - name: envoy.filters.http.ext_proc
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor

--- a/AuthBridge/demos/single-target/k8s/configmaps-webhook.yaml
+++ b/AuthBridge/demos/single-target/k8s/configmaps-webhook.yaml
@@ -162,17 +162,19 @@ data:
                 virtual_hosts:
                 - name: local_app
                   domains: ["*"]
-                  request_headers_to_add:
-                  - header:
-                      key: "x-authbridge-direction"
-                      value: "inbound"
-                    append: false
                   routes:
                   - match:
                       prefix: "/"
                     route:
                       cluster: original_destination
               http_filters:
+              - name: envoy.filters.http.lua
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+                  inline_code: |
+                    function envoy_on_request(request_handle)
+                      request_handle:headers():add("x-authbridge-direction", "inbound")
+                    end
               - name: envoy.filters.http.ext_proc
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (must be EXACT, case-sensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix must match EXACT CASE (this is enforced by our PR Title
    workflow, which validates exact-match prefixes via the
    `allowed_prefixes` input of the GitHub Action used). [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`).

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary
Bug 1: iptables backend mismatch — The proxy-init init container (Alpine 3.18) used iptables-nft by default, but Kind's networking stack uses iptables-legacy. PREROUTING rules were set in the nft tables where they had no effect. Fixed by adding auto-detection in init-iptables.sh that prefers iptables-legacy.

Bug 2: Envoy filter ordering (the actual blocker) — The x-authbridge-direction: inbound header was configured at the route level (request_headers_to_add in virtual_hosts). Route-level headers are applied by the router filter, which is the last HTTP filter in the chain. The ext_proc filter runs before the router and never saw the direction header, defaulting to outbound (token exchange passthrough). Fixed by adding a Lua filter before ext_proc in the inbound listener to inject the direction header at the right point in the filter chain.

## Related issue(s)

## (Optional) Testing Instructions

Fixes #
