### PR TITLE
refactor: Remove redundant file-path env vars from webhook injection

### DIFF
--- a/AuthBridge/CLAUDE.md
+++ b/AuthBridge/CLAUDE.md
@@ -75,7 +75,7 @@ The core ext-proc that handles both traffic directions:
 - The `DEFAULT_OUTBOUND_POLICY` env var controls the fallback behavior (default: `passthrough`)
 
 **Route resolver (outbound):**
-- Reads `/etc/authproxy-routes/routes.yaml` (path controlled by `ROUTES_CONFIG_PATH` env var)
+- Reads `/etc/authproxy/routes.yaml` (default path; override with `ROUTES_CONFIG_PATH` env var in standalone deployments)
 - Each route entry has: `host` (glob pattern), `target_audience`, `token_scopes`
 - Host matching uses `filepath.Match` semantics (supports `*`, `?`, `[...]` patterns)
 - Most commonly, `host` is a plain Kubernetes service name (e.g., `github-tool-mcp`) because the HTTP client sets the Host header from the URL hostname
@@ -86,7 +86,7 @@ The core ext-proc that handles both traffic directions:
 - Reads `CLIENT_ID` from `/shared/client-id.txt` (file) or `CLIENT_ID` env var (fallback)
 - Reads `CLIENT_SECRET` from `/shared/client-secret.txt` (file) or `CLIENT_SECRET` env var (fallback)
 - Static config from env vars: `TOKEN_URL`, `ISSUER`, `EXPECTED_AUDIENCE`
-- Outbound route config from `ROUTES_CONFIG_PATH` (default `/etc/authproxy-routes/routes.yaml`). Target audience and scopes are configured per-route only.
+- Outbound route config from `/etc/authproxy/routes.yaml` (default; override with `ROUTES_CONFIG_PATH` env var in standalone deployments). Target audience and scopes are configured per-route only.
 - Default outbound policy from `DEFAULT_OUTBOUND_POLICY` env var: `"passthrough"` (default) or `"exchange"`
 - JWKS URL is derived from TOKEN_URL: replaces `/token` suffix with `/certs`
 

--- a/kagenti-webhook/internal/webhook/injector/container_builder.go
+++ b/kagenti-webhook/internal/webhook/injector/container_builder.go
@@ -364,18 +364,6 @@ func (b *ContainerBuilder) BuildEnvoyProxyContainerWithSpireOption(spireEnabled 
 				},
 			},
 			{
-				Name:  "CLIENT_ID_FILE",
-				Value: "/shared/client-id.txt",
-			},
-			{
-				Name:  "CLIENT_SECRET_FILE",
-				Value: "/shared/client-secret.txt",
-			},
-			{
-				Name:  "ROUTES_CONFIG_PATH",
-				Value: "/etc/authproxy/routes.yaml",
-			},
-			{
 				Name: "DEFAULT_OUTBOUND_POLICY",
 				ValueFrom: &corev1.EnvVarSource{
 					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{


### PR DESCRIPTION
## Summary

- Remove `CLIENT_ID_FILE`, `CLIENT_SECRET_FILE`, and `ROUTES_CONFIG_PATH` env vars from the envoy-proxy sidecar injected by the webhook
- These were hardcoded literals in `container_builder.go` that duplicated the go-processor built-in defaults (`/shared/client-id.txt`, `/shared/client-secret.txt`, `/etc/authproxy/routes.yaml`)
- Operators could not override them in the webhook path since the volume mount paths are also hardcoded in the same function — even if the env vars were changed, the files would not exist at the new paths
- The override mechanism remains in the go-processor code for standalone (non-webhook) deployments where users control the full container spec
- Fix doc bug in AuthBridge/CLAUDE.md: default routes path was `/etc/authproxy-routes/routes.yaml` (wrong) instead of `/etc/authproxy/routes.yaml`

## Test plan

- [x] `make build` passes in `kagenti-webhook/`
- [x] `make test` passes in `kagenti-webhook/` (injector 86.3%, v1alpha1 75.0%)
- [ ] Deploy webhook demo end-to-end, verify go-processor uses built-in defaults correctly

Closes #227