### PR TITLE
docs: Rewrite root README for AuthBridge-focused repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,53 @@
 # Kagenti Extensions
 
-This repository contains extension projects for the Kagenti ecosystem
+Kubernetes security extensions for the [Kagenti](https://github.com/kagenti/kagenti) ecosystem, providing **zero-trust authentication** for workloads through transparent token exchange and dynamic Keycloak client registration using SPIFFE/SPIRE identities.
 
-## Projects
+## AuthBridge
 
-- **kagenti-webhook** — Migrated to [kagenti/kagenti-operator](https://github.com/kagenti/kagenti-operator). See [kagenti-operator#238](https://github.com/kagenti/kagenti-operator/issues/238) for details.
-- [AuthBridge](./AuthBridge/) - Collection of Identity components to demonstrate a complete end-to-end authentication flow with [SPIFFE/SPIRE](https://spiffe.io) integration
-  - [AuthProxy](./AuthBridge/AuthProxy/) - AuthProxy is a **JWT validation and token exchange proxy** for Kubernetes workloads. It enables secure service-to-service communication by intercepting and validating incoming tokens and transparently exchanging them for tokens with the correct audience for downstream services.
-  - [Keycloak client-registration](./AuthBridge/client-registration/) - Keycloak Client Registration is an **automated OAuth2/OIDC client provisioning** tool for Kubernetes workloads. It automatically registers pods as Keycloak clients, eliminating the need for manual client configuration and static credentials.
+[AuthBridge](./AuthBridge/) provides end-to-end authentication for Kubernetes workloads with [SPIFFE/SPIRE](https://spiffe.io) integration. It consists of:
+
+- **[AuthProxy](./AuthBridge/AuthProxy/)** — Envoy proxy with a gRPC external processor for inbound JWT validation and outbound OAuth 2.0 token exchange (RFC 8693). Enables secure service-to-service communication by transparently intercepting traffic.
+- **[Client Registration](./AuthBridge/client-registration/)** — Automatically registers Kubernetes workloads as Keycloak OAuth2 clients using their SPIFFE identity, eliminating manual client configuration and static credentials.
+- **[Keycloak Sync](./AuthBridge/keycloak_sync.py)** — Declarative tool for synchronizing Keycloak configuration.
+
+See the [AuthBridge README](./AuthBridge/README.md) for architecture details and the [demos index](./AuthBridge/demos/README.md) for getting started.
+
+## Container Images
+
+All images are published to `ghcr.io/kagenti/kagenti-extensions/`:
+
+| Image | Description |
+|-------|-------------|
+| `envoy-with-processor` | Envoy 1.28 + go-processor ext-proc |
+| `proxy-init` | Alpine + iptables init container |
+| `client-registration` | Python Keycloak client registrar |
+| `authbridge` | Combined sidecar (Envoy + go-processor + spiffe-helper + client-registration) |
+| `auth-proxy` | Example pass-through proxy (for demos) |
+| `demo-app` | Demo target service |
+
+## Development
+
+```bash
+# Install pre-commit hooks
+make pre-commit
+
+# Run formatters
+make fmt
+
+# Build AuthProxy Docker images
+make build-images
+
+# Run local testing (requires Kind cluster)
+./local-build-and-test.sh
+```
+
+See [LOCAL_TESTING_GUIDE.md](./LOCAL_TESTING_GUIDE.md) for the full local development setup.
+
+## Related Repositories
+
+- [kagenti](https://github.com/kagenti/kagenti) — Core Kagenti platform
+- [kagenti-operator](https://github.com/kagenti/kagenti-operator) — Kubernetes operator for sidecar injection (includes the admission webhook)
+
+## License
+
+[Apache 2.0](./LICENSE)


### PR DESCRIPTION
## Summary

- Replace the stale project listing that still referenced the migrated kagenti-webhook
- Describe AuthBridge as the primary content with its sub-components
- Add container images table, development quickstart commands, and links to related repos

The previous README was a minimal bullet list that still framed kagenti-webhook as a project in this repo. This rewrite reflects the post-#291 state where AuthBridge is the sole extension.

## Test plan

- [ ] All links resolve correctly
- [ ] No references to kagenti-webhook remain