### PR TITLE
ci: Add Go test step and Python fail-fast to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,6 +63,9 @@ jobs:
       - name: Build
         run: go build -v ./...
 
+      - name: Test
+        run: go test -v -race -cover ./...
+
   python-test:
     name: Python Tests
     runs-on: ubuntu-latest
@@ -79,4 +82,4 @@ jobs:
           pip install pytest==8.* python-keycloak==5.3.1 pyjwt==2.10.1 pyyaml==6.*
 
       - name: Run tests
-        run: pytest tests/ -v --ignore=tests/e2e
+        run: pytest tests/ -v -x --ignore=tests/e2e


### PR DESCRIPTION
## Summary

- Add `go test -v -race -cover ./...` step to the go-ci job
- Add `-x` flag to pytest for fail-fast on first failure

The go-ci job ran `go fmt`, `go vet`, and `go build` but never executed `go test`. This meant 25 existing test functions were never verified in CI:

- Outbound token exchange flow (handleOutbound, exchangeToken, clientCredentialsGrant)
- Route resolver (glob matching, passthrough routes, default policy)
- Actor token caching (TTL, concurrency, error handling, min TTL floor)
- Bypass path matching (normalization, query strings, glob patterns)

**Coverage:** 42.6% for go-processor, 86.2% for resolver — all from existing tests that were just never run.

## Test plan

- [ ] Go CI job now runs tests (visible in Actions logs)
- [ ] All 25 Go tests pass with `-race` flag
- [ ] Python tests still pass with `-x` flag