### PR TITLE
🐛 Start gRPC listener before credential resolution

### DIFF
--- a/authbridge/authlib/auth/auth.go
+++ b/authbridge/authlib/auth/auth.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/bypass"
@@ -50,7 +51,7 @@ type Auth struct {
 	cache            *cache.Cache
 	bypass           *bypass.Matcher
 	router           *routing.Router
-	identity         IdentityConfig
+	identity         atomic.Pointer[IdentityConfig]
 	noTokenPolicy    string
 	actorTokenSource ActorTokenSource
 	audienceDeriver  AudienceDeriver
@@ -63,18 +64,31 @@ func New(cfg Config) *Auth {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &Auth{
+	a := &Auth{
 		verifier:         cfg.Verifier,
 		exchanger:        cfg.Exchanger,
 		cache:            cfg.Cache,
 		bypass:           cfg.Bypass,
 		router:           cfg.Router,
-		identity:         cfg.Identity,
 		noTokenPolicy:    cfg.NoTokenPolicy,
 		actorTokenSource: cfg.ActorTokenSource,
 		audienceDeriver:  cfg.AudienceDeriver,
 		log:              logger,
 	}
+	id := cfg.Identity
+	a.identity.Store(&id)
+	return a
+}
+
+// UpdateIdentity updates the agent's identity and exchanger credentials
+// after credential files have been resolved. This is called from a background
+// goroutine after the gRPC listener has started.
+func (a *Auth) UpdateIdentity(id IdentityConfig, clientAuth exchange.ClientAuth) {
+	a.identity.Store(&id)
+	if clientAuth != nil {
+		a.exchanger.UpdateAuth(clientAuth)
+	}
+	a.log.Info("identity updated", "client_id", id.ClientID)
 }
 
 // HandleInbound validates an inbound request's JWT token.
@@ -114,7 +128,7 @@ func (a *Auth) HandleInbound(ctx context.Context, authHeader, path, audience str
 		}
 	}
 	if audience == "" {
-		audience = a.identity.Audience
+		audience = a.identity.Load().Audience
 	}
 	claims, err := a.verifier.Verify(ctx, token, audience)
 	if err != nil {

--- a/authbridge/authlib/config/resolve.go
+++ b/authbridge/authlib/config/resolve.go
@@ -19,7 +19,7 @@ import (
 
 // Resolve applies presets, validates, and instantiates all authlib components
 // from the configuration. Returns a fully wired auth.Config ready for auth.New().
-func Resolve(ctx context.Context, cfg *Config) (*auth.Config, error) {
+func Resolve(_ context.Context, cfg *Config) (*auth.Config, error) {
 	ApplyPreset(cfg)
 
 	// Derive URLs from KEYCLOAK_URL + KEYCLOAK_REALM when explicit values are missing
@@ -28,10 +28,9 @@ func Resolve(ctx context.Context, cfg *Config) (*auth.Config, error) {
 	// Derive JWKS URL from TOKEN_URL when not explicitly set (Keycloak convention)
 	deriveJWKSURL(cfg)
 
-	// Wait for and load credentials from files when configured
-	if err := resolveCredentialFiles(cfg); err != nil {
-		return nil, fmt.Errorf("credential files: %w", err)
-	}
+	// Credential files are NOT resolved here — caller handles them
+	// asynchronously via ResolveCredentialFiles() after the listener starts.
+	// This avoids blocking gRPC startup for up to 2 minutes.
 
 	if err := Validate(cfg); err != nil {
 		return nil, fmt.Errorf("config validation: %w", err)
@@ -46,14 +45,12 @@ func Resolve(ctx context.Context, cfg *Config) (*auth.Config, error) {
 		return nil, fmt.Errorf("bypass patterns: %w", err)
 	}
 
-	// JWT verifier
-	verifier, err := validation.NewJWKSVerifier(ctx, cfg.Inbound.JWKSURL, cfg.Inbound.Issuer)
-	if err != nil {
-		return nil, fmt.Errorf("JWKS verifier: %w", err)
-	}
+	// JWT verifier — lazy initialization defers the JWKS HTTP fetch to the
+	// first Verify() call, so the gRPC listener can start immediately.
+	verifier := validation.NewLazyJWKSVerifier(cfg.Inbound.JWKSURL, cfg.Inbound.Issuer)
 
 	// Client auth for token exchange
-	clientAuth, err := resolveClientAuth(cfg)
+	clientAuth, err := ResolveClientAuth(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("client auth: %w", err)
 	}
@@ -121,9 +118,10 @@ func deriveJWKSURL(cfg *Config) {
 	}
 }
 
-// resolveCredentialFiles waits for and reads credential files when configured.
+// ResolveCredentialFiles waits for and reads credential files when configured.
+// Call this after the server listener starts to avoid blocking startup.
 // This handles the startup race with client-registration and spiffe-helper.
-func resolveCredentialFiles(cfg *Config) error {
+func ResolveCredentialFiles(cfg *Config) {
 	if cfg.Identity.ClientIDFile != "" {
 		if err := waitAndReadFile(cfg.Identity.ClientIDFile, &cfg.Identity.ClientID, 60*time.Second); err != nil {
 			slog.Warn("client_id_file not available, using client_id from config", "error", err)
@@ -140,7 +138,6 @@ func resolveCredentialFiles(cfg *Config) error {
 			slog.Warn("jwt_svid_path not available at startup, will be read on each exchange", "error", err)
 		}
 	}
-	return nil
 }
 
 // waitAndReadFile polls for a file to exist, then reads its content into dest.
@@ -169,7 +166,9 @@ func waitForFile(path string, timeout time.Duration) error {
 	return fmt.Errorf("timeout waiting for %s (%v)", path, timeout)
 }
 
-func resolveClientAuth(cfg *Config) (exchange.ClientAuth, error) {
+// ResolveClientAuth creates the appropriate client authentication from config.
+// Exported so main.go can rebuild it after credential files are loaded.
+func ResolveClientAuth(cfg *Config) (exchange.ClientAuth, error) {
 	switch cfg.Identity.Type {
 	case "spiffe":
 		if cfg.Identity.JWTSVIDPath != "" {

--- a/authbridge/authlib/exchange/client.go
+++ b/authbridge/authlib/exchange/client.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -32,6 +33,7 @@ type ExchangeResponse struct {
 // Client performs OAuth token exchange and client credentials requests.
 type Client struct {
 	tokenURL   string
+	authMu     sync.RWMutex
 	auth       ClientAuth
 	httpClient *http.Client
 }
@@ -59,6 +61,21 @@ func NewClient(tokenURL string, auth ClientAuth, opts ...Option) *Client {
 	return c
 }
 
+// UpdateAuth replaces the client authentication used for token requests.
+// This supports dynamic credential loading after the server has started.
+func (c *Client) UpdateAuth(auth ClientAuth) {
+	c.authMu.Lock()
+	c.auth = auth
+	c.authMu.Unlock()
+}
+
+// getAuth returns the current client authentication under a read lock.
+func (c *Client) getAuth() ClientAuth {
+	c.authMu.RLock()
+	defer c.authMu.RUnlock()
+	return c.auth
+}
+
 // Exchange performs an RFC 8693 token exchange.
 func (c *Client) Exchange(ctx context.Context, req *ExchangeRequest) (*ExchangeResponse, error) {
 	if req.SubjectToken == "" {
@@ -81,7 +98,7 @@ func (c *Client) Exchange(ctx context.Context, req *ExchangeRequest) (*ExchangeR
 		form.Set("actor_token_type", "urn:ietf:params:oauth:token-type:access_token")
 	}
 
-	if err := c.auth.Apply(ctx, form); err != nil {
+	if err := c.getAuth().Apply(ctx, form); err != nil {
 		return nil, fmt.Errorf("applying client auth: %w", err)
 	}
 
@@ -106,7 +123,7 @@ func (c *Client) ClientCredentials(ctx context.Context, audience, scopes string)
 		form.Set("scope", scopes)
 	}
 
-	if err := c.auth.Apply(ctx, form); err != nil {
+	if err := c.getAuth().Apply(ctx, form); err != nil {
 		return nil, fmt.Errorf("applying client auth: %w", err)
 	}
 

--- a/authbridge/authlib/validation/lazy.go
+++ b/authbridge/authlib/validation/lazy.go
@@ -1,0 +1,51 @@
+package validation
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// LazyJWKSVerifier wraps JWKSVerifier with lazy initialization.
+// The JWKS keys are fetched on the first Verify() call, not at construction time.
+// This avoids blocking startup on an HTTP call to the JWKS endpoint.
+//
+// Unlike sync.Once, initialization is retried on failure so that a temporarily
+// unreachable JWKS endpoint doesn't permanently break token validation.
+type LazyJWKSVerifier struct {
+	jwksURL string
+	issuer  string
+	opts    []JWKSOption
+
+	mu    sync.Mutex
+	inner *JWKSVerifier
+}
+
+// NewLazyJWKSVerifier creates a Verifier that defers the JWKS HTTP fetch
+// until the first token needs to be verified. This allows the authbridge
+// gRPC listener to start immediately without waiting for the JWKS endpoint.
+func NewLazyJWKSVerifier(jwksURL, issuer string, opts ...JWKSOption) *LazyJWKSVerifier {
+	return &LazyJWKSVerifier{
+		jwksURL: jwksURL,
+		issuer:  issuer,
+		opts:    opts,
+	}
+}
+
+// Verify initializes the underlying JWKSVerifier on first call, then delegates.
+// If initialization fails, it retries on the next call rather than caching the error.
+func (v *LazyJWKSVerifier) Verify(ctx context.Context, tokenStr string, audience string) (*Claims, error) {
+	v.mu.Lock()
+	if v.inner == nil {
+		inner, err := NewJWKSVerifier(ctx, v.jwksURL, v.issuer, v.opts...)
+		if err != nil {
+			v.mu.Unlock()
+			return nil, fmt.Errorf("JWKS verifier init: %w", err)
+		}
+		v.inner = inner
+	}
+	inner := v.inner
+	v.mu.Unlock()
+
+	return inner.Verify(ctx, tokenStr, audience)
+}

--- a/authbridge/cmd/authbridge/main.go
+++ b/authbridge/cmd/authbridge/main.go
@@ -50,20 +50,20 @@ func main() {
 		cfg.Mode = *mode // flag overrides YAML
 	}
 
-	// Resolve config into auth dependencies
+	// Resolve config into auth dependencies.
+	// Credential files and JWKS are resolved lazily — the gRPC listener
+	// starts immediately so Envoy can connect without waiting.
 	resolved, err := config.Resolve(ctx, cfg)
 	if err != nil {
 		log.Fatalf("resolving config: %v", err)
 	}
 	handler := auth.New(*resolved)
 
-	slog.Info("authbridge starting", "mode", cfg.Mode)
-
 	// Track servers for graceful shutdown
 	var grpcServers []*grpc.Server
 	var httpServers []*http.Server
 
-	// Start listeners based on mode
+	// Start listeners FIRST — before credential resolution
 	switch cfg.Mode {
 	case config.ModeEnvoySidecar:
 		grpcServers = append(grpcServers, startGRPCExtProc(handler, cfg.Listener.ExtProcAddr))
@@ -83,6 +83,27 @@ func main() {
 	default:
 		log.Fatalf("unhandled mode %q", cfg.Mode)
 	}
+
+	slog.Info("authbridge starting", "mode", cfg.Mode)
+
+	// Resolve credentials in background — doesn't block the listener.
+	// Once credential files are available, update the handler's identity
+	// and exchanger so token exchange requests use the loaded credentials.
+	go func() {
+		slog.Info("resolving credentials in background...")
+		config.ResolveCredentialFiles(cfg)
+		// Safe to read cfg.Identity here — ResolveCredentialFiles completed
+		// and this is the only goroutine that writes these fields.
+		clientAuth, err := config.ResolveClientAuth(cfg)
+		if err != nil {
+			slog.Warn("failed to resolve client auth after credential load", "error", err)
+			return
+		}
+		handler.UpdateIdentity(auth.IdentityConfig{
+			ClientID: cfg.Identity.ClientID,
+			Audience: cfg.Identity.ClientID,
+		}, clientAuth)
+	}()
 
 	// Wait for shutdown signal
 	sigCh := make(chan os.Signal, 1)


### PR DESCRIPTION
## Summary

- Start the ext_proc gRPC listener **before** resolving credential files, so Envoy can connect immediately
- Replace eager NewJWKSVerifier with LazyJWKSVerifier that fetches JWKS keys on first Verify() call (with retry on failure)
- Resolve credential files in a background goroutine after listeners start
- Use atomic.Pointer for identity and sync.RWMutex for exchanger auth to safely update from the background goroutine

## Problem

The authbridge binary blocks for up to **2 minutes** at startup waiting for /shared/client-id.txt and /shared/client-secret.txt (60s timeout each). These files are written by the client-registration sidecar, which may not be ready yet on a fresh cluster. During this wait, the ext_proc gRPC server on port 9090 is not running -- Envoy gets Connection refused on every outbound request.

This caused flaky E2E failures: test_agent_simple_query fails because the weather-service agent cannot reach weather-tool-mcp through Envoy.

## Fix

| Before | After |
|--------|-------|
| Resolve() blocks on credential files (up to 120s) | Resolve() returns immediately |
| NewJWKSVerifier() makes HTTP call at startup | LazyJWKSVerifier defers to first Verify() |
| gRPC listener starts after all blocking completes | gRPC listener starts immediately |
| Outbound passthrough fails during wait | Outbound passthrough works from the start |

## Files changed

- authbridge/authlib/validation/lazy.go -- new: LazyJWKSVerifier with retry on init failure
- authbridge/authlib/config/resolve.go -- remove blocking waits, export ResolveCredentialFiles and ResolveClientAuth
- authbridge/authlib/auth/auth.go -- atomic.Pointer[IdentityConfig], add UpdateIdentity
- authbridge/authlib/exchange/client.go -- sync.RWMutex for auth, add UpdateAuth
- authbridge/cmd/authbridge/main.go -- start listeners first, resolve credentials in background

## Test plan

- [x] go test ./authlib/... -race passes
- [x] go test ./cmd/authbridge/... -race passes
- [x] go build succeeds for both modules
- [ ] E2E: deploy on Kind, verify weather-agent reaches weather-tool within seconds of pod creation
- [ ] E2E: verify inbound JWT validation works after JWKS keys are lazily fetched

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>