### PR TITLE
ci: Apply latest image tag on PR merges and manual triggers

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,9 @@ on:
   push:
     tags:
       - 'v*'
+    # Trigger on PR merges to main
+    branches:
+      - main
   # Allow manual trigger
   workflow_dispatch:
 
@@ -86,8 +89,8 @@ jobs:
           tags: |
             # Always use the computed tag
             type=raw,value=${{ steps.tag.outputs.tag }}
-            # Add 'latest' tag only for version tags
-            type=raw,value=latest,enable=${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}
+            # Add 'latest' tag for version tags, workflow_dispatch, and pushes to main
+            type=raw,value=latest,enable=${{ (github.ref_type == 'tag' && startsWith(github.ref_name, 'v')) || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' }}
 
       # 7. Build and push image
       - name: Build and push ${{ matrix.image_config.name }}


### PR DESCRIPTION
## Summary
- Build workflow now triggers on pushes to `main` (PR merges), not just version tags
- `latest` image tag is applied on version tag pushes, `workflow_dispatch`, and PR merges to main
- Previously, manual triggers and PR merges produced images tagged only with `branch-sha`, leaving `latest` stale

## Test plan
- [ ] Merge this PR and verify the build workflow runs and pushes images with `latest` tag
- [ ] Manually trigger `workflow_dispatch` and verify `latest` tag is applied
- [ ] Verify version tag push still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)