### PR TITLE
refactor: Remove dead TARGET_AUDIENCE and TARGET_SCOPES global env vars

### DIFF
--- a/AuthBridge/AuthProxy/README.md
+++ b/AuthBridge/AuthProxy/README.md
@@ -129,10 +129,10 @@ The Ext Proc reads token exchange configuration directly from environment variab
 | `EXPECTED_AUDIENCE` | Expected audience claim for inbound JWT validation. Optional - if not set, audience validation is skipped. | Environment variable |
 | `CLIENT_ID` | Client ID for token exchange | `/shared/client-id.txt` file or `CLIENT_ID` env var |
 | `CLIENT_SECRET` | Client secret | `/shared/client-secret.txt` file or `CLIENT_SECRET` env var |
-| `TARGET_AUDIENCE` | Target service audience for outbound token exchange | Environment variable |
-| `TARGET_SCOPES` | Scopes for exchanged token | Environment variable |
 
 > **Note:** `CLIENT_ID` and `CLIENT_SECRET` are preferentially loaded from `/shared/` files (when using dynamic client registration with SPIFFE). If files are not available, environment variables are used as fallback.
+
+> **Note:** Target audience and scopes for outbound token exchange are configured per-route in the `authproxy-routes` ConfigMap, not as global environment variables. See the [AuthBridge CLAUDE.md](../../AuthBridge/CLAUDE.md) for the `authproxy-routes` format.
 
 #### Configuration Secret
 
@@ -149,8 +149,6 @@ stringData:
   EXPECTED_AUDIENCE: "authproxy"  # Optional: expected audience for inbound requests
   CLIENT_ID: "authproxy"
   CLIENT_SECRET: "<your-client-secret>"
