### PR TITLE
fix: Downgrade cross-mode listener fields from errors to warnings

### DIFF
--- a/authbridge/authlib/config/config_test.go
+++ b/authbridge/authlib/config/config_test.go
@@ -50,7 +50,7 @@ func TestApplyPreset_ProxySidecar(t *testing.T) {
 
 func TestApplyPreset_UserOverride(t *testing.T) {
 	cfg := &Config{
-		Mode: ModeEnvoySidecar,
+		Mode:     ModeEnvoySidecar,
 		Identity: IdentityConfig{Type: "client-secret"}, // user override
 	}
 	ApplyPreset(cfg)
@@ -61,7 +61,7 @@ func TestApplyPreset_UserOverride(t *testing.T) {
 
 func TestNoTokenPolicyForMode(t *testing.T) {
 	tests := []struct {
-		mode   string
+		mode string
 		want string
 	}{
 		{ModeEnvoySidecar, "client-credentials"},
@@ -130,19 +130,45 @@ func TestValidate_SpiffeIdentityRequiresPath(t *testing.T) {
 	}
 }
 
-func TestValidate_InvalidListenerCombo(t *testing.T) {
-	cfg := validEnvoySidecarConfig()
-	cfg.Listener.ReverseProxyAddr = ":8080" // invalid for envoy-sidecar
-	if err := Validate(cfg); err == nil {
-		t.Error("expected error for envoy-sidecar + reverse_proxy_addr")
+func TestValidate_CrossModeFieldsAreWarnings(t *testing.T) {
+	// Cross-mode listener fields are now warnings, not errors.
+	// This allows a shared ConfigMap with ${...} placeholders for all modes.
+	tests := []struct {
+		name string
+		cfg  *Config
+	}{
+		{"envoy-sidecar + reverse_proxy_addr", func() *Config {
+			c := validEnvoySidecarConfig()
+			c.Listener.ReverseProxyAddr = "${REVERSE_PROXY_ADDR}"
+			return c
+		}()},
+		{"envoy-sidecar + ext_authz_addr", func() *Config {
+			c := validEnvoySidecarConfig()
+			c.Listener.ExtAuthzAddr = ":9091"
+			return c
+		}()},
+		{"waypoint + ext_proc_addr", func() *Config {
+			c := validWaypointConfig()
+			c.Listener.ExtProcAddr = ":9090"
+			return c
+		}()},
+		{"waypoint + reverse_proxy_addr", func() *Config {
+			c := validWaypointConfig()
+			c.Listener.ReverseProxyAddr = ":8080"
+			return c
+		}()},
+		{"proxy-sidecar + ext_proc_addr", func() *Config {
+			c := validProxySidecarConfig()
+			c.Listener.ExtProcAddr = ":9090"
+			return c
+		}()},
 	}
-}
-
-func TestValidate_WaypointRejectsExtProc(t *testing.T) {
-	cfg := validWaypointConfig()
-	cfg.Listener.ExtProcAddr = ":9090"
-	if err := Validate(cfg); err == nil {
-		t.Error("expected error for waypoint + ext_proc_addr")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := Validate(tt.cfg); err != nil {
+				t.Errorf("cross-mode field should warn, not error: %v", err)
+			}
+		})
 	}
 }
 

--- a/authbridge/authlib/config/validate.go
+++ b/authbridge/authlib/config/validate.go
@@ -76,31 +76,30 @@ func validateIdentity(cfg *Config) error {
 func validateListeners(cfg *Config) error {
 	switch cfg.Mode {
 	case ModeEnvoySidecar:
-		if cfg.Listener.ReverseProxyAddr != "" {
-			return fmt.Errorf("envoy-sidecar mode does not support reverse_proxy_addr (use proxy-sidecar mode)")
-		}
-		if cfg.Listener.ExtAuthzAddr != "" {
-			return fmt.Errorf("envoy-sidecar mode does not support ext_authz_addr (use waypoint mode)")
-		}
+		// Cross-mode fields are warnings, not errors. The shared ConfigMap may
+		// contain ${...} placeholders for other modes that remain as literal
+		// strings when those env vars are unset. These fields are unused at
+		// runtime in envoy-sidecar mode and cause no harm.
+		warnCrossModeField(cfg.Mode, "reverse_proxy_addr", cfg.Listener.ReverseProxyAddr)
+		warnCrossModeField(cfg.Mode, "ext_authz_addr", cfg.Listener.ExtAuthzAddr)
 	case ModeWaypoint:
-		if cfg.Listener.ExtProcAddr != "" {
-			return fmt.Errorf("waypoint mode does not support ext_proc_addr (use envoy-sidecar mode)")
-		}
-		if cfg.Listener.ReverseProxyAddr != "" {
-			return fmt.Errorf("waypoint mode does not support reverse_proxy_addr")
-		}
+		warnCrossModeField(cfg.Mode, "ext_proc_addr", cfg.Listener.ExtProcAddr)
+		warnCrossModeField(cfg.Mode, "reverse_proxy_addr", cfg.Listener.ReverseProxyAddr)
 	case ModeProxySidecar:
-		if cfg.Listener.ExtProcAddr != "" {
-			return fmt.Errorf("proxy-sidecar mode does not support ext_proc_addr (use envoy-sidecar mode)")
-		}
-		if cfg.Listener.ExtAuthzAddr != "" {
-			return fmt.Errorf("proxy-sidecar mode does not support ext_authz_addr (use waypoint mode)")
-		}
+		warnCrossModeField(cfg.Mode, "ext_proc_addr", cfg.Listener.ExtProcAddr)
+		warnCrossModeField(cfg.Mode, "ext_authz_addr", cfg.Listener.ExtAuthzAddr)
 		if cfg.Listener.ReverseProxyBackend == "" {
 			return fmt.Errorf("proxy-sidecar mode requires listener.reverse_proxy_backend")
 		}
 	}
 	return nil
+}
+
+func warnCrossModeField(mode, field, value string) {
+	if value != "" {
+		slog.Warn("listener field ignored in this mode",
+			"mode", mode, "field", field, "value", value)
+	}
 }
 
 func warnUnusual(cfg *Config) {
@@ -127,4 +126,3 @@ func ValidateOutboundPolicy(policy string) error {
 		return fmt.Errorf("unknown outbound.default_policy %q (valid: exchange, passthrough)", policy)
 	}
 }
-


### PR DESCRIPTION
## Summary

- Cross-mode listener field checks in `validateListeners()` are now **warnings** instead of errors
- Enables a shared per-namespace ConfigMap with `${...}` placeholders for all modes
- The required-field check (`reverse_proxy_backend` for proxy-sidecar) remains an error

## Context

The shared `authbridge-runtime-config` ConfigMap uses `${ENV_VAR}` expansion for
listener addresses. In envoy-sidecar mode, proxy-sidecar env vars like `REVERSE_PROXY_ADDR`
are unset, so `Load()` preserves them as literal `"${REVERSE_PROXY_ADDR}"` strings
(by design — see `config.go:95-99`). The validator was rejecting these non-empty values,
breaking envoy-sidecar startup when the ConfigMap contains proxy-sidecar placeholders.

Since cross-mode fields are unused at runtime (envoy-sidecar only starts ext_proc,
proxy-sidecar only starts reverse/forward proxy), having them set to garbage strings
causes no harm. Logging a warning preserves observability without blocking startup.

## Test plan

- [x] `TestValidate_CrossModeFieldsAreWarnings` covers all 5 cross-mode combinations
- [x] `TestValidate_ProxySidecarRequiresBackend` still asserts the required-field error
- [x] All existing tests pass (`go test ./config/ -v`)

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>