### PR TITLE
feat: Add dynamic log level via LOG_LEVEL env var and SIGUSR1 toggle

### DIFF
--- a/authbridge/authlib/auth/auth.go
+++ b/authbridge/authlib/auth/auth.go
@@ -38,7 +38,7 @@ type Config struct {
 	Bypass           *bypass.Matcher
 	Router           *routing.Router
 	Identity         IdentityConfig
-	NoTokenPolicy    string // NoTokenClientCredentials, NoTokenAllow, or NoTokenDeny
+	NoTokenPolicy    string           // NoTokenClientCredentials, NoTokenAllow, or NoTokenDeny
 	ActorTokenSource ActorTokenSource // optional, for act claim chaining
 	AudienceDeriver  AudienceDeriver  // optional, derives audience from host (waypoint mode)
 	Logger           *slog.Logger
@@ -104,6 +104,7 @@ func (a *Auth) HandleInbound(ctx context.Context, authHeader, path, audience str
 
 	// 2. Extract bearer token
 	if authHeader == "" {
+		a.log.Debug("inbound denied: no Authorization header", "path", path)
 		return &InboundResult{
 			Action:     ActionDeny,
 			DenyStatus: http.StatusUnauthorized,
@@ -112,6 +113,7 @@ func (a *Auth) HandleInbound(ctx context.Context, authHeader, path, audience str
 	}
 	token := extractBearer(authHeader)
 	if token == "" {
+		a.log.Debug("inbound denied: malformed Authorization header", "path", path)
 		return &InboundResult{
 			Action:     ActionDeny,
 			DenyStatus: http.StatusUnauthorized,
@@ -130,11 +132,17 @@ func (a *Auth) HandleInbound(ctx context.Context, authHeader, path, audience str
 	if audience == "" {
 		audience = a.identity.Load().Audience
 	}
+	a.log.Debug("validating inbound JWT", "path", path, "expectedAudience", audience)
 	claims, err := a.verifier.Verify(ctx, token, audience)
 	if err != nil {
-		// Log full error server-side; return generic message to client
-		// to avoid leaking issuer URL, audience, or algorithm details.
+		// Log full error at Info; log detailed context at Debug.
+		// Generic message returned to client to avoid leaking details.
 		a.log.Info("JWT validation failed", "error", err)
+		a.log.Debug("JWT validation details",
+			"path", path,
+			"expectedAudience", audience,
+			"expectedIssuer", a.identity.Load().Audience,
+			"error", err)
 		return &InboundResult{
 			Action:     ActionDeny,
 			DenyStatus: http.StatusUnauthorized,
@@ -143,7 +151,12 @@ func (a *Auth) HandleInbound(ctx context.Context, authHeader, path, audience str
 	}
 
 	// 4. Allow with claims
-	a.log.Info("inbound authorized", "subject", claims.Subject, "client_id", claims.ClientID, "audience", audience)
+	a.log.Debug("inbound authorized",
+		"path", path,
+		"subject", claims.Subject,
+		"clientID", claims.ClientID,
+		"audience", claims.Audience,
+		"scopes", claims.Scopes)
 	return &InboundResult{Action: ActionAllow, Claims: claims}
 }
 
@@ -157,11 +170,11 @@ func (a *Auth) HandleOutbound(ctx context.Context, authHeader, host string) *Out
 
 	// 2. Passthrough
 	if resolved == nil {
-		a.log.Info("outbound passthrough (no route)", "host", host)
+		a.log.Debug("outbound passthrough: no matching route", "host", host)
 		return &OutboundResult{Action: ActionAllow}
 	}
 	if resolved.Passthrough {
-		a.log.Info("outbound passthrough", "host", host)
+		a.log.Debug("outbound passthrough: route configured as passthrough", "host", host)
 		return &OutboundResult{Action: ActionAllow}
 	}
 
@@ -172,27 +185,35 @@ func (a *Auth) HandleOutbound(ctx context.Context, authHeader, host string) *Out
 	// If no audience from route and deriver is set, derive from host (waypoint pattern)
 	if audience == "" && a.audienceDeriver != nil {
 		audience = a.audienceDeriver(host)
+		a.log.Debug("audience derived from host", "host", host, "audience", audience)
 	}
+
+	a.log.Debug("outbound exchange requested",
+		"host", host, "audience", audience, "scopes", scopes,
+		"hasSubjectToken", authHeader != "")
 
 	// 4. Extract bearer token
 	subjectToken := extractBearer(authHeader)
 
 	if subjectToken == "" {
 		// No token — apply no-token policy
+		a.log.Debug("no subject token, applying no-token policy",
+			"policy", a.noTokenPolicy, "host", host, "audience", audience)
 		return a.handleNoToken(ctx, audience, scopes)
 	}
 
 	// 5. Cache check
 	if a.cache != nil {
 		if cached, ok := a.cache.Get(subjectToken, audience); ok {
-			a.log.Debug("cache hit", "host", host, "audience", audience)
+			a.log.Debug("outbound cache hit", "host", host, "audience", audience)
 			return &OutboundResult{Action: ActionReplaceToken, Token: cached}
 		}
 	}
 
 	// 6. Token exchange
 	if a.exchanger == nil {
-		a.log.Warn("exchanger not configured, passing through")
+		a.log.Warn("exchanger not configured, passing through",
+			"host", host, "audience", audience)
 		return &OutboundResult{Action: ActionAllow}
 	}
 
@@ -202,7 +223,8 @@ func (a *Auth) HandleOutbound(ctx context.Context, authHeader, host string) *Out
 		var err error
 		actorToken, err = a.actorTokenSource(ctx)
 		if err != nil {
-			a.log.Warn("failed to obtain actor token, proceeding without", "error", err)
+			a.log.Warn("failed to obtain actor token, proceeding without",
+				"error", err, "host", host)
 		}
 	}
 
@@ -215,6 +237,13 @@ func (a *Auth) HandleOutbound(ctx context.Context, authHeader, host string) *Out
 	})
 	if err != nil {
 		a.log.Info("token exchange failed", "host", host, "error", err)
+		a.log.Debug("token exchange failure details",
+			"host", host,
+			"audience", audience,
+			"scopes", scopes,
+			"hasActorToken", actorToken != "",
+			"tokenEndpoint", resolved.TokenEndpoint,
+			"error", err)
 		return &OutboundResult{
 			Action:     ActionDeny,
 			DenyStatus: http.StatusServiceUnavailable,
@@ -228,7 +257,8 @@ func (a *Auth) HandleOutbound(ctx context.Context, authHeader, host string) *Out
 			time.Duration(resp.ExpiresIn)*time.Second)
 	}
 
-	a.log.Info("outbound token exchanged", "host", host, "audience", audience)
+	a.log.Debug("outbound token exchanged",
+		"host", host, "audience", audience, "expiresIn", resp.ExpiresIn)
 	return &OutboundResult{Action: ActionReplaceToken, Token: resp.AccessToken}
 }
 
@@ -240,16 +270,21 @@ func (a *Auth) handleNoToken(ctx context.Context, audience, scopes string) *Outb
 
 	case NoTokenPolicyClientCredentials:
 		if a.exchanger == nil {
+			a.log.Debug("no token, client_credentials requested but exchanger not configured",
+				"audience", audience)
 			return &OutboundResult{
 				Action:     ActionDeny,
 				DenyStatus: http.StatusServiceUnavailable,
 				DenyReason: "exchanger not configured for client credentials",
 			}
 		}
-		a.log.Debug("no token, falling back to client_credentials")
+		a.log.Debug("no token, falling back to client_credentials",
+			"audience", audience, "scopes", scopes)
 		resp, err := a.exchanger.ClientCredentials(ctx, audience, scopes)
 		if err != nil {
 			a.log.Info("client credentials grant failed", "error", err)
+			a.log.Debug("client credentials failure details",
+				"audience", audience, "scopes", scopes, "error", err)
 			return &OutboundResult{
 				Action:     ActionDeny,
 				DenyStatus: http.StatusServiceUnavailable,
@@ -259,6 +294,8 @@ func (a *Auth) handleNoToken(ctx context.Context, audience, scopes string) *Outb
 		return &OutboundResult{Action: ActionReplaceToken, Token: resp.AccessToken}
 
 	default: // NoTokenDeny or unknown
+		a.log.Debug("no token, policy denies request",
+			"policy", a.noTokenPolicy, "audience", audience)
 		return &OutboundResult{
 			Action:     ActionDeny,
 			DenyStatus: http.StatusUnauthorized,

--- a/authbridge/cmd/authbridge/README.md
+++ b/authbridge/cmd/authbridge/README.md
@@ -162,6 +162,32 @@ Explicit values always take precedence over derived values.
 
 When `client_id_file`, `client_secret_file`, or `jwt_svid_path` are configured, the binary polls for the file to exist (up to 60 seconds) before starting. This handles the startup race with client-registration and spiffe-helper sidecars.
 
+## Logging
+
+AuthBridge uses Go's `slog` structured logger. The log level is configurable at startup and at runtime.
+
+### Set level at startup
+
+Set the `LOG_LEVEL` env var (`debug`, `info`, `warn`, `error`). Default: `info`.
+
+```bash
+# In a deployment
+kubectl set env deployment/weather-service -n team1 -c authbridge-proxy LOG_LEVEL=debug
+
+# Standalone
+LOG_LEVEL=debug authbridge --config /etc/authbridge/config.yaml
+```
+
+### Toggle at runtime (no restart)
+
+Send `SIGUSR1` to toggle between `info` and `debug`:
+
+```bash
+kubectl exec deploy/weather-service -n team1 -c authbridge-proxy -- kill -USR1 1
+```
+
+Send again to toggle back. The current level is logged on each toggle.
+
 ## Architecture
 
 ```

--- a/authbridge/cmd/authbridge/main.go
+++ b/authbridge/cmd/authbridge/main.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"os/signal"
 	"strings"
-	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -51,23 +50,18 @@ func initLogging() {
 }
 
 func startSignalToggle() {
-	// SIGUSR1 toggles between info and debug at runtime.
+	// SIGUSR1 toggles between info and debug at runtime, regardless of
+	// the initial LOG_LEVEL (warn/error are treated as "not debug").
 	// Usage: kubectl exec <pod> -c authbridge-proxy -- kill -USR1 1
-	var debugOn atomic.Bool
-	if logLevel.Level() == slog.LevelDebug {
-		debugOn.Store(true)
-	}
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGUSR1)
 	go func() {
 		for range sigCh {
-			if debugOn.Load() {
+			if logLevel.Level() == slog.LevelDebug {
 				logLevel.Set(slog.LevelInfo)
-				debugOn.Store(false)
 				slog.Info("log level toggled to INFO (send SIGUSR1 to switch back to DEBUG)")
 			} else {
 				logLevel.Set(slog.LevelDebug)
-				debugOn.Store(true)
 				slog.Info("log level toggled to DEBUG (send SIGUSR1 to switch back to INFO)")
 			}
 		}

--- a/authbridge/cmd/authbridge/main.go
+++ b/authbridge/cmd/authbridge/main.go
@@ -12,6 +12,8 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -29,10 +31,56 @@ import (
 	"github.com/kagenti/kagenti-extensions/authbridge/cmd/authbridge/listener/reverseproxy"
 )
 
+// logLevel is the dynamic log level, togglable at runtime via SIGUSR1.
+var logLevel = new(slog.LevelVar)
+
+func initLogging() {
+	// LOG_LEVEL env var sets the initial level: debug, info, warn, error.
+	// Default: info. Override at runtime with SIGUSR1 (toggles debug/info).
+	switch strings.ToLower(os.Getenv("LOG_LEVEL")) {
+	case "debug":
+		logLevel.Set(slog.LevelDebug)
+	case "warn":
+		logLevel.Set(slog.LevelWarn)
+	case "error":
+		logLevel.Set(slog.LevelError)
+	default:
+		logLevel.Set(slog.LevelInfo)
+	}
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevel})))
+}
+
+func startSignalToggle() {
+	// SIGUSR1 toggles between info and debug at runtime.
+	// Usage: kubectl exec <pod> -c authbridge-proxy -- kill -USR1 1
+	var debugOn atomic.Bool
+	if logLevel.Level() == slog.LevelDebug {
+		debugOn.Store(true)
+	}
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGUSR1)
+	go func() {
+		for range sigCh {
+			if debugOn.Load() {
+				logLevel.Set(slog.LevelInfo)
+				debugOn.Store(false)
+				slog.Info("log level toggled to INFO (send SIGUSR1 to switch back to DEBUG)")
+			} else {
+				logLevel.Set(slog.LevelDebug)
+				debugOn.Store(true)
+				slog.Info("log level toggled to DEBUG (send SIGUSR1 to switch back to INFO)")
+			}
+		}
+	}()
+}
+
 func main() {
 	mode := flag.String("mode", "", "deployment mode: envoy-sidecar, waypoint, proxy-sidecar")
 	configPath := flag.String("config", "", "path to config YAML file")
 	flag.Parse()
+
+	initLogging()
+	startSignalToggle()
 
 	if *configPath == "" {
 		log.Fatal("--config is required")
@@ -84,7 +132,7 @@ func main() {
 		log.Fatalf("unhandled mode %q", cfg.Mode)
 	}
 
-	slog.Info("authbridge starting", "mode", cfg.Mode)
+	slog.Info("authbridge starting", "mode", cfg.Mode, "logLevel", logLevel.Level().String())
 
 	// Resolve credentials in background — doesn't block the listener.
 	// Once credential files are available, update the handler's identity


### PR DESCRIPTION
## Summary

- `LOG_LEVEL` env var sets the initial slog level at startup (debug, info, warn, error). Default: info.
- `SIGUSR1` toggles between info and debug at runtime without pod restart.

## Usage

Set at deployment time:
```bash
kubectl set env deployment/weather-service -n team1 -c authbridge-proxy LOG_LEVEL=debug
```

Toggle at runtime (no restart):
```bash
kubectl exec deploy/weather-service -n team1 -c authbridge-proxy -- kill -USR1 1
```

## Design

Single-repo change (kagenti-extensions only). No operator, Helm chart, or backend changes needed — `LOG_LEVEL` is a standard env var that users set via any deployment mechanism.

Uses `slog.LevelVar` for atomic level switching. The SIGUSR1 handler runs in a goroutine and toggles the shared level variable.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>