-  TARGET_AUDIENCE: "target-service"
-  TARGET_SCOPES: "openid target-service-aud"
 ```
 
 ## Token Exchange Flow

--- a/AuthBridge/AuthProxy/go-processor/main.go
+++ b/AuthBridge/AuthProxy/go-processor/main.go
@@ -29,12 +29,10 @@ import (
 
 // Configuration for token exchange
 type Config struct {
-	ClientID       string
-	ClientSecret   string
-	TokenURL       string
-	TargetAudience string
-	TargetScopes   string
-	mu             sync.RWMutex
+	ClientID     string
+	ClientSecret string
+	TokenURL     string
+	mu           sync.RWMutex
 }
 
 var globalConfig = &Config{}
@@ -107,8 +105,6 @@ func loadConfig() {
 
 	// Static configuration from environment variables
 	globalConfig.TokenURL = os.Getenv("TOKEN_URL")
-	globalConfig.TargetAudience = os.Getenv("TARGET_AUDIENCE")
-	globalConfig.TargetScopes = os.Getenv("TARGET_SCOPES")
 
 	// For CLIENT_ID and CLIENT_SECRET, prefer files from /shared/ (dynamic credentials)
 	// This allows AuthProxy to use the same credentials as the auto-registered client
@@ -144,8 +140,6 @@ func loadConfig() {
 	log.Printf("[Config]   CLIENT_ID: %s", globalConfig.ClientID)
 	log.Printf("[Config]   CLIENT_SECRET: [REDACTED, length=%d]", len(globalConfig.ClientSecret))
 	log.Printf("[Config]   TOKEN_URL: %s", globalConfig.TokenURL)
-	log.Printf("[Config]   TARGET_AUDIENCE: %s", globalConfig.TargetAudience)
-	log.Printf("[Config]   TARGET_SCOPES: %s", globalConfig.TargetScopes)
 }
 
 // waitForCredentials waits for credential files to be available
@@ -182,10 +176,10 @@ func waitForCredentials(maxWait time.Duration) bool {
 }
 
 // getConfig returns the current configuration
-func getConfig() (clientID, clientSecret, tokenURL, targetAudience, targetScopes string) {
+func getConfig() (clientID, clientSecret, tokenURL string) {
 	globalConfig.mu.RLock()
 	defer globalConfig.mu.RUnlock()
-	return globalConfig.ClientID, globalConfig.ClientSecret, globalConfig.TokenURL, globalConfig.TargetAudience, globalConfig.TargetScopes
+	return globalConfig.ClientID, globalConfig.ClientSecret, globalConfig.TokenURL
 }
 
 var (
@@ -517,19 +511,15 @@ func (p *processor) handleOutbound(ctx context.Context, headers *core.HeaderMap)
 	}
 
 	// Get global configuration (from files or env vars)
-	clientID, clientSecret, tokenURL, targetAudience, targetScopes := getConfig()
+	clientID, clientSecret, tokenURL := getConfig()
 
-	// Apply target-specific overrides if available
+	// Get target audience and scopes from the route configuration.
+	// These are required per-route fields; there is no global fallback.
+	var targetAudience, targetScopes string
 	if targetConfig != nil {
 		log.Printf("[Resolver] Applying target config for host %q", requestHost)
-		if targetConfig.Audience != "" {
-			targetAudience = targetConfig.Audience
-			log.Printf("[Resolver] Using target audience: %s", targetAudience)
-		}
-		if targetConfig.Scopes != "" {
-			targetScopes = targetConfig.Scopes
-			log.Printf("[Resolver] Using target scopes: %s", targetScopes)
-		}
+		targetAudience = targetConfig.Audience
+		targetScopes = targetConfig.Scopes
 		if targetConfig.TokenEndpoint != "" {
 			tokenURL = targetConfig.TokenEndpoint
 			log.Printf("[Resolver] Using target token_url: %s", tokenURL)
@@ -610,7 +600,7 @@ func (p *processor) handleOutbound(ctx context.Context, headers *core.HeaderMap)
 		log.Println("[Token Exchange] Missing configuration, skipping token exchange")
 		log.Printf("[Token Exchange] CLIENT_ID present: %v, CLIENT_SECRET present: %v, TOKEN_URL present: %v",
 			clientID != "", clientSecret != "", tokenURL != "")
-		log.Printf("[Token Exchange] TARGET_AUDIENCE present: %v, TARGET_SCOPES present: %v",
+		log.Printf("[Token Exchange] Route target_audience present: %v, Route token_scopes present: %v",
 			targetAudience != "", targetScopes != "")
 	}
 
@@ -679,7 +669,7 @@ func main() {
 	loadConfig()
 
 	// Initialize inbound JWT validation
-	_, _, tokenURL, _, _ := getConfig()
+	_, _, tokenURL := getConfig()
 	inboundIssuer = os.Getenv("ISSUER")
 	expectedAudience = os.Getenv("EXPECTED_AUDIENCE")
 	if tokenURL != "" && inboundIssuer != "" {

--- a/AuthBridge/AuthProxy/go-processor/main_test.go
+++ b/AuthBridge/AuthProxy/go-processor/main_test.go
@@ -269,26 +269,22 @@ func hasReplacedAuthHeader(resp *v3.ProcessingResponse) (string, bool) {
 }
 
 type savedGlobals struct {
-	policy         string
-	resolver       resolver.TargetResolver
-	clientID       string
-	clientSecret   string
-	tokenURL       string
-	targetAudience string
-	targetScopes   string
+	policy       string
+	resolver     resolver.TargetResolver
+	clientID     string
+	clientSecret string
+	tokenURL     string
 }
 
 func saveGlobals() savedGlobals {
 	globalConfig.mu.RLock()
 	defer globalConfig.mu.RUnlock()
 	return savedGlobals{
-		policy:         defaultOutboundPolicy,
-		resolver:       globalResolver,
-		clientID:       globalConfig.ClientID,
-		clientSecret:   globalConfig.ClientSecret,
-		tokenURL:       globalConfig.TokenURL,
-		targetAudience: globalConfig.TargetAudience,
-		targetScopes:   globalConfig.TargetScopes,
+		policy:       defaultOutboundPolicy,
+		resolver:     globalResolver,
+		clientID:     globalConfig.ClientID,
+		clientSecret: globalConfig.ClientSecret,
+		tokenURL:     globalConfig.TokenURL,
 	}
 }
 
@@ -300,18 +296,14 @@ func restoreGlobals(saved savedGlobals) {
 	globalConfig.ClientID = saved.clientID
 	globalConfig.ClientSecret = saved.clientSecret
 	globalConfig.TokenURL = saved.tokenURL
-	globalConfig.TargetAudience = saved.targetAudience
-	globalConfig.TargetScopes = saved.targetScopes
 }
 
-func setGlobalConfig(clientID, clientSecret, tokenURL, audience, scopes string) {
+func setGlobalConfig(clientID, clientSecret, tokenURL string) {
 	globalConfig.mu.Lock()
 	defer globalConfig.mu.Unlock()
 	globalConfig.ClientID = clientID
 	globalConfig.ClientSecret = clientSecret
 	globalConfig.TokenURL = tokenURL
-	globalConfig.TargetAudience = audience
-	globalConfig.TargetScopes = scopes
 }
 
 // --- Test: Default agents (weather-service pattern) ---
@@ -373,9 +365,9 @@ func TestDefaultOutboundPolicy(t *testing.T) {
 			globalResolver = emptyResolver(t)
 
 			if tt.globalConfig {
-				setGlobalConfig("test-client", "test-secret", "http://keycloak/token", "test-aud", "openid")
+				setGlobalConfig("test-client", "test-secret", "http://keycloak/token")
 			} else {
-				setGlobalConfig("", "", "", "", "")
+				setGlobalConfig("", "", "")
 			}
 
 			p := &processor{}
@@ -392,10 +384,29 @@ func TestDefaultOutboundPolicy(t *testing.T) {
 	}
 }
 
-// TestDefaultOutboundPolicyLegacyExchange verifies backward compatibility:
-// when DEFAULT_OUTBOUND_POLICY=exchange and global config is complete, unmatched
-// hosts still get token exchange (the old behavior).
-func TestDefaultOutboundPolicyLegacyExchange(t *testing.T) {
+// TestDefaultOutboundPolicyLegacyExchangeNoRoutes verifies that when
+// DEFAULT_OUTBOUND_POLICY=exchange but no routes are configured, the request
+// passes through because there is no target audience/scopes to use.
+func TestDefaultOutboundPolicyLegacyExchangeNoRoutes(t *testing.T) {
+	saved := saveGlobals()
+	defer restoreGlobals(saved)
+
+	defaultOutboundPolicy = "exchange"
+	globalResolver = emptyResolver(t)
+	setGlobalConfig("test-client", "test-secret", "http://keycloak/token")
+
+	p := &processor{}
+	headers := buildHeaders("random-service.example.com", "Bearer some-jwt-token")
+	resp := p.handleOutbound(context.Background(), headers)
+
+	if !isPassthrough(resp) {
+		t.Error("expected passthrough when exchange policy is set but no routes provide audience/scopes")
+	}
+}
+
+// TestDefaultOutboundPolicyLegacyExchangeWithRoute verifies that when
+// DEFAULT_OUTBOUND_POLICY=exchange and a route matches, token exchange works.
+func TestDefaultOutboundPolicyLegacyExchangeWithRoute(t *testing.T) {
 	saved := saveGlobals()
 	defer restoreGlobals(saved)
 
@@ -406,9 +417,16 @@ func TestDefaultOutboundPolicyLegacyExchange(t *testing.T) {
 	})
 	defer keycloak.Close()
 
+	routesYAML := fmt.Sprintf(`
+- host: "random-service.example.com"
+  target_audience: "test-audience"
+  token_scopes: "openid test-aud"
+  token_url: %q
+`, keycloak.URL)
+
 	defaultOutboundPolicy = "exchange"
-	globalResolver = emptyResolver(t)
-	setGlobalConfig("test-client", "test-secret", keycloak.URL, "test-audience", "openid test-aud")
+	globalResolver = setupTestResolver(t, routesYAML)
+	setGlobalConfig("test-client", "test-secret", keycloak.URL)
 
 	p := &processor{}
 	headers := buildHeaders("random-service.example.com", "Bearer some-jwt-token")
@@ -417,9 +435,9 @@ func TestDefaultOutboundPolicyLegacyExchange(t *testing.T) {
 	token, ok := hasReplacedAuthHeader(resp)
 	if !ok {
 		if isDenied(resp) {
-			t.Fatal("legacy exchange policy: expected token exchange to succeed, but got 503 denial")
+			t.Fatal("expected token exchange to succeed, but got 503 denial")
 		}
-		t.Fatal("legacy exchange policy: expected Authorization header to be replaced, but got passthrough")
+		t.Fatal("expected Authorization header to be replaced, but got passthrough")
 	}
 	if token != "Bearer legacy-exchanged-token" {
 		t.Errorf("expected 'Bearer legacy-exchanged-token', got %q", token)
@@ -453,7 +471,7 @@ func TestOutboundPolicyWithRoutes(t *testing.T) {
 
 	defaultOutboundPolicy = "passthrough"
 	globalResolver = setupTestResolver(t, routesYAML)
-	setGlobalConfig("spiffe://localtest.me/ns/team1/sa/github-issue-agent", "client-secret-123", keycloak.URL, "", "")
+	setGlobalConfig("spiffe://localtest.me/ns/team1/sa/github-issue-agent", "client-secret-123", keycloak.URL)
 
 	t.Run("route_match_exchanges_token", func(t *testing.T) {
 		p := &processor{}
@@ -531,7 +549,7 @@ func TestOutboundPolicyRouteMatchExchangeFails(t *testing.T) {
 
 	defaultOutboundPolicy = "passthrough"
 	globalResolver = setupTestResolver(t, routesYAML)
-	setGlobalConfig("test-client", "test-secret", keycloak.URL, "", "")
+	setGlobalConfig("test-client", "test-secret", keycloak.URL)
 
 	p := &processor{}
 	headers := buildHeaders("github-issue-tool-headless.team1.svc.cluster.local", "Bearer some-invalid-jwt")

--- a/AuthBridge/AuthProxy/k8s/auth-proxy-deployment.yaml
+++ b/AuthBridge/AuthProxy/k8s/auth-proxy-deployment.yaml
@@ -104,18 +104,6 @@ spec:
               name: auth-proxy-config
               key: CLIENT_SECRET
               optional: true
-        - name: TARGET_AUDIENCE
-          valueFrom:
-            secretKeyRef:
-              name: auth-proxy-config
-              key: TARGET_AUDIENCE
-              optional: true
-        - name: TARGET_SCOPES
-          valueFrom:
-            secretKeyRef:
-              name: auth-proxy-config
-              key: TARGET_SCOPES
-              optional: true
         volumeMounts:
         - name: envoy-config
           mountPath: /etc/envoy

--- a/AuthBridge/AuthProxy/quickstart/README.md
+++ b/AuthBridge/AuthProxy/quickstart/README.md
@@ -100,9 +100,7 @@ kubectl create secret generic auth-proxy-config \
   --from-literal=ISSUER="http://keycloak.localtest.me:8080/realms/demo" \
   --from-literal=EXPECTED_AUDIENCE="authproxy" \
   --from-literal=CLIENT_ID="authproxy" \
-  --from-literal=CLIENT_SECRET="$AUTHPROXY_SECRET" \
-  --from-literal=TARGET_AUDIENCE="demoapp" \
-  --from-literal=TARGET_SCOPES="openid demoapp-aud"
+  --from-literal=CLIENT_SECRET="$AUTHPROXY_SECRET"
 ```
 
 Then restart the auth-proxy deployment to pick up the secret:

