### PR TITLE
chore(deps): bump python-keycloak to 7.1.1 in AuthBridge/requirements.txt

### DIFF
--- a/AuthBridge/requirements.txt
+++ b/AuthBridge/requirements.txt
@@ -1,2 +1,2 @@
-python-keycloak==5.3.1
+python-keycloak==7.1.1
 PyYAML>=6.0


### PR DESCRIPTION
## Summary

- Aligns `AuthBridge/requirements.txt` (`keycloak_sync.py`) with `AuthBridge/client-registration/requirements.txt`, which was updated to `python-keycloak==7.1.1` in PR #194
- Removes the version split where two files in the same component used different major versions of the same library

## Compatibility

The 7.1.1 `KeycloakAdmin` API patterns were validated via a live smoke test against a Kind cluster Keycloak before PR #194 was approved — all 12 checks passed, including the methods used by `keycloak_sync.py` (`KeycloakAdmin` constructor, `get_client_id`, `get_client_scopes`, `create_client_scope`).

## Test plan

- [ ] CI passes (Python Tests, Bandit, Pre-commit, Dependency Review)
- [ ] No functional changes — version alignment only

Fixes #218