### PR TITLE
fix: Use local Ollama as default in GitHub Issue Agent demo (manual)

### DIFF
--- a/AuthBridge/demos/github-issue/demo-manual.md
+++ b/AuthBridge/demos/github-issue/demo-manual.md
@@ -465,6 +465,15 @@ ollama serve
 > **Tip:** If using a different model, update `TASK_MODEL_ID` in
 > `git-issue-agent-deployment.yaml` before deploying.
 
+> **Note:** The `git-issue-agent-deployment.yaml` file defaults to `LLM_API_BASE=http://host.docker.internal:11434` and `OLLAMA_API_BASE=http://host.docker.internal:11434`,
+> which reaches Ollama running on your host machine via the Kind/Docker Desktop gateway.
+> If you deploy Ollama inside the cluster instead, modify the `git-issue-agent-deployment.yaml` file directly or patch the agent:
+> ```bash
+> kubectl set env deployment/git-issue-agent -n team1 -c agent \
+>   LLM_API_BASE="http://ollama.ollama.svc:11434" \
+>   OLLAMA_API_BASE="http://ollama.ollama.svc:11434"
+> ```
+
 ---
 
 ## Step 8: Test the AuthBridge Flow

--- a/AuthBridge/demos/github-issue/k8s/git-issue-agent-deployment.yaml
+++ b/AuthBridge/demos/github-issue/k8s/git-issue-agent-deployment.yaml
@@ -62,8 +62,13 @@ spec:
             # Matches upstream .env.ollama from agent-examples repo
             - name: TASK_MODEL_ID
               value: "ollama/ibm/granite4:latest"
+            # Ollama API base URL. Required by litellm (used by crewai >=1.10).
+            # For Docker Desktop / Kind: http://host.docker.internal:11434
+            # For in-cluster Ollama:     http://ollama.ollama.svc:11434
             - name: LLM_API_BASE
-              value: "http://ollama.ollama.svc:11434"
+              value: "http://host.docker.internal:11434"
+            - name: OLLAMA_API_BASE
+              value: "http://host.docker.internal:11434"
             - name: LLM_API_KEY
               value: "ollama"
             - name: MODEL_TEMPERATURE


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (must be EXACT, case-sensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix must match EXACT CASE (this is enforced by our PR Title
    workflow, which validates exact-match prefixes via the
    `allowed_prefixes` input of the GitHub Action used). [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`).

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary

- Add/modify `OLLAMA_API_BASE` and `LLM_API_BASE` in AuthBridge/demos/github-issue/k8s/git-issue-agent-deployment.yaml to `http://host.docker.internal:11434`
- Add comments with the URLs for cluster and local instance options in `AuthBridge/demos/github-issue/k8s/git-issue-agent-deployment.yaml`
- Add a note in `AuthBridge/demos/github-issue/demo-manual.md` to inform of the default instance type and provide method to switch to use cluster Ollama

## Context

Currently, the manual demo for the GitHub Issue Agent defaults to a cluster-based Ollama instance, which differs from the environment variables used in the UI demo: https://github.com/kagenti/agent-examples/blob/main/a2a/git_issue_agent/.env.ollama, and to what is stated within the current version of the deployment YAML: https://github.com/kagenti/kagenti-extensions/blob/main/AuthBridge/demos/github-issue/k8s/git-issue-agent-deployment.yaml

The user is also unaware if or how they need to change the environment variables to use the correct instance of Ollama. This change sets the default instance in the manual demo to the local Ollama instance and adds instructions for switching to a cluster-based Ollama instance if desired.

## Tests

- [x] The GitHub Issue Agent successfully connects to the local Ollama instance with the modified YAML file
- [x] The GitHub Issue Agent successfully connects after overriding the environment variables with: `kubectl set env`