### PR TITLE
fix: Migrate deprecated Lua inline_code and pin Envoy to v1.37.1

### DIFF
--- a/AuthBridge/AuthProxy/Dockerfile.envoy
+++ b/AuthBridge/AuthProxy/Dockerfile.envoy
@@ -10,7 +10,7 @@ COPY go-processor/ ./go-processor/
 RUN CGO_ENABLED=0 GOOS=linux go build -o /go-processor ./go-processor
 
 # Use official Envoy image as base
-FROM envoyproxy/envoy:v1.37-latest
+FROM envoyproxy/envoy:v1.37.1
 
 # Install ca-certificates for TLS connections
 USER root

--- a/AuthBridge/AuthProxy/k8s/auth-proxy-deployment.yaml
+++ b/AuthBridge/AuthProxy/k8s/auth-proxy-deployment.yaml
@@ -237,10 +237,11 @@ data:
               - name: envoy.filters.http.lua
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-                  inline_code: |
-                    function envoy_on_request(request_handle)
-                      request_handle:headers():add("x-authbridge-direction", "inbound")
-                    end
+                  default_source_code:
+                    inline_string: |
+                      function envoy_on_request(request_handle)
+                        request_handle:headers():add("x-authbridge-direction", "inbound")
+                      end
               - name: envoy.filters.http.ext_proc
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor


### PR DESCRIPTION
## Summary

Follow-up to #207 (Envoy v1.28 → v1.37 upgrade), addressing two issues found during automated upgrade validation.

- **Migrate Lua `inline_code` → `default_source_code`**: Envoy v1.37 deprecates `inline_code` in the Lua HTTP filter. Migrated to `default_source_code.inline_string` which produces zero deprecation warnings.
- **Pin Envoy image to `v1.37.1`**: Replace mutable `v1.37-latest` tag with specific patch version for reproducible builds.

## Test plan

- [ ] Validated migrated config against Envoy v1.37.1 — zero deprecation warnings
- [ ] `envoy --mode validate` passes with the updated config
- [ ] Lua filter still loads and logs `envoy_on_response() function not found` (expected — only `envoy_on_request` is defined)
- [ ] CI checks pass (Dockerfile lint, Go tests, Trivy scan)

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)