### PR TITLE
docs: Add webhook deprecation notice to extensions README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains extension projects for the Kagenti ecosystem
 ## Projects
 
 - [kagenti-webhook](./kagenti-webhook/) - Admission webhook for Kubernetes workloads (Deployments, StatefulSets, etc.) with Envoy proxy and optional SPIFFE/SPIRE integration.
+  > **Deprecated:** The kagenti-webhook has been migrated to [kagenti/kagenti-operator](https://github.com/kagenti/kagenti-operator). All new webhook development should be directed there. See [kagenti-operator#238](https://github.com/kagenti/kagenti-operator/issues/238) for details.
 - [AuthBridge](./AuthBridge/) - Collection of Identity components to demonstrate a complete end-to-end authentication flow with [SPIFFE/SPIRE](https://spiffe.io) integration
   - [AuthProxy](./AuthBridge/AuthProxy/) - AuthProxy is a **JWT validation and token exchange proxy** for Kubernetes workloads. It enables secure service-to-service communication by intercepting and validating incoming tokens and transparently exchanging them for tokens with the correct audience for downstream services.
   - [Keycloak client-registration](./AuthBridge/client-registration/) - Keycloak Client Registration is an **automated OAuth2/OIDC client provisioning** tool for Kubernetes workloads. It automatically registers pods as Keycloak clients, eliminating the need for manual client configuration and static credentials.


### PR DESCRIPTION
## Summary
- Adds a deprecation notice under the kagenti-webhook entry in the top-level README
- Directs users to kagenti-operator for all new webhook development

Related: [kagenti-operator#238](https://github.com/kagenti/kagenti-operator/issues/238), #266