### PR TITLE
feat: Add A2A AgentCard endpoint to quickstart demo-app

### DIFF
--- a/AuthBridge/AuthProxy/quickstart/README.md
+++ b/AuthBridge/AuthProxy/quickstart/README.md
@@ -163,6 +163,16 @@ curl http://localhost:9080/test
 # Expected response: "unauthorized: missing Authorization header"
 ```
 
+### AgentCard discovery (A2A)
+
+**Public endpoint — no authentication required:**
+```bash
+curl http://localhost:9080/.well-known/agent.json
+# Expected: JSON AgentCard with agent name, skills, protocol version
+```
+
+The `/.well-known/agent.json` endpoint is a public [A2A](https://google.github.io/A2A/) discovery endpoint that does not require JWT authentication. This is the use case motivating route-based auth bypass (see [issue #124](https://github.com/kagenti/kagenti-extensions/issues/124)) — public discovery endpoints like AgentCard must be accessible without a token, even when the rest of the application is protected by AuthBridge.
+
 ### HTTPS test (TLS passthrough)
 
 **HTTPS connectivity through Envoy TLS passthrough:**


### PR DESCRIPTION
## Summary

- Add GET /.well-known/agent.json endpoint to the quickstart demo-app that returns a static A2A AgentCard JSON (agent name, skills, protocol version)
- Register the route before the catch-all / handler so it is served without JWT authentication
- Document the new endpoint in the quickstart README with curl example and context on route-based auth bypass

Closes #131

## Test plan

- [x] go build compiles successfully (no new dependencies -- encoding/json is stdlib)
- [x] make build-images && make load-images && make deploy -- full quickstart deployed to Kind
- [x] curl http://localhost:9080/.well-known/agent.json -- returns AgentCard JSON (200)
- [x] curl -H "Authorization: Bearer $TOKEN" http://localhost:9080/test -- returns "authorized" (existing flow unchanged)
- [x] curl http://localhost:9080/test -- returns "unauthorized" (existing flow unchanged)
- [x] curl http://localhost:9080/tls-test -- returns "tls-ok" (TLS passthrough unchanged)

Generated with [Claude Code](https://claude.com/claude-code)