--- a/AuthBridge/CLAUDE.md
+++ b/AuthBridge/CLAUDE.md
@@ -86,8 +86,8 @@ The core ext-proc that handles both traffic directions:
 - Reads `CLIENT_ID` from `/shared/client-id.txt` (file) or `CLIENT_ID` env var (fallback)
 - Reads `CLIENT_SECRET` from `/shared/client-secret.txt` (file) or `CLIENT_SECRET` env var (fallback)
 - Static config from env vars: `TOKEN_URL`, `ISSUER`, `EXPECTED_AUDIENCE`
-- Outbound route config from `ROUTES_CONFIG_PATH` (default `/etc/authproxy-routes/routes.yaml`)
-- Default outbound policy from `DEFAULT_OUTBOUND_POLICY` env var: `"passthrough"` (default) or `"exchange"` (legacy)
+- Outbound route config from `ROUTES_CONFIG_PATH` (default `/etc/authproxy-routes/routes.yaml`). Target audience and scopes are configured per-route only.
+- Default outbound policy from `DEFAULT_OUTBOUND_POLICY` env var: `"passthrough"` (default) or `"exchange"`
 - JWKS URL is derived from TOKEN_URL: replaces `/token` suffix with `/certs`
 
 **Key types:**
@@ -177,7 +177,7 @@ When the kagenti-webhook injects sidecars, these ConfigMaps must exist in the ta
 |----------|------|----------|------------|
 | `environments` | ConfigMap | client-registration | `KEYCLOAK_URL`, `KEYCLOAK_REALM`, `SPIRE_ENABLED` |
 | `keycloak-admin-secret` | Secret | client-registration | `KEYCLOAK_ADMIN_USERNAME`, `KEYCLOAK_ADMIN_PASSWORD` |
