### PR TITLE
fix: Make ISSUER env var optional to allow pods to start without authbridge-config

### DIFF
--- a/kagenti-webhook/internal/webhook/injector/container_builder.go
+++ b/kagenti-webhook/internal/webhook/injector/container_builder.go
@@ -347,7 +347,7 @@ func (b *ContainerBuilder) BuildEnvoyProxyContainerWithSpireOption(spireEnabled 
 							Name: "authbridge-config",
 						},
 						Key:      "ISSUER",
-						Optional: ptr.To(false),
+						Optional: ptr.To(true),
 					},
 				},
 			},


### PR DESCRIPTION
## Summary

- Change `ISSUER` ConfigMapKeyRef from `Optional: false` to `Optional: true` in the envoy-proxy sidecar container spec
- This aligns `ISSUER` with the other three env vars from `authbridge-config` (`TOKEN_URL`, `EXPECTED_AUDIENCE`, `DEFAULT_OUTBOUND_POLICY`) which are already optional
- The go-processor already handles a missing `ISSUER` gracefully by disabling inbound JWT validation

## Problem

When `authbridge-config` ConfigMap does not exist in the target namespace, pods with injected AuthBridge sidecars are stuck in `CreateContainerConfigError` because `ISSUER` is marked as required. This is unnecessarily strict since the go-processor degrades gracefully without it.

## Test plan

- [ ] Verify `make build` passes (confirmed locally)
- [ ] Verify `make test` passes in CI
- [ ] Deploy a workload with AuthBridge injection to a namespace without `authbridge-config` — pod should start with inbound validation disabled
- [ ] Deploy with `authbridge-config` present — behavior unchanged

Fixes #229