### PR TITLE
fix: mount svid-output volume in envoy-proxy container

### DIFF
--- a/kagenti-webhook/internal/webhook/injector/container_builder_test.go
+++ b/kagenti-webhook/internal/webhook/injector/container_builder_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package injector
+
+import (
+	"testing"
+
+	"github.com/kagenti/kagenti-extensions/kagenti-webhook/internal/webhook/config"
+)
+
+func TestBuildEnvoyProxyContainer_SpireEnabled_HasSvidOutputMount(t *testing.T) {
+	builder := NewContainerBuilder(config.CompiledDefaults())
+	container := builder.BuildEnvoyProxyContainerWithSpireOption(true)
+
+	found := false
+	for _, vm := range container.VolumeMounts {
+		if vm.Name == "svid-output" {
+			found = true
+			if vm.MountPath != "/opt" {
+				t.Errorf("svid-output mount path = %q, want /opt", vm.MountPath)
+			}
+			if !vm.ReadOnly {
+				t.Error("svid-output mount should be read-only")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("envoy-proxy container missing svid-output volume mount when SPIRE is enabled")
+	}
+}
+
+func TestBuildEnvoyProxyContainer_SpireDisabled_NoSvidOutputMount(t *testing.T) {
+	builder := NewContainerBuilder(config.CompiledDefaults())
+	container := builder.BuildEnvoyProxyContainerWithSpireOption(false)
+
+	for _, vm := range container.VolumeMounts {
+		if vm.Name == "svid-output" {
+			t.Error("envoy-proxy container should NOT have svid-output mount when SPIRE is disabled")
+		}
+	}
+}
+
+func TestBuildEnvoyProxyContainer_DefaultIncludesSvidOutput(t *testing.T) {
+	// The no-arg BuildEnvoyProxyContainer defaults to SPIRE enabled
+	builder := NewContainerBuilder(config.CompiledDefaults())
+	container := builder.BuildEnvoyProxyContainer()
+
+	found := false
+	for _, vm := range container.VolumeMounts {
+		if vm.Name == "svid-output" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("default BuildEnvoyProxyContainer should include svid-output mount")
+	}
+}
+
+func TestBuildEnvoyProxyContainer_HasAllRequiredMounts(t *testing.T) {
+	builder := NewContainerBuilder(config.CompiledDefaults())
+	container := builder.BuildEnvoyProxyContainerWithSpireOption(true)
+
+	requiredMounts := map[string]string{
+		"envoy-config": "/etc/envoy",
+		"shared-data":  "/shared",
+		"svid-output":  "/opt",
+	}
+
+	mountsByName := make(map[string]string)
+	for _, vm := range container.VolumeMounts {
+		mountsByName[vm.Name] = vm.MountPath
+	}
+
+	for name, expectedPath := range requiredMounts {
+		path, ok := mountsByName[name]
+		if !ok {
+			t.Errorf("missing volume mount %q", name)
+			continue
+		}
+		if path != expectedPath {
+			t.Errorf("volume mount %q path = %q, want %q", name, path, expectedPath)
+		}
+	}
+}
+
+func TestBuildEnvoyProxyContainer_Name(t *testing.T) {
+	builder := NewContainerBuilder(config.CompiledDefaults())
+	container := builder.BuildEnvoyProxyContainer()
+
+	if container.Name != EnvoyProxyContainerName {
+		t.Errorf("container name = %q, want %q", container.Name, EnvoyProxyContainerName)
+	}
+}

--- a/kagenti-webhook/internal/webhook/injector/pod_mutator.go
+++ b/kagenti-webhook/internal/webhook/injector/pod_mutator.go
@@ -199,7 +199,7 @@ func (m *PodMutator) InjectAuthBridge(ctx context.Context, podSpec *corev1.PodSp
 
 	// Conditionally inject sidecars based on precedence decisions
 	if decision.EnvoyProxy.Inject && !containerExists(podSpec.Containers, EnvoyProxyContainerName) {
-		podSpec.Containers = append(podSpec.Containers, builder.BuildEnvoyProxyContainer())
+		podSpec.Containers = append(podSpec.Containers, builder.BuildEnvoyProxyContainerWithSpireOption(spireEnabled))
 	}
 
 	if decision.ProxyInit.Inject && !containerExists(podSpec.InitContainers, ProxyInitContainerName) {
@@ -335,7 +335,7 @@ func (m *PodMutator) InjectSidecarsWithSpireOption(podSpec *corev1.PodSpec, name
 
 	// Check and inject envoy-proxy sidecar
 	if !containerExists(podSpec.Containers, EnvoyProxyContainerName) {
-		podSpec.Containers = append(podSpec.Containers, m.Builder.BuildEnvoyProxyContainer())
+		podSpec.Containers = append(podSpec.Containers, m.Builder.BuildEnvoyProxyContainerWithSpireOption(spireEnabled))
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

- Mount `svid-output` volume (read-only) in the envoy-proxy container when SPIRE is enabled, so the go-processor can read `/opt/jwt_svid.token` for RFC 8693 token exchange on outbound requests
- Add `BuildEnvoyProxyContainerWithSpireOption()` method following the same pattern as `BuildClientRegistrationContainerWithSpireOption()`
- When SPIRE is disabled, the mount is omitted to avoid referencing a non-existent volume

Closes #153
Part of: kagenti/kagenti#767

## Test plan

- [x] Unit tests added (`container_builder_test.go`) covering SPIRE-enabled, SPIRE-disabled, default, and all-mounts scenarios
- [x] Full webhook test suite passes (injector + precedence + pod_mutator tests)
- [x] `go vet` clean
- [ ] Deploy to Kind cluster and verify envoy-proxy container has `svid-output` mount
- [ ] Verify go-processor can read JWT SVID for outbound token exchange

🤖 Generated with [Claude Code](https://claude.com/claude-code)