### PR TITLE
⚡ Shrink authbridge images: UBI9-micro for Envoy variant, distroless for lightweight

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,6 +56,12 @@ jobs:
             context: ./authbridge
             dockerfile: cmd/authbridge/Dockerfile
 
+          # Lightweight AuthBridge (Go binary only, no Envoy)
+          # Used for waypoint and proxy-sidecar modes
+          - name: authbridge-light
+            context: ./authbridge
+            dockerfile: cmd/authbridge/Dockerfile.light
+
           # Demo application for testing
           - name: demo-app
             context: ./authbridge/authproxy/quickstart/demo-app

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,7 +52,14 @@ jobs:
 
           # Unified AuthBridge binary (Envoy + authbridge in one container)
           # Drop-in replacement for envoy-with-processor
+          # DEPRECATED: use authbridge-envoy instead
           - name: authbridge-unified
+            context: ./authbridge
+            dockerfile: cmd/authbridge/Dockerfile
+
+          # AuthBridge with Envoy (envoy-sidecar mode)
+          # New canonical name for authbridge-unified
+          - name: authbridge-envoy
             context: ./authbridge
             dockerfile: cmd/authbridge/Dockerfile
 

--- a/authbridge/cmd/authbridge/Dockerfile
+++ b/authbridge/cmd/authbridge/Dockerfile
@@ -21,14 +21,13 @@ COPY cmd/authbridge/ cmd/authbridge/
 # In Docker the layout is /app/authlib and /app/cmd/authbridge, so the
 # relative path ../../authlib resolves to /app/authlib. Correct.
 ENV GOWORK=off
-RUN cd cmd/authbridge && CGO_ENABLED=0 GOOS=linux go build -o /authbridge . \
-    && chmod 755 /authbridge
+RUN cd cmd/authbridge && CGO_ENABLED=0 GOOS=linux go build -o /authbridge .
 
 # Stage 2: Get Envoy binary
 FROM docker.io/envoyproxy/envoy:v1.37.1 AS envoy-source
 
 # Stage 3: Runtime — UBI9-micro (glibc-compatible, ~24 MB)
-FROM registry.access.redhat.com/ubi9/ubi-micro:latest
+FROM registry.access.redhat.com/ubi9/ubi-micro@sha256:2173487b3b72b1a7b11edc908e9bbf1726f9df46a4f78fd6d19a2bab0a701f38
 
 COPY --from=envoy-source --chmod=755 /usr/local/bin/envoy /usr/local/bin/envoy
 COPY --from=builder --chmod=755 /authbridge /usr/local/bin/authbridge

--- a/authbridge/cmd/authbridge/Dockerfile
+++ b/authbridge/cmd/authbridge/Dockerfile
@@ -1,6 +1,9 @@
 # AuthBridge unified image — Envoy + authbridge binary in one container.
 # Drop-in replacement for envoy-with-processor (Dockerfile.envoy).
 #
+# Uses UBI9-micro base (~24 MB) instead of UBI9-minimal (~134 MB)
+# for a ~42% smaller image while remaining glibc-compatible for Envoy.
+#
 # Build context: ./authbridge (needs access to both authlib/ and cmd/authbridge/)
 
 # Stage 1: Build authbridge binary
@@ -18,23 +21,18 @@ COPY cmd/authbridge/ cmd/authbridge/
 # In Docker the layout is /app/authlib and /app/cmd/authbridge, so the
 # relative path ../../authlib resolves to /app/authlib. Correct.
 ENV GOWORK=off
-RUN cd cmd/authbridge && CGO_ENABLED=0 GOOS=linux go build -o /authbridge .
+RUN cd cmd/authbridge && CGO_ENABLED=0 GOOS=linux go build -o /authbridge . \
+    && chmod 755 /authbridge
 
 # Stage 2: Get Envoy binary
 FROM docker.io/envoyproxy/envoy:v1.37.1 AS envoy-source
 
-# Stage 3: Runtime — same base as Dockerfile.envoy
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:83006d535923fcf1345067873524a3980316f51794f01d8655be55d6e9387183
+# Stage 3: Runtime — UBI9-micro (glibc-compatible, ~24 MB)
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest
 
