### PR TITLE
fix: Correct spiffe-helper image tag to use latest

### DIFF
--- a/charts/kagenti-webhook/values.yaml
+++ b/charts/kagenti-webhook/values.yaml
@@ -126,7 +126,7 @@ defaults:
   images:
     envoyProxy: ghcr.io/kagenti/kagenti-extensions/envoy-with-processor:latest
     proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:latest
-    spiffeHelper: ghcr.io/kagenti/kagenti-extensions/spiffe-helper:v0.11.0
+    spiffeHelper: ghcr.io/kagenti/kagenti-extensions/spiffe-helper:latest
     clientRegistration: ghcr.io/kagenti/kagenti-extensions/client-registration:latest
     # authbridge is the combined sidecar image (used when featureGates.combinedSidecar=true)
     authbridge: ghcr.io/kagenti/kagenti-extensions/authbridge:latest

--- a/kagenti-webhook/internal/webhook/config/defaults.go
+++ b/kagenti-webhook/internal/webhook/config/defaults.go
@@ -13,7 +13,7 @@ func CompiledDefaults() *PlatformConfig {
 		Images: ImageConfig{
 			EnvoyProxy:         "ghcr.io/kagenti/kagenti-extensions/envoy-with-processor:latest",
 			ProxyInit:          "ghcr.io/kagenti/kagenti-extensions/proxy-init:latest",
-			SpiffeHelper:       "ghcr.io/kagenti/kagenti-extensions/spiffe-helper:v0.11.0",
+			SpiffeHelper:       "ghcr.io/kagenti/kagenti-extensions/spiffe-helper:latest",
 			ClientRegistration: "ghcr.io/kagenti/kagenti-extensions/client-registration:latest",
 			AuthBridge:         "ghcr.io/kagenti/kagenti-extensions/authbridge:latest",
 			PullPolicy:         corev1.PullIfNotPresent,


### PR DESCRIPTION
## Summary

- Fix spiffe-helper image tag `v0.11.0` → `latest` in Helm chart `values.yaml` and compiled defaults (`defaults.go`)
- The tag `v0.11.0` does not exist in `ghcr.io/kagenti/kagenti-extensions/spiffe-helper`
- Now consistent with all other sidecar images which use `latest`

## Files changed

- `charts/kagenti-webhook/values.yaml` — `defaults.images.spiffeHelper`
- `kagenti-webhook/internal/webhook/config/defaults.go` — `CompiledDefaults()` fallback

Closes #269