### PR TITLE
docs: Fix cross-document inconsistencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ kagenti-extensions/
 └── CLAUDE.md                 # This file
 ```
 
-## The Two Major Components
+## Major Components
 
 ### 1. AuthProxy (Go)
 

--- a/authbridge/authproxy/README.md
+++ b/authbridge/authproxy/README.md
@@ -288,7 +288,7 @@ kubectl logs <pod-name> -c envoy-proxy
 ## Related Documentation
 
 - [AuthBridge](../README.md) - Complete AuthBridge overview with token exchange flow
-- [AuthBridge Demo](../demo.md) - Step-by-step demo instructions
+- [AuthBridge Demos](../demos/README.md) - Demo scenarios and getting started
 - [Client Registration](../client-registration/README.md) - Automatic Keycloak client registration with SPIFFE
 - [OAuth 2.0 Token Exchange (RFC 8693)](https://datatracker.ietf.org/doc/html/rfc8693)
 - [Envoy External Processing](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/ext_proc_filter)

--- a/authbridge/authproxy/quickstart/README.md
+++ b/authbridge/authproxy/quickstart/README.md
@@ -36,7 +36,7 @@ Let's clone the assets locally:
 
 ```bash
 git clone git@github.com:kagenti/kagenti-extensions.git
-cd kagent-extensions/authbridge/authproxy
+cd kagenti-extensions/authbridge/authproxy
 ```
 
 We can use the following `make` commands to build and load the images to the Kind cluster:

--- a/authbridge/client-registration/README.md
+++ b/authbridge/client-registration/README.md
@@ -132,7 +132,7 @@ sequenceDiagram
 | `KEYCLOAK_ADMIN_PASSWORD` | Yes | Admin password | `admin` |
 | `KEYCLOAK_TOKEN_EXCHANGE_ENABLED` | No | Enable token exchange for client (default: `true`) | `true` |
 | `KEYCLOAK_CLIENT_REGISTRATION_ENABLED` | No | Enable/disable registration (default: `true`) | `true` |
-| `SECRET_FILE_PATH` | No | Path to write client secret (default: `/shared/secret.txt`) | `/shared/client-secret.txt` |
+| `SECRET_FILE_PATH` | No | Path to write client secret (default: `/shared/client-secret.txt`) | `/shared/client-secret.txt` |
 
 **Note:** `KEYCLOAK_URL` and `KEYCLOAK_REALM` can be automatically derived from `TOKEN_URL` if not explicitly provided. For example:
 - `TOKEN_URL`: `http://keycloak-service.keycloak.svc:8080/realms/kagenti/protocol/openid-connect/token`

--- a/authbridge/demos/single-target/demo.md
+++ b/authbridge/demos/single-target/demo.md
@@ -2,7 +2,7 @@
 
 This guide provides step-by-step instructions for running the AuthBridge demo.
 
-> **📘 New to AuthBridge?** See the [README](./README.md) for an overview of what AuthBridge does and how it works.
+> **📘 New to AuthBridge?** See the [AuthBridge README](../../README.md) for an overview of what AuthBridge does and how it works.
 
 ## Demo Components
 
@@ -280,7 +280,7 @@ pip install --upgrade pip
 pip install -r requirements.txt
 
 # Run setup script
-python setup_keycloak.py
+python demos/single-target/setup_keycloak.py
 ```
 
 The `setup_keycloak` script creates:
@@ -718,6 +718,6 @@ kubectl delete namespace authbridge
 
 ## Next Steps
 
-- See [AuthProxy Documentation](authproxy/README.md) for details on token validation and exchange
-- See [Client Registration Documentation](client-registration/README.md) for details on automatic Keycloak registration
-- See [README](./README.md) for architecture overview
+- See [AuthProxy Documentation](../../authproxy/README.md) for details on token validation and exchange
+- See [Client Registration Documentation](../../client-registration/README.md) for details on automatic Keycloak registration
+- See [AuthBridge README](../../README.md) for architecture overview

--- a/authbridge/demos/webhook/README.md
+++ b/authbridge/demos/webhook/README.md
@@ -32,7 +32,7 @@ Combined mode reduces per-pod overhead from 3 long-running sidecars to 1, simpli
 ┌────────────────────────────────────────────────────────────────────┐
 │                        Agent Pod                                   │
 │  ┌─────────────┐  ┌──────────────┐  ┌────────────────────────────┐ │
-│  │   agent     │  │spiffe-helper │  │keycloak-client-registration│ |
+│  │   agent     │  │spiffe-helper │  │kagenti-client-registration │ |
 │  │ (your app)  │  │              │  │                            │ │
 │  └──────┬──────┘  └──────────────┘  └────────────────────────────┘ │
 │         │                                                          │


### PR DESCRIPTION
## Summary

Fix 7 inconsistencies found during a cross-document audit of all 18 markdown files:

1. **SECRET_FILE_PATH default** — client-registration README documented `/shared/secret.txt` but code defaults to `/shared/client-secret.txt`
2. **Container name in diagram** — webhook demo used `keycloak-client-registration` instead of `kagenti-client-registration`
3. **Broken link** — authproxy README linked to `../demo.md` which does not exist (now `../demos/README.md`)
4. **3 broken links in single-target/demo.md** — `./README.md`, `authproxy/README.md`, `client-registration/README.md` all missing relative path prefix
5. **Repo name typo** — quickstart README had `kagent-extensions` (missing "i")
6. **Wrong script path** — single-target demo instructed `python setup_keycloak.py` from `authbridge/` but the script is in `demos/single-target/`
7. **Framing mismatch** — root CLAUDE.md said "Two Major Components" while authbridge/CLAUDE.md says "three capabilities" and root README lists three items

## Test plan

- [x] All fixed links verified to resolve
- [ ] No broken relative links across all markdown files