-RUN microdnf install -y ca-certificates && microdnf clean all
-
-COPY --from=envoy-source /usr/local/bin/envoy /usr/local/bin/envoy
-COPY --from=builder /authbridge /usr/local/bin/authbridge
-COPY cmd/authbridge/entrypoint.sh /usr/local/bin/entrypoint.sh
-
-RUN chmod 755 /usr/local/bin/entrypoint.sh \
-              /usr/local/bin/envoy \
-              /usr/local/bin/authbridge
+COPY --from=envoy-source --chmod=755 /usr/local/bin/envoy /usr/local/bin/envoy
+COPY --from=builder --chmod=755 /authbridge /usr/local/bin/authbridge
+COPY --chmod=755 cmd/authbridge/entrypoint.sh /usr/local/bin/entrypoint.sh
 
 # Envoy writes hot-restart lock files and admin socket here
 RUN mkdir -p /tmp/envoy && chmod 775 /tmp/envoy

--- a/authbridge/cmd/authbridge/Dockerfile
+++ b/authbridge/cmd/authbridge/Dockerfile
@@ -3,11 +3,12 @@
 #
 # Uses UBI9-micro base (~24 MB) instead of UBI9-minimal (~134 MB)
 # for a ~42% smaller image while remaining glibc-compatible for Envoy.
+# Total image size: ~140 MB (24 MB base + 87 MB Envoy + 26 MB authbridge).
 #
 # Build context: ./authbridge (needs access to both authlib/ and cmd/authbridge/)
 
 # Stage 1: Build authbridge binary
-FROM golang:1.24-alpine AS builder
+FROM golang:1.24-alpine@sha256:8bee1901f1e530bfb4a7850aa7a479d17ae3a18beb6e09064ed54cfd245b7191 AS builder
 
 RUN apk add --no-cache git
 
@@ -27,8 +28,11 @@ RUN cd cmd/authbridge && CGO_ENABLED=0 GOOS=linux go build -o /authbridge .
 FROM docker.io/envoyproxy/envoy:v1.37.1 AS envoy-source
 
 # Stage 3: Runtime — UBI9-micro (glibc-compatible, ~24 MB)
+# UBI9-micro has no package manager and no CA certificates.
+# CA certs are copied from the Alpine builder for HTTPS (JWKS, Keycloak).
 FROM registry.access.redhat.com/ubi9/ubi-micro@sha256:2173487b3b72b1a7b11edc908e9bbf1726f9df46a4f78fd6d19a2bab0a701f38
 
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=envoy-source --chmod=755 /usr/local/bin/envoy /usr/local/bin/envoy
 COPY --from=builder --chmod=755 /authbridge /usr/local/bin/authbridge
 COPY --chmod=755 cmd/authbridge/entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/authbridge/cmd/authbridge/Dockerfile.light
+++ b/authbridge/cmd/authbridge/Dockerfile.light
@@ -20,13 +20,12 @@ COPY authlib/ authlib/
 COPY cmd/authbridge/ cmd/authbridge/
 
 ENV GOWORK=off
-RUN cd cmd/authbridge && CGO_ENABLED=0 GOOS=linux go build -o /authbridge . \
-    && chmod 755 /authbridge
+RUN cd cmd/authbridge && CGO_ENABLED=0 GOOS=linux go build -o /authbridge .
 
 # Stage 2: Runtime — distroless static (~2 MB, includes CA certs)
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:a9329520abc449e3b14d5bc3a6ffae065bdde0f02667fa10880c49b35c109fd1
 
-COPY --from=builder /authbridge /usr/local/bin/authbridge
+COPY --from=builder --chmod=755 /authbridge /usr/local/bin/authbridge
 
 # ext_authz/ext_proc (9090), forward proxy (8080), reverse proxy (8081)
 EXPOSE 9090 8080 8081

--- a/authbridge/cmd/authbridge/Dockerfile.light
+++ b/authbridge/cmd/authbridge/Dockerfile.light
@@ -1,0 +1,32 @@
+# AuthBridge lightweight image — Go binary only, no Envoy.
+# Used for waypoint and proxy-sidecar modes where Envoy is not needed.
+# For envoy-sidecar mode, use the main Dockerfile which includes Envoy.
+#
+# Build context: ./authbridge (needs access to both authlib/ and cmd/authbridge/)
+
+# Stage 1: Build authbridge binary
+FROM golang:1.24-alpine AS builder
+
+RUN apk add --no-cache git
+
+WORKDIR /app
+
+# Copy both modules with Docker-compatible layout
+COPY authlib/ authlib/
+COPY cmd/authbridge/ cmd/authbridge/
+
+ENV GOWORK=off
+RUN cd cmd/authbridge && CGO_ENABLED=0 GOOS=linux go build -o /authbridge . \
+    && chmod 755 /authbridge
+
+# Stage 2: Runtime — UBI9-micro (~24 MB, glibc-compatible)
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest
+
+COPY --from=builder --chmod=755 /authbridge /usr/local/bin/authbridge
+
+USER 1337
+
+# ext_authz/ext_proc (9090), forward proxy (8080), reverse proxy (8081)
+EXPOSE 9090 8080 8081
+
+ENTRYPOINT ["/usr/local/bin/authbridge"]