-| `authbridge-config` | ConfigMap | envoy-proxy (ext-proc) | `TOKEN_URL`, `ISSUER`, `DEFAULT_OUTBOUND_POLICY` (optional) |
+| `authbridge-config` | ConfigMap | envoy-proxy (ext-proc) | `TOKEN_URL`, `ISSUER`, `DEFAULT_OUTBOUND_POLICY` (optional). Target audience and scopes are configured per-route in `authproxy-routes`. |
 | `authproxy-routes` | ConfigMap (optional) | envoy-proxy (ext-proc) | `routes.yaml` with per-host token exchange rules |
 | `spiffe-helper-config` | ConfigMap | spiffe-helper | `helper.conf` (SPIRE agent address, cert paths, JWT SVID config) |
 | `envoy-config` | ConfigMap | envoy-proxy | `envoy.yaml` (full Envoy configuration) |
@@ -193,7 +193,7 @@ routes:
     token_scopes: "openid auth-target-aud"
 ```
 
-The go-processor defaults to **passthrough** for outbound requests that don't match any route. Token exchange only happens for hosts with explicit entries in `authproxy-routes`. Set `DEFAULT_OUTBOUND_POLICY: "exchange"` in `authbridge-config` to restore legacy behavior.
+The go-processor defaults to **passthrough** for outbound requests that don't match any route. Token exchange only happens for hosts with explicit entries in `authproxy-routes`, where target audience and scopes are configured per-route.
 
 ## Shared Volume Contract
 

--- a/AuthBridge/demos/github-issue/demo-manual.md
+++ b/AuthBridge/demos/github-issue/demo-manual.md
@@ -308,22 +308,16 @@ kubectl create secret generic keycloak-admin-secret -n team1 \
   --dry-run=client -o yaml | kubectl apply -f -
 ```
 
-Then apply the demo-specific `authbridge-config` override — the token exchange
-target audience (`github-tool`), scopes, and the agent's SPIFFE ID for inbound
-audience validation. Apply this **before** deploying the agent.
+Then apply the demo-specific ConfigMaps — the `authproxy-routes` ConfigMap
+configures per-route token exchange (target audience and scopes for the
+`github-tool` host), and `authbridge-config` sets the agent's SPIFFE ID for
+inbound audience validation. Apply this **before** deploying the agent.
 
 ```bash
 cd AuthBridge
 
-# Override authbridge-config for this demo (sets TARGET_AUDIENCE=github-tool)
+# Apply demo ConfigMaps (authbridge-config and authproxy-routes)
 kubectl apply -f demos/github-issue/k8s/configmaps.yaml
-```
-
-Verify the demo ConfigMap was applied:
-
-```bash
-kubectl get configmap authbridge-config -n team1 -o jsonpath='{.data.TARGET_AUDIENCE}'
-# Expected: github-tool
 ```
 
 > **Note:** If you're using a different namespace or service account, edit
@@ -813,15 +807,15 @@ kubectl delete pod test-client -n team1 --ignore-not-found
 <!-- WORKAROUND: Remove this note once kagenti-extensions#139 is implemented.
      The full scope-forwarding feature in go-processor is required for this step to work
      end-to-end. Until that lands, the exchanged token always includes github-full-access
