### PR TITLE
🐛 Skip audience validation when credentials not yet loaded

### DIFF
--- a/authbridge/authlib/validation/jwks.go
+++ b/authbridge/authlib/validation/jwks.go
@@ -62,15 +62,16 @@ func (v *JWKSVerifier) Verify(ctx context.Context, tokenStr string, audience str
 		return nil, fmt.Errorf("fetching JWKS: %w", err)
 	}
 
-	if audience == "" {
-		return nil, fmt.Errorf("audience is required (prevents confused deputy attacks)")
-	}
-
 	parseOpts := []jwt.ParseOption{
 		jwt.WithKeySet(keySet),
 		jwt.WithValidate(true),
 		jwt.WithIssuer(v.issuer),
-		jwt.WithAudience(audience),
+	}
+	// When audience is configured, enforce it. When empty (credentials not yet
+	// loaded), skip audience validation — matches the old go-processor behavior
+	// that logged "Audience validation disabled (CLIENT_ID not available)".
+	if audience != "" {
+		parseOpts = append(parseOpts, jwt.WithAudience(audience))
 	}
 
 	token, err := jwt.Parse([]byte(tokenStr), parseOpts...)

--- a/authbridge/authlib/validation/jwks_test.go
+++ b/authbridge/authlib/validation/jwks_test.go
@@ -187,7 +187,7 @@ func TestJWKSVerifier_WrongAudience(t *testing.T) {
 	}
 }
 
-func TestJWKSVerifier_EmptyAudience_Rejected(t *testing.T) {
+func TestJWKSVerifier_EmptyAudience_SkipsValidation(t *testing.T) {
 	privKey, jwksSrv := setupTestJWKS(t)
 	defer jwksSrv.Close()
 
@@ -202,9 +202,14 @@ func TestJWKSVerifier_EmptyAudience_Rejected(t *testing.T) {
 		"iat": time.Now().Unix(),
 	})
 
-	_, err := v.Verify(ctx, token, "")
-	if err == nil {
-		t.Fatal("expected error for empty audience (confused deputy protection)")
+	// When audience is empty (credentials not yet loaded), audience validation
+	// is skipped — signature, expiry, and issuer are still checked.
+	claims, err := v.Verify(ctx, token, "")
+	if err != nil {
+		t.Fatalf("expected success with empty audience (skips validation), got: %v", err)
+	}
+	if claims.Subject != "user" {
+		t.Errorf("subject = %q, want %q", claims.Subject, "user")
 	}
 }
 


### PR DESCRIPTION
## Summary

When client-id.txt is not yet available, the audience defaults to empty. The old go-processor skipped audience validation in this case. The new authbridge rejected all tokens with "audience is required", causing 401 on every inbound request.

This fix matches the old behavior: when audience is empty, skip the aud claim check while still validating signature, expiry, and issuer.

## Root cause

On OCP/HyperShift, the client-registration sidecar crashes during Keycloak admin token refresh (master realm auth mismatch). Even when it partially succeeds (writes client-id.txt), the audience scope is never created, so tokens lack the aud claim. The old go-processor tolerated both conditions; the new authbridge did not.

## Changes

- `validation/jwks.go`: Replace hard rejection of empty audience with conditional -- only add `jwt.WithAudience` when audience is non-empty
- `validation/jwks_test.go`: Update test to match new behavior

## Test plan

- [x] `go test ./authlib/... -race` passes
- [ ] E2E: deploy on HyperShift, verify inbound requests succeed even before credentials load

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>