--- a/authbridge/cmd/authbridge/Dockerfile.light
+++ b/authbridge/cmd/authbridge/Dockerfile.light
@@ -2,6 +2,10 @@
 # Used for waypoint and proxy-sidecar modes where Envoy is not needed.
 # For envoy-sidecar mode, use the main Dockerfile which includes Envoy.
 #
+# Uses distroless base (~2 MB) for minimal attack surface.
+# The binary is statically linked (CGO_ENABLED=0), so no glibc needed.
+# No shell — debug via kubectl logs, not kubectl exec.
+#
 # Build context: ./authbridge (needs access to both authlib/ and cmd/authbridge/)
 
 # Stage 1: Build authbridge binary
@@ -19,12 +23,10 @@ ENV GOWORK=off
 RUN cd cmd/authbridge && CGO_ENABLED=0 GOOS=linux go build -o /authbridge . \
     && chmod 755 /authbridge
 
-# Stage 2: Runtime — UBI9-micro (~24 MB, glibc-compatible)
-FROM registry.access.redhat.com/ubi9/ubi-micro:latest
+# Stage 2: Runtime — distroless static (~2 MB, includes CA certs)
+FROM gcr.io/distroless/static-debian12:nonroot
 
-COPY --from=builder --chmod=755 /authbridge /usr/local/bin/authbridge
-
-USER 1337
+COPY --from=builder /authbridge /usr/local/bin/authbridge
 
 # ext_authz/ext_proc (9090), forward proxy (8080), reverse proxy (8081)
 EXPOSE 9090 8080 8081

--- a/authbridge/cmd/authbridge/Dockerfile.light
+++ b/authbridge/cmd/authbridge/Dockerfile.light
@@ -9,7 +9,7 @@
 # Build context: ./authbridge (needs access to both authlib/ and cmd/authbridge/)
 
 # Stage 1: Build authbridge binary
-FROM golang:1.24-alpine AS builder
+FROM golang:1.24-alpine@sha256:8bee1901f1e530bfb4a7850aa7a479d17ae3a18beb6e09064ed54cfd245b7191 AS builder
 
 RUN apk add --no-cache git
 


### PR DESCRIPTION
## Summary

- Switch `authbridge-unified` (Envoy variant) from UBI9-minimal to UBI9-micro base
- Add new `authbridge-light` image for waypoint/proxy-sidecar modes using distroless base
- Add `authbridge-light` to CI build matrix

## Image sizes

| Image | Before | After | Reduction |
|-------|--------|-------|-----------|
| `authbridge-unified` (Envoy + authbridge) | 243 MB | **140 MB** | 42% |
| `authbridge-light` (Go binary only) | N/A | **29 MB** | New |

## Why two images

The unified image bundles Envoy (~87 MB) which is only needed for envoy-sidecar mode. Waypoint and proxy-sidecar modes run pure Go listeners and pay the full image cost for nothing. The lightweight image eliminates Envoy and uses a distroless base (~2 MB) since the Go binary is statically linked.

## Details

### authbridge-unified (Envoy variant)
- Base: UBI9-minimal (134 MB) -> UBI9-micro (24 MB)
- Use `COPY --chmod` to avoid redundant chmod layer
- Same Envoy binary, same entrypoint, drop-in compatible

### authbridge-light (new)
- Base: `gcr.io/distroless/static-debian12:nonroot` (~2 MB)
- Go binary only, statically linked (`CGO_ENABLED=0`)
- No Envoy, no shell, no entrypoint wrapper
- Includes CA certificates for HTTPS (JWKS endpoint)
- Debug via `kubectl logs`, not `kubectl exec`

## Test plan

- [x] `authbridge-unified` builds and runs (Envoy + authbridge verified)
- [x] `authbridge-light` builds and runs (`--help` verified)
- [x] Local Kind deployment tested with authbridge-unified slim image
- [ ] CI builds both images successfully

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>