### PR TITLE
fix: Assign admin realm role to demo users in github-issue setup

### DIFF
--- a/AuthBridge/demos/github-issue/setup_keycloak.py
+++ b/AuthBridge/demos/github-issue/setup_keycloak.py
@@ -50,7 +50,7 @@ import argparse
 import os
 import sys
 
-from keycloak import KeycloakAdmin, KeycloakPostError
+from keycloak import KeycloakAdmin, KeycloakGetError, KeycloakPostError
 
 # Default configuration
 KEYCLOAK_URL = os.environ.get("KEYCLOAK_URL", "http://keycloak.localtest.me:8080")
@@ -423,7 +423,10 @@ def main():
     # The Kagenti backend uses the "admin" realm role for RBAC. Without
     # it, users can log in but see no agents or tools in the UI.
     print("\n--- Assigning 'admin' realm role to demo users ---")
-    admin_role = keycloak_admin.get_realm_role("admin")
+    try:
+        admin_role = keycloak_admin.get_realm_role("admin")
+    except KeycloakGetError:
+        admin_role = None
     if admin_role:
         for user in DEMO_USERS:
             user_id = keycloak_admin.get_user_id(user["username"])


### PR DESCRIPTION
## Summary
- The Kagenti backend requires the `admin` realm role for RBAC-based resource visibility in the UI
- Demo users (alice, bob) created by `setup_keycloak.py` only received `default-roles-kagenti`, so they could log in but saw no agents or tools
- Adds a step after user creation that looks up the `admin` realm role and assigns it to both demo users
- Includes a warning if the role is not found (e.g., if the Kagenti platform was not installed first)

## Test plan
- [ ] Run `python demos/github-issue/setup_keycloak.py` after Kagenti platform install
- [ ] Log in as alice or bob in the Kagenti UI and verify agents/tools are visible
- [ ] Re-run the script (idempotent) and verify no errors for already-assigned roles