### PR TITLE
fix: Rename SERVICE_PORT to PORT in github-issue demo manifest

### DIFF
--- a/authbridge/demos/github-issue/k8s/git-issue-agent-deployment.yaml
+++ b/authbridge/demos/github-issue/k8s/git-issue-agent-deployment.yaml
@@ -88,6 +88,9 @@ spec:
             #       key: apikey
 
             # Agent service settings
+            # PORT tells the agent where to listen for A2A traffic.
+            # The kagenti operator may override this via proxy-sidecar
+            # port-stealing to relocate the agent to a free port.
             - name: PORT
               value: "8000"
             - name: LOG_LEVEL

--- a/authbridge/demos/github-issue/k8s/git-issue-agent-deployment.yaml
+++ b/authbridge/demos/github-issue/k8s/git-issue-agent-deployment.yaml
@@ -88,7 +88,7 @@ spec:
             #       key: apikey
 
             # Agent service settings
-            - name: SERVICE_PORT
+            - name: PORT
               value: "8000"
             - name: LOG_LEVEL
               value: "DEBUG"


### PR DESCRIPTION
## Summary

- Rename `SERVICE_PORT` to `PORT` in `authbridge/demos/github-issue/k8s/git-issue-agent-deployment.yaml`

## Context

The kagenti operator sets `PORT` (not `SERVICE_PORT`) during proxy-sidecar port-stealing. The agent-examples repo has been updated to read `PORT` instead of `SERVICE_PORT` (kagenti/agent-examples#254). This companion PR updates the demo deployment manifest to match.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>