### PR TITLE
🐛 Fix Envoy image SHA pin pulling wrong architecture

### DIFF
--- a/authbridge/cmd/authbridge/Dockerfile
+++ b/authbridge/cmd/authbridge/Dockerfile
@@ -21,7 +21,7 @@ ENV GOWORK=off
 RUN cd cmd/authbridge && CGO_ENABLED=0 GOOS=linux go build -o /authbridge .
 
 # Stage 2: Get Envoy binary
-FROM docker.io/envoyproxy/envoy:v1.37.1@sha256:70e7c82d8c82fecdebe3408f7227e9abc3c34b4fdc7f9c1c2842d87bcda1e5ff AS envoy-source
+FROM docker.io/envoyproxy/envoy:v1.37.1 AS envoy-source
 
 # Stage 3: Runtime — same base as Dockerfile.envoy
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:83006d535923fcf1345067873524a3980316f51794f01d8655be55d6e9387183


### PR DESCRIPTION
## Summary

- Remove ARM64-specific SHA digest pin from `authbridge/cmd/authbridge/Dockerfile`
- The pinned `sha256:70e7c82d...` is the ARM64 platform digest, not the multi-arch manifest
- On AMD64 CI runners, this resolves to an ARM64 Envoy binary → exit code 126
- Use tag-only (`v1.37.1`) matching `Dockerfile.envoy` and `Dockerfile.authbridge` patterns

## Root Cause

`docker.io/envoyproxy/envoy:v1.37.1@sha256:70e7c82d...` pins to the ARM64 variant. During multi-arch builds (`linux/amd64,linux/arm64`), Docker uses the pinned digest for both platforms, producing an ARM64 Envoy binary in the AMD64 image.

## Test plan

- [ ] CI multi-arch build passes (linux/amd64 + linux/arm64)
- [ ] `podman run --rm --platform linux/amd64 --entrypoint /usr/local/bin/envoy <image> --version` succeeds
- [ ] kagenti-operator E2E tests pass with rebuilt image

Fixes kagenti/kagenti-operator#289 (E2E failure)