### PR TITLE
docs: document deployment modes, image variants, and port-stealing

### DIFF
--- a/authbridge/README.md
+++ b/authbridge/README.md
@@ -19,7 +19,7 @@ The [`cmd/authbridge/`](./cmd/authbridge/) directory contains a unified binary t
 | `proxy-sidecar` | `authbridge-light` | Lightweight proxy via HTTP_PROXY env | Agent routes outbound traffic through forward proxy; reverse proxy validates inbound JWTs |
 | `waypoint` | `authbridge-light` | Shared proxy in Istio ambient mesh | Standalone deployment (not injected as sidecar) |
 
-The operator selects the mode via the `kagenti.io/authbridge-mode` annotation on the workload. Default is `envoy-sidecar`.
+The operator selects the mode via the `kagenti.io/authbridge-mode` annotation on the workload. Default is `envoy-sidecar`. See [kagenti-operator PR #295](https://github.com/kagenti/kagenti-operator/pull/295) for the implementation.
 
 ### Image naming
 

--- a/authbridge/README.md
+++ b/authbridge/README.md
@@ -4,17 +4,30 @@ AuthBridge provides **secure, transparent token management** for Kubernetes work
 
 > **📘 Looking to run the demo?** See the [Single-Target Demo](./demos/single-target/demo.md) or [Multi-Target Demo](./demos/multi-target/demo.md) for step-by-step instructions.
 
-## Unified AuthBridge Binary (New)
+## Deployment Modes
 
-The [`cmd/authbridge/`](./cmd/authbridge/) directory contains a unified binary that supports three deployment modes in a single codebase:
+The [`cmd/authbridge/`](./cmd/authbridge/) directory contains a unified binary that supports three deployment modes in a single codebase. Two container images are published:
 
-| Mode | Use Case | Replaces |
-|------|----------|----------|
-| `envoy-sidecar` | Sidecar per agent pod (Envoy + ext_proc) | `envoy-with-processor` (go-processor) |
-| `waypoint` | Shared service in Istio ambient mesh | Waypoint token-exchange-service |
-| `proxy-sidecar` | Sidecar without Envoy (reverse + forward proxy) | Klaviger |
+| Image | Size | Contents |
+|-------|------|----------|
+| `authbridge-envoy` | 140 MB | Go binary + Envoy (UBI9-micro base) |
+| `authbridge-light` | 29 MB | Go binary only (distroless base) |
 
-The unified image (`authbridge-unified`) is a **drop-in replacement** for `envoy-with-processor` with the same base image, UID (1337), and ports. See [`cmd/authbridge/README.md`](./cmd/authbridge/README.md) for config format and usage.
+| Mode | Image | Use Case | How It Works |
+|------|-------|----------|-------------|
+| `envoy-sidecar` (default) | `authbridge-envoy` | Transparent interception via iptables | Envoy intercepts all traffic, delegates auth to authbridge via ext_proc gRPC |
+| `proxy-sidecar` | `authbridge-light` | Lightweight proxy via HTTP_PROXY env | Agent routes outbound traffic through forward proxy; reverse proxy validates inbound JWTs |
+| `waypoint` | `authbridge-light` | Shared proxy in Istio ambient mesh | Standalone deployment (not injected as sidecar) |
+
+The operator selects the mode via the `kagenti.io/authbridge-mode` annotation on the workload. Default is `envoy-sidecar`.
+
+### Image naming
+
+| Name | Status |
+|------|--------|
+| `authbridge-envoy` | Canonical name for the Envoy variant |
+| `authbridge-light` | Lightweight variant (no Envoy) |
+| `authbridge-unified` | Deprecated alias for `authbridge-envoy` |
 
 The shared auth library at [`authlib/`](./authlib/) contains the building blocks (JWT validation, token exchange, caching, routing) with no protocol dependencies. See [`authlib/README.md`](./authlib/README.md) for package reference.
 

--- a/authbridge/README.md
+++ b/authbridge/README.md
@@ -31,9 +31,9 @@ The operator selects the mode via the `kagenti.io/authbridge-mode` annotation on
 
 The shared auth library at [`authlib/`](./authlib/) contains the building blocks (JWT validation, token exchange, caching, routing) with no protocol dependencies. See [`authlib/README.md`](./authlib/README.md) for package reference.
 
-## Classic Architecture (Operator-Injected)
+## Architecture (Operator-Injected)
 
-The following describes the current production deployment using operator-injected split sidecars. The unified binary (`cmd/authbridge/`) replaces the `envoy-proxy` sidecar in this architecture.
+The following describes the operator-injected sidecar deployment. The `authbridge-envoy` image replaces the legacy `envoy-with-processor` in envoy-sidecar mode. The `authbridge-light` image is used for proxy-sidecar mode.
 
 ### What AuthBridge Does
 

--- a/authbridge/cmd/authbridge/README.md
+++ b/authbridge/cmd/authbridge/README.md
@@ -1,26 +1,49 @@
-# AuthBridge Unified Binary
+# AuthBridge Binary
 
 A single binary that replaces three separate codebases (go-processor, waypoint, klaviger) with a unified auth proxy supporting three deployment modes.
 
+## Images
+
+| Image | Dockerfile | Size | Contents |
+|-------|-----------|------|----------|
+| `authbridge-envoy` | `Dockerfile` | 140 MB | Envoy + authbridge (UBI9-micro) |
+| `authbridge-light` | `Dockerfile.light` | 29 MB | authbridge only (distroless) |
+| `authbridge-unified` | `Dockerfile` | 140 MB | Deprecated alias for `authbridge-envoy` |
+
 ## Modes
 
-| Mode | Interception | Listeners | Deployment |
-|------|-------------|-----------|------------|
-| `envoy-sidecar` | Envoy iptables + ext_proc | gRPC ext_proc on :9090 | Sidecar per agent pod |
-| `waypoint` | Istio ambient + ext_authz | gRPC ext_authz + HTTP forward proxy | Shared service in kagenti-system |
-| `proxy-sidecar` | Reverse proxy + forward proxy | HTTP reverse proxy + forward proxy | Sidecar without Envoy |
+| Mode | Image | Interception | Listeners |
+|------|-------|-------------|-----------|
+| `envoy-sidecar` | `authbridge-envoy` | Envoy iptables + ext_proc | gRPC ext_proc on :9090 |
+| `proxy-sidecar` | `authbridge-light` | HTTP_PROXY env + port-stealing | HTTP reverse proxy + forward proxy |
+| `waypoint` | `authbridge-light` | Istio ambient + ext_authz | gRPC ext_authz + HTTP forward proxy |
+
+### proxy-sidecar port-stealing
+
+In proxy-sidecar mode, the kagenti-operator webhook transparently intercepts the agent's port:
+
+1. The reverse proxy takes over the agent's original port (e.g., `:8000`)
+2. The agent is moved to a free port (e.g., `:8001`) via `PORT` env var
+3. `HTTP_PROXY`/`HTTPS_PROXY` env vars are injected into the agent container
+4. The Service targetPort remains unchanged — traffic flows through the reverse proxy
+
+The operator passes the dynamically assigned ports via env vars (`REVERSE_PROXY_ADDR`, `REVERSE_PROXY_BACKEND`, `FORWARD_PROXY_ADDR`) which are expanded via `${...}` in the config YAML.
 
 ## Building
 
 ```bash
-# From authbridge/ directory (build context)
-podman build -f cmd/authbridge/Dockerfile -t authbridge-unified:local .
+# Envoy variant (envoy-sidecar mode)
+podman build -f cmd/authbridge/Dockerfile -t authbridge-envoy:local authbridge/
+
+# Lightweight variant (proxy-sidecar / waypoint modes)
+podman build -f cmd/authbridge/Dockerfile.light -t authbridge-light:local authbridge/
 
 # Load into Kind
-kind load docker-image authbridge-unified:local --name kagenti
+kind load docker-image authbridge-envoy:local --name kagenti
+kind load docker-image authbridge-light:local --name kagenti
 ```
 
-The image contains both Envoy and the authbridge binary. The entrypoint starts both processes with `wait -n` supervision (if either dies, the container restarts).
+The Envoy image contains both Envoy and the authbridge binary. The entrypoint starts both processes with `wait -n` supervision (if either dies, the container restarts). The light image runs the authbridge binary directly as the entrypoint.
 
 ## Running
 

--- a/authbridge/cmd/authbridge/README.md
+++ b/authbridge/cmd/authbridge/README.md
@@ -8,7 +8,7 @@ A single binary that replaces three separate codebases (go-processor, waypoint, 
 |-------|-----------|------|----------|
 | `authbridge-envoy` | `Dockerfile` | 140 MB | Envoy + authbridge (UBI9-micro) |
 | `authbridge-light` | `Dockerfile.light` | 29 MB | authbridge only (distroless) |
-| `authbridge-unified` | `Dockerfile` | 140 MB | Deprecated alias for `authbridge-envoy` |
+| `authbridge-unified` | `Dockerfile` | 140 MB | Deprecated alias (same image as `authbridge-envoy`) |
 
 ## Modes
 
@@ -18,9 +18,9 @@ A single binary that replaces three separate codebases (go-processor, waypoint, 
 | `proxy-sidecar` | `authbridge-light` | HTTP_PROXY env + port-stealing | HTTP reverse proxy + forward proxy |
 | `waypoint` | `authbridge-light` | Istio ambient + ext_authz | gRPC ext_authz + HTTP forward proxy |
 
-### proxy-sidecar port-stealing
+### proxy-sidecar port reassignment
 
-In proxy-sidecar mode, the kagenti-operator webhook transparently intercepts the agent's port:
+In proxy-sidecar mode, the kagenti-operator webhook transparently reassigns the agent's port to interpose the reverse proxy:
 
 1. The reverse proxy takes over the agent's original port (e.g., `:8000`)
 2. The agent is moved to a free port (e.g., `:8001`) via `PORT` env var

--- a/authbridge/cmd/authbridge/README.md
+++ b/authbridge/cmd/authbridge/README.md
@@ -29,14 +29,34 @@ In proxy-sidecar mode, the kagenti-operator webhook transparently intercepts the
 
 The operator passes the dynamically assigned ports via env vars (`REVERSE_PROXY_ADDR`, `REVERSE_PROXY_BACKEND`, `FORWARD_PROXY_ADDR`) which are expanded via `${...}` in the config YAML.
 
+## Selecting a Mode
+
+The operator selects the mode via annotation on the workload's pod template:
+
+```yaml
+# Default (envoy-sidecar) — no annotation needed
+metadata:
+  labels:
+    kagenti.io/type: agent
+
+# Proxy-sidecar mode
+metadata:
+  labels:
+    kagenti.io/type: agent
+  annotations:
+    kagenti.io/authbridge-mode: "proxy-sidecar"
+```
+
 ## Building
+
+All builds run from the **repo root** with `authbridge/` as the build context:
 
 ```bash
 # Envoy variant (envoy-sidecar mode)
-podman build -f cmd/authbridge/Dockerfile -t authbridge-envoy:local authbridge/
+podman build -f authbridge/cmd/authbridge/Dockerfile -t authbridge-envoy:local authbridge/
 
 # Lightweight variant (proxy-sidecar / waypoint modes)
-podman build -f cmd/authbridge/Dockerfile.light -t authbridge-light:local authbridge/
+podman build -f authbridge/cmd/authbridge/Dockerfile.light -t authbridge-light:local authbridge/
 
 # Load into Kind
 kind load docker-image authbridge-envoy:local --name kagenti


### PR DESCRIPTION
## Summary

Update authbridge documentation to reflect the three deployment modes and two image variants.

### authbridge/README.md
- Replace 'Unified AuthBridge Binary' section with 'Deployment Modes'
- Document envoy-sidecar, proxy-sidecar, and waypoint modes
- Add image naming table (authbridge-envoy, authbridge-light, deprecated authbridge-unified)

### cmd/authbridge/README.md
- Add Images table with Dockerfile, size, and contents
- Update Modes table with image column
- Document proxy-sidecar port-stealing behavior
- Update build commands for both image variants

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>