### PR TITLE
ci: Add CI/build for unified authbridge, deprecate old components (Phase 4)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,6 +50,12 @@ jobs:
             context: ./authbridge
             dockerfile: authproxy/Dockerfile.authbridge
 
+          # Unified AuthBridge binary (Envoy + authbridge in one container)
+          # Drop-in replacement for envoy-with-processor
+          - name: authbridge-unified
+            context: ./authbridge
+            dockerfile: cmd/authbridge/Dockerfile
+
           # Demo application for testing
           - name: demo-app
             context: ./authbridge/authproxy/quickstart/demo-app

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,6 +66,63 @@ jobs:
       - name: Test
         run: go test -v -race -cover ./...
 
+  go-ci-authlib:
+    name: Go CI (authlib)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: authbridge/authlib
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
+        with:
+          go-version-file: authbridge/authlib/go.mod
+          cache-dependency-path: authbridge/authlib/go.sum
+
+      - name: Lint
+        run: |
+          go fmt ./...
+          go vet ./...
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Test
+        run: go test -v -race -cover ./...
+
+  go-ci-authbridge-cmd:
+    name: Go CI (authbridge cmd)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: authbridge/cmd/authbridge
+    env:
+      # Disable go.work — the workspace at authbridge/ includes ./authproxy
+      # which would pull in the old go-processor module. The replace directive
+      # in go.mod handles the authlib dependency for CI builds.
+      GOWORK: "off"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
+        with:
+          go-version-file: authbridge/cmd/authbridge/go.mod
+          cache-dependency-path: authbridge/cmd/authbridge/go.sum
+
+      - name: Lint
+        run: |
+          go fmt ./...
+          go vet ./...
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Test
+        run: go test -v -race -cover ./...
+
   python-test:
     name: Python Tests
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,21 @@ The sidecar injection webhook lives in a separate repo: [kagenti/kagenti-operato
 ```
 kagenti-extensions/
 ├── authbridge/               # Authentication bridge components
-│   ├── authproxy/            #   Envoy + ext-proc sidecar (Go) — token validation & exchange
-│   │   ├── go-processor/     #     gRPC ext-proc server (inbound JWT validation, outbound token exchange)
+│   ├── authlib/              #   Shared auth building blocks (Go module)
+│   │   ├── validation/       #     JWKS-backed JWT verifier
+│   │   ├── exchange/         #     RFC 8693 token exchange client
+│   │   ├── cache/            #     SHA-256 keyed token cache
+│   │   ├── bypass/           #     Path pattern matcher
+│   │   ├── spiffe/           #     SPIFFE credential sources
+│   │   ├── routing/          #     Host-to-audience router
+│   │   ├── auth/             #     HandleInbound + HandleOutbound composition
+│   │   └── config/           #     Mode presets, YAML config, validation
+│   ├── cmd/authbridge/       #   Unified binary — 3 modes, 1 codebase
+│   │   ├── listener/         #     Protocol adapters (ext_proc, ext_authz, forward/reverse proxy)
+│   │   ├── entrypoint.sh     #     Envoy + authbridge process supervision
+│   │   └── Dockerfile        #     Combined Envoy + authbridge image
+│   ├── authproxy/            #   [DEPRECATED] Old Envoy + ext-proc sidecar
+│   │   ├── go-processor/     #     [DEPRECATED] Use cmd/authbridge instead
 │   │   ├── quickstart/       #     Standalone demo (no SPIFFE)
 │   │   └── k8s/              #     Standalone K8s manifests
 │   ├── client-registration/  #   Keycloak auto-registration (Python)
@@ -88,12 +101,34 @@ The kagenti-operator (in a separate repo) injects AuthBridge sidecars into workl
          └────────────────────────────────────┘
 ```
 
+## Unified AuthBridge Binary
+
+The `cmd/authbridge/` directory contains a unified binary that replaces three separate
+codebases (go-processor, waypoint, klaviger) with a single binary supporting three modes:
+
+| Mode | Interception | Listeners | Use Case |
+|------|-------------|-----------|----------|
+| `envoy-sidecar` | Envoy iptables + ext_proc | gRPC ext_proc on :9090 | Sidecar per agent pod |
+| `waypoint` | Istio ambient + ext_authz | gRPC ext_authz + HTTP forward proxy | Shared service |
+| `proxy-sidecar` | Reverse proxy + forward proxy | HTTP reverse proxy + forward proxy | Sidecar without Envoy |
+
+**Go modules:**
+- `authbridge/authlib/` — pure library, no protocol deps (validation, exchange, cache, bypass, spiffe, routing, auth, config)
+- `authbridge/cmd/authbridge/` — binary + listeners, imports authlib + gRPC/Envoy deps
+- `authbridge/go.work` — workspace linking both modules for local development
+
+**Config format:** YAML with `${ENV_VAR}` expansion, mode presets, and startup validation.
+Supports `keycloak_url` + `keycloak_realm` derivation for operator compatibility.
+
+**Image:** `ghcr.io/kagenti/kagenti-extensions/authbridge-unified` — Envoy + authbridge
+in one container (drop-in replacement for `envoy-with-processor`).
+
 ## CI/CD Workflows
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
-| `ci.yaml` | PR to main/release-* | Go fmt, vet, build for AuthProxy; Python tests |
-| `build.yaml` | Tag push (`v*`) or manual | Multi-arch Docker builds for: client-registration, auth-proxy, proxy-init, envoy-with-processor, authbridge, demo-app |
+| `ci.yaml` | PR to main/release-* | Go fmt, vet, build, test for authproxy, authlib, and cmd/authbridge; Python tests |
+| `build.yaml` | Tag push (`v*`) or manual | Multi-arch Docker builds for: client-registration, auth-proxy, proxy-init, envoy-with-processor, authbridge, authbridge-unified, demo-app |
 | `security-scans.yaml` | PR to main | Dependency review, shellcheck, YAML lint, Hadolint, Bandit, Trivy, CodeQL |
 | `scorecard.yaml` | Weekly / push to main | OpenSSF Scorecard security health metrics |
 | `spellcheck_action.yml` | PR | Spellcheck on markdown files |
@@ -114,11 +149,12 @@ All images are pushed to `ghcr.io/kagenti/kagenti-extensions/`:
 
 | Image | Source | Description |
 |-------|--------|-------------|
-| `envoy-with-processor` | `authbridge/authproxy/Dockerfile.envoy` | Envoy 1.28 + go-processor ext-proc |
+| **`authbridge-unified`** | **`authbridge/cmd/authbridge/Dockerfile`** | **Unified Envoy + authbridge binary (recommended)** |
+| `envoy-with-processor` | `authbridge/authproxy/Dockerfile.envoy` | [DEPRECATED] Envoy + go-processor ext-proc |
 | `proxy-init` | `authbridge/authproxy/Dockerfile.init` | Alpine + iptables init container |
 | `client-registration` | `authbridge/client-registration/Dockerfile` | Python Keycloak client registrar |
 | `spiffe-helper` | `authbridge/spiffe-helper/Dockerfile` | Fetches SPIFFE credentials from SPIRE |
-| `authbridge` | `authbridge/authproxy/Dockerfile.authbridge` | Combined sidecar (Envoy + go-processor + spiffe-helper + client-registration) |
+| `authbridge` | `authbridge/authproxy/Dockerfile.authbridge` | [DEPRECATED] Combined sidecar (old architecture) |
 | `auth-proxy` | `authbridge/authproxy/Dockerfile` | Example pass-through proxy (for demos) |
 | `demo-app` | `authbridge/authproxy/quickstart/demo-app/Dockerfile` | Demo target service |
 

--- a/authbridge/authproxy/Dockerfile.envoy
+++ b/authbridge/authproxy/Dockerfile.envoy
@@ -1,3 +1,5 @@
+# Deprecated: This Dockerfile builds the old envoy-with-processor image.
+# Use authbridge/cmd/authbridge/Dockerfile instead (unified binary).
 FROM golang:1.26-alpine AS go-builder
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/authbridge/authproxy/entrypoint-envoy.sh
+++ b/authbridge/authproxy/entrypoint-envoy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Deprecated: Use authbridge/cmd/authbridge/entrypoint.sh instead (unified binary).
 set -eu
 
 # Envoy + go-processor entrypoint with process supervision.

--- a/authbridge/authproxy/go-processor/main.go
+++ b/authbridge/authproxy/go-processor/main.go
@@ -1,3 +1,7 @@
+// Deprecated: This go-processor ext_proc server is replaced by the unified
+// authbridge binary at cmd/authbridge/. The unified binary supports envoy-sidecar,
+// waypoint, and proxy-sidecar modes with a shared auth library (authlib/).
+// This file is kept for backwards compatibility during migration.
 package main
 
 import (


### PR DESCRIPTION
## Summary

Phase 4 of the modular token exchange library (#279). Makes the unified authbridge production-ready with CI, build pipeline, documentation, and deprecation markers.

**Depends on:** #312 (Phase 3), #311 (Phase 2), #310 (Phase 1)

### CI changes
- Add `Go CI (authlib)` job for the authlib module (lint, build, test with -race -cover)
- Add `Go CI (authbridge cmd)` job for the cmd/authbridge module
- Add `authbridge-unified` image to build.yaml matrix

### Documentation
- Updated CLAUDE.md with unified binary architecture, Go module structure, and 3 deployment modes
- Marked `authbridge-unified` as the recommended image
- Marked `envoy-with-processor` and old `authbridge` images as deprecated

### Deprecation markers
- `go-processor/main.go`, `Dockerfile.envoy`, `entrypoint-envoy.sh` marked deprecated with pointers to replacements

### Follow-up (separate repos)
- **kagenti-operator**: Add `authbridge-unified` to image config in `kagenti-platform-config` ConfigMap. The operator already supports image overrides via `PlatformConfig.Images`.
- **kagenti**: Add `authbridge-unified-config` ConfigMap to Helm chart `agent-namespaces.yaml` template, generated from existing Helm values.

## Related issue(s)

Ref #279

## Test plan

- [x] All 80 tests pass (63 authlib + 17 listeners)
- [ ] CI passes
- [ ] Build pipeline produces `authbridge-unified` image

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
