### PR TITLE
feat: Enable Istio ambient mesh on demo namespaces

### DIFF
--- a/AuthBridge/demos/multi-target/k8s/authbridge-deployment-no-spiffe.yaml
+++ b/AuthBridge/demos/multi-target/k8s/authbridge-deployment-no-spiffe.yaml
@@ -21,6 +21,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: authbridge
+  labels:
+    istio.io/dataplane-mode: ambient
 
 ---
 apiVersion: v1
@@ -195,9 +197,9 @@ spec:
     metadata:
       labels:
         app: caller
-        istio.io/dataplane-mode: none
+        # istio.io/dataplane-mode: none
       annotations:
-        ambient.istio.io/redirection: disabled
+        # ambient.istio.io/redirection: disabled
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: caller

--- a/AuthBridge/demos/multi-target/k8s/authbridge-deployment.yaml
+++ b/AuthBridge/demos/multi-target/k8s/authbridge-deployment.yaml
@@ -31,6 +31,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: authbridge
+  labels:
+    istio.io/dataplane-mode: ambient
 
 ---
 apiVersion: v1
@@ -224,9 +226,9 @@ spec:
     metadata:
       labels:
         app: agent
-        istio.io/dataplane-mode: none
+        # istio.io/dataplane-mode: none
       annotations:
-        ambient.istio.io/redirection: disabled
+        # ambient.istio.io/redirection: disabled
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: agent

--- a/AuthBridge/demos/multi-target/k8s/targets.yaml
+++ b/AuthBridge/demos/multi-target/k8s/targets.yaml
@@ -7,6 +7,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: authbridge
+  labels:
+    istio.io/dataplane-mode: ambient
 ---
 # Target Alpha
 apiVersion: apps/v1

--- a/AuthBridge/demos/single-target/k8s/authbridge-deployment-no-spiffe.yaml
+++ b/AuthBridge/demos/single-target/k8s/authbridge-deployment-no-spiffe.yaml
@@ -25,6 +25,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: authbridge
+  labels:
+    istio.io/dataplane-mode: ambient
 
 ---
 apiVersion: v1

--- a/AuthBridge/demos/single-target/k8s/authbridge-deployment.yaml
+++ b/AuthBridge/demos/single-target/k8s/authbridge-deployment.yaml
@@ -37,6 +37,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: authbridge
+  labels:
+    istio.io/dataplane-mode: ambient
 
 ---
 apiVersion: v1

--- a/kagenti-webhook/scripts/webhook-rollout.sh
+++ b/kagenti-webhook/scripts/webhook-rollout.sh
@@ -220,6 +220,7 @@ if [ "${AUTHBRIDGE_DEMO}" = "true" ]; then
     echo "[AuthBridge 1/2] Creating namespace ${AUTHBRIDGE_NAMESPACE}..."
     kubectl create namespace "${AUTHBRIDGE_NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
     kubectl label namespace "${AUTHBRIDGE_NAMESPACE}" kagenti-enabled=true --overwrite
+    kubectl label namespace "${AUTHBRIDGE_NAMESPACE}" istio.io/dataplane-mode=ambient --overwrite
 
     # Apply ConfigMaps (update namespace in-place)
     # Note: AUTHBRIDGE_NAMESPACE is validated above to be a safe DNS-1123 label,


### PR DESCRIPTION
## Summary
- Add `istio.io/dataplane-mode: ambient` label to all `authbridge` namespace definitions in single-target and multi-target demo manifests (5 files)
- Comment out pod-level ambient opt-out annotations (`istio.io/dataplane-mode: none`, `ambient.istio.io/redirection: disabled`) in multi-target demos so ztunnel enrolls agent/caller pods, matching the single-target demo pattern and enabling AuthBridge/ambient coexistence via `init-iptables.sh`
- Add `istio.io/dataplane-mode=ambient` label in `webhook-rollout.sh` for dynamically created namespaces

## Test plan
- [ ] Deploy single-target demo with Istio ambient mesh enabled and verify ztunnel enrolls pods in the `authbridge` namespace
- [ ] Deploy multi-target demo and verify agent/caller pods coexist with ambient mesh (AuthBridge iptables + ztunnel)
- [ ] Run `webhook-rollout.sh` with `AUTHBRIDGE_DEMO=true` and verify the created namespace has the ambient label

🤖 Generated with [Claude Code](https://claude.com/claude-code)