### PR TITLE
docs: add commit attribution policy and commit-msg hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,15 @@ repos:
       - id: helmlint
         files: ^charts/
 
+  # Rewrite AI Co-authored-by trailers to Assisted-By
+  - repo: local
+    hooks:
+      - id: ai-assisted-by-trailer
+        name: Replace Co-Authored-By with Assisted-By
+        entry: scripts/hooks/commit-msg
+        language: script
+        stages: [commit-msg]
+
   - repo: local
     hooks:
       - id: go-fmt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,3 +289,19 @@ AUTHBRIDGE_DEMO=true ./scripts/webhook-rollout.sh
 5. **CI Go version alignment:** Ensure the Go version in `ci.yaml` matches the highest Go version required across all modules (currently Go 1.24, matching `kagenti-webhook/go.mod`).
 
 6. **Envoy config not embedded:** The envoy-proxy sidecar mounts `envoy-config` ConfigMap at `/etc/envoy`. This ConfigMap must exist in the target namespace before workloads are created.
+
+## Commit Attribution Policy
+
+When creating git commits, do NOT use `Co-Authored-By` trailers for AI attribution.
+Instead, use `Assisted-By` to acknowledge AI assistance without inflating contributor stats:
+
+    Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
+
+Never add `Co-authored-by`, `Made-with`, or similar trailers that GitHub parses as co-authorship.
+
+A `commit-msg` hook in `scripts/hooks/commit-msg` enforces this automatically.
+Install it via pre-commit:
+
+```sh
+pre-commit install --hook-type pre-commit --hook-type commit-msg
+```

--- a/scripts/hooks/commit-msg
+++ b/scripts/hooks/commit-msg
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMMIT_MSG_FILE="$1"
+TEMP_FILE=$(mktemp)
+
+# Check if any AI co-author trailers exist before stripping
+HAS_AI_TRAILER=false
+if grep -qi -E '^Co-authored-by:.*(Claude|Cursor|anthropic)' "$COMMIT_MSG_FILE"; then
+  HAS_AI_TRAILER=true
+fi
+
+# Strip Co-authored-by lines for Claude/Cursor and Made-with lines
+grep -vi -E '^Co-authored-by:.*(Claude|Cursor|anthropic|cursor)' "$COMMIT_MSG_FILE" \
+  | grep -vi '^Made-with:' \
+  > "$TEMP_FILE" || true
+
+# Remove trailing blank lines (awk is portable across macOS/Linux unlike sed labels)
+awk '/^[[:space:]]*$/{buf=buf $0 ORS; next} {if(buf) printf "%s",buf; buf=""; print}' "$TEMP_FILE" > "$COMMIT_MSG_FILE"
+
+# If AI trailers were present, add Assisted-By instead
+if [ "$HAS_AI_TRAILER" = true ]; then
+  # Ensure there's a blank line before the trailer
+  echo "" >> "$COMMIT_MSG_FILE"
+  echo "Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>" >> "$COMMIT_MSG_FILE"
+fi
+
+rm -f "$TEMP_FILE"


### PR DESCRIPTION
## Summary

- Adds a `commit-msg` git hook (`scripts/hooks/commit-msg`) that automatically strips AI `Co-authored-by` trailers (Claude, Cursor, Anthropic) and replaces them with `Assisted-By`, preventing inflated GitHub contributor stats.
- Integrates the hook into `.pre-commit-config.yaml` as a `commit-msg` stage hook so developers get it automatically via `pre-commit install --hook-type pre-commit --hook-type commit-msg`.
- Documents the **Commit Attribution Policy** and hook install instructions in `CLAUDE.md`.

## Test plan

- [x] Hook correctly strips `Co-authored-by: Claude` trailers and replaces with `Assisted-By`
- [x] Non-AI `Co-authored-by` trailers (human contributors) are preserved
- [x] Hook works on macOS (uses portable `awk` instead of GNU `sed`)
- [x] Pre-commit framework correctly invokes the hook at the `commit-msg` stage