### PR TITLE
fix: restore TOKEN_URL and ISSUER auto-derivation (regression from refactor)

### DIFF
--- a/AuthBridge/AuthProxy/go-processor/main.go
+++ b/AuthBridge/AuthProxy/go-processor/main.go
@@ -820,9 +820,29 @@ func main() {
 	// Load configuration from files (or environment variables as fallback)
 	loadConfig()
 
-	// Initialize inbound JWT validation
+	// Derive TOKEN_URL and ISSUER from KEYCLOAK_URL + KEYCLOAK_REALM when not explicitly set.
+	// Explicit values always take precedence (override).
+	// This was originally added in PR #233 but accidentally removed in a later refactor.
 	config := getConfig()
+	keycloakURL := strings.TrimRight(os.Getenv("KEYCLOAK_URL"), "/")
+	keycloakRealm := os.Getenv("KEYCLOAK_REALM")
+
+	if config.TokenURL == "" && keycloakURL != "" && keycloakRealm != "" {
+		derived := keycloakURL + "/realms/" + keycloakRealm + "/protocol/openid-connect/token"
+		globalConfig.mu.Lock()
+		globalConfig.TokenURL = derived
+		globalConfig.mu.Unlock()
+		config = getConfig()
+		log.Printf("[Config] TOKEN_URL derived from KEYCLOAK_URL + KEYCLOAK_REALM: %s", derived)
+	}
+
 	inboundIssuer = os.Getenv("ISSUER")
+	if inboundIssuer == "" && keycloakURL != "" && keycloakRealm != "" {
+		inboundIssuer = keycloakURL + "/realms/" + keycloakRealm
+		log.Printf("[Config] ISSUER derived from KEYCLOAK_URL + KEYCLOAK_REALM: %s", inboundIssuer)
+	}
+
+	// Initialize inbound JWT validation
 	expectedAudience = os.Getenv("EXPECTED_AUDIENCE")
 	if config.TokenURL != "" && inboundIssuer != "" {
 		inboundJWKSURL = deriveJWKSURL(config.TokenURL)


### PR DESCRIPTION
## Summary

Restores the auto-derivation of `TOKEN_URL` and `ISSUER` from `KEYCLOAK_URL` + `KEYCLOAK_REALM` in the go-processor. This was originally added in PR #233 (commit 6256f8b) but accidentally removed in a subsequent refactor (commit 6ad6baa).

## Problem

The default helm chart installation only sets `KEYCLOAK_URL` and `KEYCLOAK_REALM` in the `authbridge-config` ConfigMap. Without auto-derivation, `TOKEN_URL` is empty, which **silently disables inbound JWT validation** for all AuthBridge-protected agents.

This means since March 20, 2026, no default installation has had working inbound JWT validation unless `TOKEN_URL` was explicitly added to the ConfigMap.

## Root cause

Commit 6ad6baa ("refactor: improve go-processor config handling") changed `getConfig()` to return a struct but removed the derivation block that ran between `loadConfig()` and the inbound validation setup.

## Fix

Restore the derivation logic before inbound validation initialization:
- If `TOKEN_URL` is empty and `KEYCLOAK_URL` + `KEYCLOAK_REALM` are set, derive it
- If `ISSUER` is empty and `KEYCLOAK_URL` + `KEYCLOAK_REALM` are set, derive it
- Explicit values always take precedence

## Test plan

- [ ] Deploy weather-service with default authbridge-config (only KEYCLOAK_URL + KEYCLOAK_REALM)
- [ ] Verify go-processor logs show: `TOKEN_URL derived from KEYCLOAK_URL + KEYCLOAK_REALM`
- [ ] Verify inbound JWT validation is active (not `TOKEN_URL not configured`)
- [ ] Verify tokens without correct audience are rejected

Generated with [Claude Code](https://claude.com/claude-code)