-     (from the static TARGET_SCOPES in authbridge-config).
+     (from the static token_scopes in the authproxy-routes ConfigMap).
      Track: https://github.com/kagenti/kagenti-extensions/issues/139 -->
 
 > **Known limitation:** This step requires the go-processor scope forwarding feature
 > ([kagenti-extensions#139](https://github.com/kagenti/kagenti-extensions/issues/139)).
-> Currently, `TARGET_SCOPES` in `authbridge-config` is static, so all exchanged tokens
-> include `github-full-access` regardless of the original user's scopes. Once scope
-> forwarding is implemented, Alice's exchanged token will omit `github-full-access`
-> while Bob's will include it.
+> Currently, `token_scopes` in the `authproxy-routes` ConfigMap is static per-route, so
+> all exchanged tokens include `github-full-access` regardless of the original user's
+> scopes. Once scope forwarding is implemented, Alice's exchanged token will omit
+> `github-full-access` while Bob's will include it.
 
 This step demonstrates **scope-based access control**: two users with different
 privilege levels get different GitHub API access through the same agent.

--- a/AuthBridge/demos/github-issue/demo-ui.md
+++ b/AuthBridge/demos/github-issue/demo-ui.md
@@ -200,14 +200,15 @@ kubectl create secret generic keycloak-admin-secret -n team1 \
   --dry-run=client -o yaml | kubectl apply -f -
 ```
 
-Then apply the demo-specific `authbridge-config` override — the token exchange
-target audience (`github-tool`), scopes, and the agent's SPIFFE ID for inbound
-audience validation:
+Then apply the demo-specific ConfigMaps — the `authproxy-routes` ConfigMap
+configures per-route token exchange (target audience and scopes for the
+`github-tool` host), and `authbridge-config` sets the agent's SPIFFE ID for
+inbound audience validation:
 
 ```bash
 cd AuthBridge
 
-# Override authbridge-config for this demo (sets TARGET_AUDIENCE=github-tool)
+# Apply demo ConfigMaps (authbridge-config and authproxy-routes)
 kubectl apply -f demos/github-issue/k8s/configmaps.yaml
 ```
 
@@ -661,15 +662,15 @@ kubectl delete pod test-client -n team1 --ignore-not-found
 <!-- WORKAROUND: Remove this note once kagenti-extensions#139 is implemented.
      The full scope-forwarding feature in go-processor is required for this step to work
      end-to-end. Until that lands, the exchanged token always includes github-full-access
-     (from the static TARGET_SCOPES in authbridge-config).
+     (from the static token_scopes in the authproxy-routes ConfigMap).
      Track: https://github.com/kagenti/kagenti-extensions/issues/139 -->
 
 > **Known limitation:** This step requires the go-processor scope forwarding feature
 > ([kagenti-extensions#139](https://github.com/kagenti/kagenti-extensions/issues/139)).
-> Currently, `TARGET_SCOPES` in `authbridge-config` is static, so all exchanged tokens
-> include `github-full-access` regardless of the original user's scopes. Once scope
-> forwarding is implemented, Alice's exchanged token will omit `github-full-access`
-> while Bob's will include it.
+> Currently, `token_scopes` in the `authproxy-routes` ConfigMap is static per-route, so
+> all exchanged tokens include `github-full-access` regardless of the original user's
+> scopes. Once scope forwarding is implemented, Alice's exchanged token will omit
+> `github-full-access` while Bob's will include it.
 
 This step demonstrates **scope-based access control**: two users with different
 privilege levels get different GitHub API access through the same agent.

--- a/AuthBridge/demos/github-issue/k8s/configmaps.yaml
+++ b/AuthBridge/demos/github-issue/k8s/configmaps.yaml
@@ -37,10 +37,6 @@ data:
   # Format: spiffe://localtest.me/ns/<namespace>/sa/<service-account>
   # Update if deploying to a different namespace or using a different service account.
   EXPECTED_AUDIENCE: "spiffe://localtest.me/ns/team1/sa/git-issue-agent"
-  # TARGET_AUDIENCE and TARGET_SCOPES are used as fallback values when a route
-  # in authproxy-routes matches but doesn't specify its own audience/scopes.
-  TARGET_AUDIENCE: "github-tool"
-  TARGET_SCOPES: "openid github-tool-aud github-full-access"
 
 ---
 # authproxy-routes ConfigMap - Per-target token exchange routes

--- a/AuthBridge/demos/multi-target/k8s/authbridge-deployment-no-spiffe.yaml
+++ b/AuthBridge/demos/multi-target/k8s/authbridge-deployment-no-spiffe.yaml
@@ -35,7 +35,6 @@ metadata:
 # =============================================================================
 # AUTH PROXY CONFIGURATION
 # CLIENT_ID and CLIENT_SECRET come from /shared/ files (populated by client-registration)
-# TARGET_AUDIENCE and TARGET_SCOPES define the target service for token exchange
 # =============================================================================
 apiVersion: v1
 kind: Secret
@@ -45,8 +44,6 @@ metadata:
 type: Opaque
 stringData:
   TOKEN_URL: "http://keycloak-service.keycloak.svc.cluster.local:8080/realms/demo/protocol/openid-connect/token"
-  TARGET_AUDIENCE: "auth-target"
-  TARGET_SCOPES: "openid auth-target-aud"
 
 ---
 # =============================================================================
@@ -372,16 +369,6 @@ spec:
                 secretKeyRef:
                   name: auth-proxy-config
                   key: TOKEN_URL
-            - name: TARGET_AUDIENCE
-              valueFrom:
-                secretKeyRef:
-                  name: auth-proxy-config
-                  key: TARGET_AUDIENCE
-            - name: TARGET_SCOPES
-              valueFrom:
-                secretKeyRef:
-                  name: auth-proxy-config
-                  key: TARGET_SCOPES
             # Dynamic credentials from client-registration (via files)
             - name: CLIENT_ID_FILE
               value: "/shared/client-id.txt"

--- a/AuthBridge/demos/multi-target/k8s/authbridge-deployment.yaml
+++ b/AuthBridge/demos/multi-target/k8s/authbridge-deployment.yaml
@@ -45,7 +45,6 @@ metadata:
 # =============================================================================
 # AUTH PROXY CONFIGURATION
 # CLIENT_ID and CLIENT_SECRET come from /shared/ files (populated by client-registration)
-# TARGET_AUDIENCE and TARGET_SCOPES define the target service for token exchange
 # =============================================================================
 apiVersion: v1
 kind: Secret
@@ -55,8 +54,6 @@ metadata:
 type: Opaque
 stringData:
   TOKEN_URL: "http://keycloak-service.keycloak.svc.cluster.local:8080/realms/demo/protocol/openid-connect/token"
-  TARGET_AUDIENCE: "auth-target"
-  TARGET_SCOPES: "openid auth-target-aud"
 
 ---
 # =============================================================================
@@ -449,16 +446,6 @@ spec:
                 secretKeyRef:
                   name: auth-proxy-config
                   key: TOKEN_URL
-            - name: TARGET_AUDIENCE
-              valueFrom:
-                secretKeyRef:
-                  name: auth-proxy-config
-                  key: TARGET_AUDIENCE
-            - name: TARGET_SCOPES
-              valueFrom:
-                secretKeyRef:
-                  name: auth-proxy-config
-                  key: TARGET_SCOPES
             # Dynamic credentials from client-registration (via files)
             - name: CLIENT_ID_FILE
               value: "/shared/client-id.txt"

--- a/AuthBridge/demos/single-target/k8s/authbridge-deployment-no-spiffe.yaml
+++ b/AuthBridge/demos/single-target/k8s/authbridge-deployment-no-spiffe.yaml
@@ -46,7 +46,6 @@ metadata:
 # =============================================================================
 # AUTH PROXY CONFIGURATION
 # CLIENT_ID and CLIENT_SECRET come from /shared/ files (populated by client-registration)
-# TARGET_AUDIENCE and TARGET_SCOPES define the target service for token exchange
 # =============================================================================
 apiVersion: v1
 kind: Secret
@@ -57,8 +56,6 @@ type: Opaque
 stringData:
   TOKEN_URL: "http://keycloak-service.keycloak.svc.cluster.local:8080/realms/demo/protocol/openid-connect/token"
   ISSUER: "http://keycloak.localtest.me:8080/realms/demo"
-  TARGET_AUDIENCE: "auth-target"
-  TARGET_SCOPES: "openid auth-target-aud"
 
 ---
 # =============================================================================
@@ -237,11 +234,9 @@ metadata:
   namespace: authbridge
 data:
   routes.yaml: |
-    # Example route configurations:
-    # - host: "github.mcp.local"
-    #   target_audience: "https://api.github.com"
-    # - host: "*.internal.svc.cluster.local"
-    #   passthrough: true
+    - host: "auth-target-service"
+      target_audience: "auth-target"
+      token_scopes: "openid auth-target-aud"
 
 ---
 # =============================================================================
@@ -437,16 +432,6 @@ spec:
                 secretKeyRef:
                   name: auth-proxy-config
                   key: ISSUER
-            - name: TARGET_AUDIENCE
-              valueFrom:
-                secretKeyRef:
-                  name: auth-proxy-config
-                  key: TARGET_AUDIENCE
-            - name: TARGET_SCOPES
-              valueFrom:
-                secretKeyRef:
-                  name: auth-proxy-config
-                  key: TARGET_SCOPES
             # Dynamic credentials from client-registration (via files)
             - name: CLIENT_ID_FILE
               value: "/shared/client-id.txt"

--- a/AuthBridge/demos/single-target/k8s/authbridge-deployment.yaml
+++ b/AuthBridge/demos/single-target/k8s/authbridge-deployment.yaml
@@ -51,7 +51,6 @@ metadata:
 # =============================================================================
 # AUTH PROXY CONFIGURATION
 # CLIENT_ID and CLIENT_SECRET come from /shared/ files (populated by client-registration)
-# TARGET_AUDIENCE and TARGET_SCOPES define the target service for token exchange
 # =============================================================================
 apiVersion: v1
 kind: Secret
@@ -62,8 +61,6 @@ type: Opaque
 stringData:
   TOKEN_URL: "http://keycloak-service.keycloak.svc.cluster.local:8080/realms/demo/protocol/openid-connect/token"
   ISSUER: "http://keycloak.localtest.me:8080/realms/demo"
-  TARGET_AUDIENCE: "auth-target"
-  TARGET_SCOPES: "openid auth-target-aud"
 
 ---
 # =============================================================================
@@ -261,11 +258,9 @@ metadata:
   namespace: authbridge
 data:
   routes.yaml: |
-    # Example route configurations:
-    # - host: "github.mcp.local"
-    #   target_audience: "https://api.github.com"
-    # - host: "*.internal.svc.cluster.local"
-    #   passthrough: true
+    - host: "auth-target-service"
+      target_audience: "auth-target"
+      token_scopes: "openid auth-target-aud"
 
 ---
 # =============================================================================
@@ -516,16 +511,6 @@ spec:
                 secretKeyRef:
                   name: auth-proxy-config
                   key: ISSUER
-            - name: TARGET_AUDIENCE
-              valueFrom:
-                secretKeyRef:
-                  name: auth-proxy-config
-                  key: TARGET_AUDIENCE
-            - name: TARGET_SCOPES
-              valueFrom:
-                secretKeyRef:
-                  name: auth-proxy-config
-                  key: TARGET_SCOPES
             # Dynamic credentials from client-registration (via files)
             - name: CLIENT_ID_FILE
               value: "/shared/client-id.txt"

--- a/AuthBridge/demos/webhook/README.md
+++ b/AuthBridge/demos/webhook/README.md
@@ -96,8 +96,7 @@ The ConfigMaps include:
   - `TOKEN_URL` - Keycloak token endpoint for token exchange
   - `ISSUER` - Expected JWT issuer for inbound validation (required)
   - `EXPECTED_AUDIENCE` - Expected audience for inbound validation (optional, if not set audience validation is skipped)
-  - `TARGET_AUDIENCE` - Target audience for outbound token exchange
-  - `TARGET_SCOPES` - Scopes for exchanged tokens
+  - Target audience and scopes for outbound token exchange are configured per-route in the `authproxy-routes` ConfigMap
 - `spiffe-helper-config` - SPIFFE helper configuration (for SPIRE mode)
 - `envoy-config` - Envoy proxy configuration
 
@@ -322,7 +321,7 @@ kubectl logs deployment/agent -n team1 -c spiffe-helper
 ### Common Issues
 
 1. **"Requested audience not available: auth-target"**
-   - Ensure `TARGET_SCOPES` in `authbridge-config` includes `auth-target-aud`
+   - Ensure the route entry in `authproxy-routes` includes `auth-target-aud` in `token_scopes`
    - Run `setup_keycloak.py` again to create the required scopes
 
 2. **ConfigMap not found errors**

--- a/AuthBridge/demos/webhook/k8s/configmaps-webhook.yaml
+++ b/AuthBridge/demos/webhook/k8s/configmaps-webhook.yaml
@@ -54,38 +54,30 @@ data:
   # Update this value if deploying to a different namespace or using a different service account.
   # If not set, audience validation is skipped (issuer and signature validation still occur).
   EXPECTED_AUDIENCE: "spiffe://localtest.me/ns/team1/sa/agent"
-  # TARGET_AUDIENCE and TARGET_SCOPES: Fallback values for token exchange when a
-  # route in authproxy-routes matches but doesn't specify its own audience/scopes.
-  TARGET_AUDIENCE: "auth-target"
-  TARGET_SCOPES: "openid auth-target-aud"
   # DEFAULT_OUTBOUND_POLICY: Controls behavior for outbound requests that don't
   # match any route in authproxy-routes. Default is "passthrough" (skip exchange).
   # Set to "exchange" to restore legacy behavior (exchange all outbound traffic).
   # DEFAULT_OUTBOUND_POLICY: "passthrough"
 
 ---
-# authproxy-routes ConfigMap (optional) - Per-target token exchange routes
+# authproxy-routes ConfigMap - Per-target token exchange routes
 #
 # Defines which outbound hosts should get token exchange. All other hosts pass
 # through unchanged when DEFAULT_OUTBOUND_POLICY is "passthrough" (the default).
 #
-# If this ConfigMap does not exist, no outbound token exchange occurs (all
-# traffic passes through). Create it only when your agents need to authenticate
-# to specific services via Keycloak token exchange.
-#
-# Example:
-#   apiVersion: v1
-#   kind: ConfigMap
-#   metadata:
-#     name: authproxy-routes
-#     namespace: team1
-#   data:
-#     routes.yaml: |
-#       - host: "auth-target.team1.svc.cluster.local"
-#         target_audience: "auth-target"
-#         token_scopes: "openid auth-target-aud"
-#       - host: "otel-collector.*.svc.cluster.local"
-#         passthrough: true
+# This ConfigMap is required for outbound token exchange to work. Without it,
+# no outbound token exchange occurs (all traffic passes through). Each route
+# specifies the target_audience and token_scopes for a given host.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authproxy-routes
+  namespace: team1
+data:
+  routes.yaml: |
+    - host: "auth-target-service"
+      target_audience: "auth-target"
+      token_scopes: "openid auth-target-aud"
 
 ---
 # spiffe-helper-config ConfigMap - Used by spiffe-helper container (SPIRE mode only)

--- a/AuthBridge/k8s/authbridge-deployment-no-spiffe.yaml
+++ b/AuthBridge/k8s/authbridge-deployment-no-spiffe.yaml
@@ -43,7 +43,6 @@ metadata:
 # =============================================================================
 # AUTH PROXY CONFIGURATION
 # CLIENT_ID and CLIENT_SECRET come from /shared/ files (populated by client-registration)
-# TARGET_AUDIENCE and TARGET_SCOPES define the target service for token exchange
 # =============================================================================
 apiVersion: v1
 kind: Secret
@@ -54,8 +53,6 @@ type: Opaque
 stringData:
   TOKEN_URL: "http://keycloak-service.keycloak.svc.cluster.local:8080/realms/demo/protocol/openid-connect/token"
   ISSUER: "http://keycloak.localtest.me:8080/realms/demo"
-  TARGET_AUDIENCE: "auth-target"
-  TARGET_SCOPES: "openid auth-target-aud"
 
 ---
 # =============================================================================
@@ -408,16 +405,6 @@ spec:
                 secretKeyRef:
                   name: auth-proxy-config
                   key: ISSUER
-            - name: TARGET_AUDIENCE
-              valueFrom:
-                secretKeyRef:
-                  name: auth-proxy-config
-                  key: TARGET_AUDIENCE
-            - name: TARGET_SCOPES
-              valueFrom:
-                secretKeyRef:
-                  name: auth-proxy-config
-                  key: TARGET_SCOPES
             # Dynamic credentials from client-registration (via files)
             - name: CLIENT_ID_FILE
               value: "/shared/client-id.txt"

--- a/AuthBridge/k8s/authbridge-deployment.yaml
+++ b/AuthBridge/k8s/authbridge-deployment.yaml
@@ -48,7 +48,6 @@ metadata:
 # =============================================================================
 # AUTH PROXY CONFIGURATION
 # CLIENT_ID and CLIENT_SECRET come from /shared/ files (populated by client-registration)
-# TARGET_AUDIENCE and TARGET_SCOPES define the target service for token exchange
 # =============================================================================
 apiVersion: v1
 kind: Secret
@@ -59,8 +58,6 @@ type: Opaque
 stringData:
   TOKEN_URL: "http://keycloak-service.keycloak.svc.cluster.local:8080/realms/demo/protocol/openid-connect/token"
   ISSUER: "http://keycloak.localtest.me:8080/realms/demo"
-  TARGET_AUDIENCE: "auth-target"
-  TARGET_SCOPES: "openid auth-target-aud"
 
 ---
 # =============================================================================
@@ -487,16 +484,6 @@ spec:
                 secretKeyRef:
                   name: auth-proxy-config
                   key: ISSUER
-            - name: TARGET_AUDIENCE
-              valueFrom:
-                secretKeyRef:
-                  name: auth-proxy-config
-                  key: TARGET_AUDIENCE
-            - name: TARGET_SCOPES
-              valueFrom:
-                secretKeyRef:
-                  name: auth-proxy-config
-                  key: TARGET_SCOPES
             # Dynamic credentials from client-registration (via files)
             - name: CLIENT_ID_FILE
               value: "/shared/client-id.txt"

--- a/AuthBridge/k8s/configmaps-webhook.yaml
+++ b/AuthBridge/k8s/configmaps-webhook.yaml
@@ -35,8 +35,6 @@ data:
   # ISSUER: Required. Keycloak frontend URL used as token issuer for inbound JWT validation.
   # Must match the "iss" claim in tokens (Keycloak's frontend URL).
   ISSUER: "http://keycloak.localtest.me:8080/realms/demo"
-  TARGET_AUDIENCE: "auth-target"
-  TARGET_SCOPES: "openid auth-target-aud"
 
 ---
 # spiffe-helper-config ConfigMap - Used by spiffe-helper container (SPIRE mode only)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,7 +204,7 @@ When the webhook injects sidecars, the target namespace needs these resources:
 |----------|------|---------|------|
 | `environments` | ConfigMap | client-registration | `KEYCLOAK_URL`, `KEYCLOAK_REALM` |
 | `keycloak-admin-secret` | Secret | client-registration | `KEYCLOAK_ADMIN_USERNAME`, `KEYCLOAK_ADMIN_PASSWORD` |
-| `authbridge-config` | ConfigMap | envoy-proxy (ext-proc) | `TOKEN_URL`, `ISSUER`, `DEFAULT_OUTBOUND_POLICY` (optional, defaults to `passthrough`) |
+| `authbridge-config` | ConfigMap | envoy-proxy (ext-proc) | `TOKEN_URL`, `ISSUER`, `DEFAULT_OUTBOUND_POLICY` (optional, defaults to `passthrough`). Target audience and scopes are configured per-route in `authproxy-routes`. |
 | `authproxy-routes` | ConfigMap (optional) | envoy-proxy (ext-proc) | `routes.yaml` -- per-host token exchange rules (see AuthBridge/CLAUDE.md for format) |
 | `spiffe-helper-config` | ConfigMap | spiffe-helper | SPIFFE helper configuration file |
 | `envoy-config` | ConfigMap | envoy-proxy | Envoy YAML configuration |
@@ -302,7 +302,7 @@ AUTHBRIDGE_DEMO=true ./scripts/webhook-rollout.sh
 
 6. **Envoy config not embedded:** The envoy-proxy sidecar mounts `envoy-config` ConfigMap at `/etc/envoy`. This ConfigMap must exist in the target namespace before workloads are created.
 
-7. **Outbound policy is passthrough by default:** The go-processor defaults to passing outbound traffic through unchanged. Token exchange only happens for hosts explicitly listed in the `authproxy-routes` ConfigMap. Setting `TARGET_AUDIENCE`/`TARGET_SCOPES` in `authbridge-config` alone does nothing unless a route references them (or the default policy is changed to `exchange`).
+7. **Outbound policy is passthrough by default:** The go-processor defaults to passing outbound traffic through unchanged. Token exchange only happens for hosts explicitly listed in the `authproxy-routes` ConfigMap. Target audience and scopes are configured per-route in `authproxy-routes`.
 
 8. **Route host patterns use short service names:** The `host` field in `authproxy-routes` matches against the HTTP `Host` header, which is typically just the short Kubernetes service name (e.g., `github-tool-mcp`), not the FQDN. Glob patterns (`*`) are supported but the most common case is a plain service name.
 

--- a/kagenti-webhook/CLAUDE.md
+++ b/kagenti-webhook/CLAUDE.md
@@ -171,7 +171,7 @@ Injected sidecars expect these resources to exist in the target namespace:
 
 ConfigMaps:
 - `environments` -- `KEYCLOAK_URL`, `KEYCLOAK_REALM`
-- `authbridge-config` -- `TOKEN_URL`, `ISSUER`, `TARGET_AUDIENCE`, `TARGET_SCOPES`
+- `authbridge-config` -- `TOKEN_URL`, `ISSUER`, `DEFAULT_OUTBOUND_POLICY` (optional). Target audience and scopes are configured per-route in the `authproxy-routes` ConfigMap.
 - `spiffe-helper-config` -- SPIFFE helper configuration (when SPIRE is enabled)
 - `envoy-config` -- Envoy proxy configuration
 

--- a/kagenti-webhook/internal/webhook/injector/container_builder.go
+++ b/kagenti-webhook/internal/webhook/injector/container_builder.go
@@ -364,30 +364,6 @@ func (b *ContainerBuilder) BuildEnvoyProxyContainerWithSpireOption(spireEnabled 
 				},
 			},
 			{
-				Name: "TARGET_AUDIENCE",
-				ValueFrom: &corev1.EnvVarSource{
-					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: "authbridge-config",
-						},
-						Key:      "TARGET_AUDIENCE",
-						Optional: ptr.To(true),
-					},
-				},
-			},
-			{
-				Name: "TARGET_SCOPES",
-				ValueFrom: &corev1.EnvVarSource{
-					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: "authbridge-config",
-						},
-						Key:      "TARGET_SCOPES",
-						Optional: ptr.To(true),
-					},
-				},
-			},
-			{
 				Name:  "CLIENT_ID_FILE",
 				Value: "/shared/client-id.txt",
 			},


### PR DESCRIPTION
## Summary

- Remove `TARGET_AUDIENCE` and `TARGET_SCOPES` global env vars from go-processor code, webhook container builder, all demo manifests, and documentation
- These global fallbacks became dead config when the default outbound policy changed to `passthrough` -- the values were never consulted
- Target audience and scopes are now configured exclusively per-route in `authproxy-routes` ConfigMap
- Demos that previously relied on global vars (single-target, webhook) now have explicit route entries for `auth-target-service`

## Test plan

- [x] `go test` passes in `AuthBridge/AuthProxy/go-processor/`
- [x] `make test` passes in `kagenti-webhook/`
- [ ] Deploy webhook demo end-to-end, verify route-based outbound exchange works

Closes #215
