### PR TITLE
feat(demos): Advanced Weather + AuthBridge demo (token exchange, tool inbound, verify script)

### DIFF
--- a/authbridge/demos/README.md
+++ b/authbridge/demos/README.md
@@ -13,6 +13,7 @@ more AuthBridge capabilities.
 | Demo | Difficulty | What It Shows | Deployment |
 |------|:----------:|---------------|:----------:|
 | **[Weather Agent](weather-agent/demo-ui.md)** | Beginner | Inbound JWT validation, automatic identity registration, outbound passthrough | UI |
+| **[Weather Agent (advanced)](weather-agent/demo-ui-advanced.md)** | Intermediate | Inbound on agent **and** tool, outbound token exchange, ingress JWT verification on the tool | [kubectl + script](weather-agent/demo-ui-advanced.md#automated-deploy-and-verify-ci-oriented) |
 | **[GitHub Issue Agent](github-issue/demo.md)** | Intermediate | Inbound validation + outbound token exchange + scope-based access control | [UI](github-issue/demo-ui.md) or [Manual](github-issue/demo-manual.md) |
 | **[Webhook](webhook/README.md)** | Intermediate | Webhook-based sidecar injection with auth-target demo app | Manual |
 | **[Single Target](single-target/demo.md)** | Advanced | Manual AuthBridge deployment (no webhook) with SPIFFE identity | Manual |
@@ -44,6 +45,14 @@ more AuthBridge capabilities.
 - Automatic SPIFFE identity registration with Keycloak
 - Default outbound passthrough — agents work out-of-the-box with any tool or LLM
 - CLI testing: public endpoints, token rejection, valid token
+
+### Weather Agent (Advanced)
+- Same images as the beginner demo, separate **`*-advanced`** Deployments so the
+  getting-started flow stays untouched
+- Outbound **token exchange** to the tool SPIFFE audience (`authproxy-routes`)
+- AuthBridge **injected on the MCP tool** — JWT checks at Envoy before the tool process
+- `deploy_and_verify_advanced.sh` for reproducible CI-style verification (Keycloak
+  exchange + MCP `initialize` without requiring a working LLM)
 
 ### GitHub Issue Agent (Full AuthBridge Flow)
 - Deploy agent + tool via **Kagenti UI** or **kubectl**

--- a/authbridge/demos/weather-agent/demo-ui-advanced.md
+++ b/authbridge/demos/weather-agent/demo-ui-advanced.md
@@ -249,9 +249,11 @@ verifies **end-to-end** without relying on an LLM:
    the authenticated client and alice’s token as the `subject_token`, with
    `audience` set to the **tool SPIFFE** and scope `openid weather-tool-exchange-aud`.
 3. HTTP `POST` to `http://weather-tool-advanced-mcp:8000/mcp` with a minimal
-   JSON-RPC `initialize` body. **HTTP 401 is a hard failure**; other statuses
-   mean the JWT was accepted at the tool’s AuthBridge ingress (the MCP layer
-   may still return application-level errors).
+   JSON-RPC `initialize` body. The tool uses **streamable HTTP**; send
+   `Accept: application/json, text/event-stream` (otherwise the MCP server
+   often returns **406** even when AuthBridge already accepted the JWT). **HTTP
+   401 is a hard failure**; a **2xx** response means the JWT was accepted and
+   the initialize handshake completed.
 
 Run from anywhere:
 

--- a/authbridge/demos/weather-agent/demo-ui-advanced.md
+++ b/authbridge/demos/weather-agent/demo-ui-advanced.md
@@ -1,0 +1,311 @@
+# Weather Agent — Advanced AuthBridge Demo (UI or kubectl)
+
+This guide is the **advanced** companion to the beginner
+[Weather Agent demo](demo-ui.md). It keeps the same weather agent and MCP tool
+images, but turns on the full platform story:
+
+- **Outbound token exchange** from the agent to the weather tool (RFC 8693),
+  so the tool receives an access token minted for its audience.
+- **AuthBridge on the tool** as well as the agent, so **JWT validation happens at
+  the tool’s Envoy ingress** (ext_proc) before traffic reaches the MCP server.
+- **Audience alignment**: the token exchange `target_audience` is the weather
+  tool’s **SPIFFE-based Keycloak client ID** (the same string written to
+  `/shared/client-id.txt` by client-registration). That matches what AuthBridge
+  expects for inbound JWT `aud`, so you can demonstrate ingress verification
+  without custom application code in the tool.
+
+The beginner [demo-ui.md](demo-ui.md) is unchanged: new users can follow it
+without Keycloak scope tuning or token exchange.
+
+For a UI-driven walkthrough that also covers GitHub PATs and privileged scopes,
+see [GitHub Issue Agent demo-ui](../github-issue/demo-ui.md). This advanced
+weather demo is smaller in scope but hits the same **exchange + validate**
+pattern with a trivial MCP backend.
+
+## What This Demo Shows
+
+1. **Agent identity** — SPIFFE registration with Keycloak for
+   `weather-service-advanced`.
+2. **Inbound validation on the agent** — same as the beginner demo.
+3. **Transparent token exchange** — when the agent calls the tool, AuthBridge
+   exchanges the caller’s token for one whose audience includes the tool’s
+   SPIFFE client ID.
+4. **Inbound validation on the tool** — AuthBridge on the tool pod validates
+   `iss`, signature (JWKS), and `aud` **before** the MCP process sees the
+   request. Logs show `[Inbound]` / `Token validated` on `envoy-proxy` (or the
+   combined `authbridge` container when that feature gate is enabled).
+5. **No GitHub tokens or PATs** — only Keycloak, SPIRE, and public weather APIs.
+
+## Kagenti 0.2+ / current operator (important)
+
+On current platforms, **three things** are required together for the full demo:
+
+1. **`AgentRuntime`** — The mutating webhook **skips** injection unless a matching
+   `agent.kagenti.dev/v1alpha1` `AgentRuntime` exists for the Deployment. Apply
+   `k8s/agentruntime-weather-tool-advanced.yaml` and
+   `k8s/agentruntime-weather-service-advanced.yaml` (the deploy script applies them
+   when the CRD is present) and restart the Deployments so new pods are admitted
+   after the CR exists.
+
+2. **AgentRuntime `spec.type` for the tool** — If `spec.type: tool`, the operator
+   can relabel the pod to `kagenti.io/type: tool`, and the **`injectTools` feature
+   gate** is off by default, so **no AuthBridge** is injected. This demo uses
+   **`spec.type: agent`** for the tool’s `AgentRuntime` so the pod keeps
+   `kagenti.io/type: agent` (the image is still `weather_tool`; only the API
+   classification changes).
+
+3. **`kagenti.io/client-registration-inject: "true"` label** (not annotation) on
+   the **pod template** so the **legacy** `kagenti-client-registration` sidecar
+   runs and registers the SPIFFE client in Keycloak. Without it, the operator’s
+   default is operator-managed registration and `setup_keycloak ... --wait-tool-client`
+   may never see the tool client.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         Kubernetes (e.g. namespace team1)                  │
+│                                                                              │
+│  ┌────────────────────────────────────────────────────────────────────────┐ │
+│  │  weather-service-advanced (agent + AuthBridge + SPIRE)                 │ │
+│  │    Inbound: validate user JWT (aud = agent SPIFFE)                     │ │
+│  │    Outbound: match host weather-tool-advanced-mcp → token exchange       │ │
+│  └───────────────────────────────┬────────────────────────────────────────┘ │
+│                                  │ Bearer: exchanged token (aud ⊇ tool SPIFFE)│
+│                                  ▼                                            │
+│  ┌────────────────────────────────────────────────────────────────────────┐ │
+│  │  weather-tool-advanced (MCP + AuthBridge + SPIRE)                      │ │
+│  │    Inbound: validate exchanged JWT at Envoy / ext_proc                 │ │
+│  │    mcp container: streamable HTTP MCP (port 8000)                        │ │
+│  └────────────────────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+Unlike the GitHub MCP tool, the weather tool listens on **port 8000**. AuthBridge’s
+gRPC ext_proc listener uses **9090 inside the pod**, so there is no port clash
+with the pattern described for `github-tool` on 9090 in the
+[GitHub Issue demo-ui](../github-issue/demo-ui.md).
+
+## Prerequisites
+
+Same platform assumptions as
+[GitHub Issue demo-ui prerequisites](../github-issue/demo-ui.md#prerequisites):
+
+- Kagenti installed with Keycloak (`keycloak` namespace), SPIRE, and the
+  admission webhook that injects AuthBridge.
+- Target namespace (default `team1`) with installer-provided `authbridge-config`,
+  `envoy-config`, `spiffe-helper-config`, and `keycloak-admin-secret`.
+- Python 3.10+ and `pip install -r AuthBridge/requirements.txt` for the Keycloak
+  helper script.
+- For **chat-style** verification: an LLM (Ollama on the host with the model
+  referenced in the Deployment, or OpenAI with keys in a Secret) and outbound
+  port **11434** excluded on the agent (see below).
+
+## Resource Names (kubectl path)
+
+To avoid colliding with an existing beginner `weather-service` /
+`weather-tool`, this demo uses:
+
+| Kind | Name |
+|------|------|
+| Deployments | `weather-tool-advanced`, `weather-service-advanced` |
+| Services | `weather-tool-advanced-mcp` (port 8000), `weather-service-advanced` (8080→8000) |
+| ServiceAccounts | `weather-tool-advanced`, `weather-service-advanced` |
+
+SPIFFE IDs (trust domain `localtest.me`):
+
+- Agent: `spiffe://localtest.me/ns/team1/sa/weather-service-advanced`
+- Tool: `spiffe://localtest.me/ns/team1/sa/weather-tool-advanced`
+
+If you change namespace or ServiceAccount names, update
+`k8s/configmaps-advanced.yaml` (`host`, `target_audience`) and re-run
+`setup_keycloak_weather_advanced.py` with matching `-n`, `-a`, and `-t`.
+
+## Step 1: Keycloak (Python)
+
+From the **AuthBridge** directory (repository path `AuthBridge/`):
+
+```bash
+cd AuthBridge
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+Port-forward Keycloak if you use the default public URL:
+
+```bash
+kubectl port-forward service/keycloak-service -n keycloak 8080:8080
+```
+
+Run setup **after** the tool pod has registered in Keycloak, or pass
+`--wait-tool-client` so the script waits for the tool SPIFFE client:
+
+```bash
+python demos/weather-agent/setup_keycloak_weather_advanced.py \
+  -n team1 \
+  -a weather-service-advanced \
+  -t weather-tool-advanced \
+  --wait-tool-client
+```
+
+Re-run once **after the agent** is running so optional exchange scopes attach to
+the agent’s dynamic client (same pattern as the GitHub demo).
+
+The script:
+
+- Ensures realm default scope `agent-team1-weather-service-advanced-aud` adds the
+  agent SPIFFE to access-token `aud` (UI / alice tokens).
+- Adds optional scope `weather-tool-exchange-aud` with an audience mapper to
+  the **tool SPIFFE** (used during token exchange).
+- Enables `standard.token.exchange.enabled` on the tool (and agent) Keycloak
+  clients once they exist.
+
+## Step 2: ConfigMap (authproxy-routes)
+
+```bash
+kubectl apply -f AuthBridge/demos/weather-agent/k8s/configmaps-advanced.yaml
+```
+
+If you are not using `team1`, edit `metadata.namespace` and the `target_audience`
+SPIFFE string first.
+
+## Step 3: Deploy Tool, Then Agent
+
+```bash
+kubectl apply -f AuthBridge/demos/weather-agent/k8s/weather-tool-advanced.yaml
+kubectl rollout status deployment/weather-tool-advanced -n team1 --timeout=300s
+
+python demos/weather-agent/setup_keycloak_weather_advanced.py \
+  -n team1 --wait-tool-client
+
+kubectl apply -f AuthBridge/demos/weather-agent/k8s/weather-service-advanced.yaml
+kubectl rollout status deployment/weather-service-advanced -n team1 --timeout=420s
+
+python demos/weather-agent/setup_keycloak_weather_advanced.py -n team1
+```
+
+### Ollama and outbound port exclusion
+
+The sample agent manifest sets `LLM_API_BASE` to `host.docker.internal:11434` and
+annotates the pod with `kagenti.io/outbound-ports-exclude: "11434"`. If you
+import through the UI instead, set **Outbound Ports to Exclude** to `11434` the
+same way as in [demo-ui.md](demo-ui.md#ollama-port-exclusion).
+
+## Step 4 (Optional): Kagenti UI
+
+You can mirror the GitHub Issue UI flow with these substitutions:
+
+- **Tool**: enable **AuthBridge sidecar injection** and **SPIRE**; image
+  `ghcr.io/kagenti/agent-examples/weather_tool`; streamable HTTP; Service name
+  pattern ending in `-mcp` that matches the `host` entry in
+  `configmaps-advanced.yaml`.
+- **Agent**: image `ghcr.io/kagenti/agent-examples/weather_service`;
+  `MCP_URL` pointing at the advanced MCP service;
+  `authproxy-routes` list shape as in
+  [Kagenti version notes](../github-issue/demo-ui.md#kagenti-version-notes-ui-import-and-authbridge).
+
+If the UI backend cannot yet express the route list, apply
+`k8s/configmaps-advanced.yaml` with kubectl and avoid duplicating routes in the UI.
+
+## Step 5: Verify Manually
+
+### Pods
+
+```bash
+kubectl get pods -n team1 | grep advanced
+# Expect 4/4 (or combined sidecar variant) for both workloads when injection is on.
+```
+
+### Tool ingress logs
+
+```bash
+kubectl logs deployment/weather-tool-advanced -n team1 -c envoy-proxy 2>&1 | grep "\[Inbound\]"
+# or -c authbridge when combinedSidecar is enabled
+```
+
+### Agent outbound exchange logs
+
+```bash
+kubectl logs deployment/weather-service-advanced -n team1 -c envoy-proxy 2>&1 | grep -E "Resolver|exchange|Injecting token"
+```
+
+### CLI token + A2A
+
+Follow [demo-ui.md — Step 6](demo-ui.md#step-6-test-via-cli), but use:
+
+- Service: `weather-service-advanced:8080`
+- SPIFFE / client lookup: `spiffe://localtest.me/ns/team1/sa/weather-service-advanced`
+
+## Automated Deploy and Verify (CI-oriented)
+
+The script **`deploy_and_verify_advanced.sh`** applies the manifests, runs the
+Keycloak setup (including waiting for the tool client), waits for rollouts, and
+verifies **end-to-end** without relying on an LLM:
+
+1. Password grant for user **alice** (create `alice` / `alice123` if missing —
+   the setup script creates her).
+2. RFC 8693 token exchange using the **agent** Keycloak client credentials as
+   the authenticated client and alice’s token as the `subject_token`, with
+   `audience` set to the **tool SPIFFE** and scope `openid weather-tool-exchange-aud`.
+3. HTTP `POST` to `http://weather-tool-advanced-mcp:8000/mcp` with a minimal
+   JSON-RPC `initialize` body. **HTTP 401 is a hard failure**; other statuses
+   mean the JWT was accepted at the tool’s AuthBridge ingress (the MCP layer
+   may still return application-level errors).
+
+Run from anywhere:
+
+```bash
+./AuthBridge/demos/weather-agent/deploy_and_verify_advanced.sh
+```
+
+Environment variables:
+
+| Variable | Purpose |
+|----------|---------|
+| `NAMESPACE` | Target namespace (default `team1`) |
+| `SKIP_DEPLOY=1` | Only run verification (resources must already exist) |
+| `KC_INTERNAL` | Keycloak base URL inside the cluster (default `http://keycloak-service.keycloak.svc:8080`) |
+| `KC_USER_CLIENT_ID` | Realm public client for password grant (default **`weather-advanced-e2e`**, created by the Keycloak script; the `kagenti` UI client often has direct access grants disabled) |
+| `KC_USER_CLIENT_SECRET` | Set only if the password client is confidential |
+| `KEYCLOAK_ADMIN_USERNAME` / `KEYCLOAK_ADMIN_PASSWORD` | For admin REST calls from the verify pod |
+
+The script also **warns** if it cannot find obvious inbound/outbound log markers
+(lines differ slightly when `combinedSidecar` is enabled).
+
+## Cleanup
+
+```bash
+kubectl delete deployment -n team1 \
+  weather-service-advanced weather-tool-advanced --ignore-not-found
+kubectl delete svc -n team1 \
+  weather-service-advanced weather-tool-advanced-mcp --ignore-not-found
+kubectl delete sa -n team1 \
+  weather-service-advanced weather-tool-advanced --ignore-not-found
+```
+
+Keycloak clients for the SPIFFE IDs can be removed from the admin console if you
+no longer need them.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Mitigation |
+|---------|--------------|------------|
+| Tool pod **CrashLoopBackOff** (container `mcp`) | The `weather_tool` image runs as **UID 1001**; a `securityContext` that forces a different UID (e.g. only `runAsNonRoot: true` with a project-assigned user on OpenShift, or a mismatch with `chown`ed `/app` in the image) prevents `uv run` from reading the app tree | The manifests set **`runAsUser` / `runAsGroup` / `fsGroup: 1001`** to match the [upstream Dockerfile](https://github.com/kagenti/agent-examples/blob/main/mcp/weather_tool/Dockerfile). Re-apply `weather-tool-advanced.yaml`. If it still fails, run `kubectl logs -n team1 deploy/weather-tool-advanced -c mcp --previous` and `kubectl describe pod` for OOMKilled or `CreateContainerError`. |
+| `invalid_scope` / 503 on agent | Optional exchange scope not on agent client | Re-run `setup_keycloak_weather_advanced.py` after the agent is running |
+| `invalid audience` / 401 on agent | Default agent audience scope missing on UI client | Re-run setup; log out and back in to the UI |
+| 401 on tool MCP | Wrong `target_audience` or scope mapper | `target_audience` must equal tool SPIFFE; scope `weather-tool-exchange-aud` must map that audience |
+| Token exchange denied | Tool Keycloak client missing `standard.token.exchange.enabled` | Re-run setup with `--wait-tool-client` after the tool pod registers |
+| No `[Inbound]` log line | Combined sidecar logging format | Grep for `Token validated` or increase log window |
+
+See also the operational table in the AuthBridge testing skill used for this repo.
+
+## Related Files
+
+| File | Role |
+|------|------|
+| [k8s/configmaps-advanced.yaml](k8s/configmaps-advanced.yaml) | `authproxy-routes` for token exchange |
+| [k8s/weather-tool-advanced.yaml](k8s/weather-tool-advanced.yaml) | Tool Deployment + Service + SA |
+| [k8s/weather-service-advanced.yaml](k8s/weather-service-advanced.yaml) | Agent Deployment + Service + SA |
+| [setup_keycloak_weather_advanced.py](setup_keycloak_weather_advanced.py) | Keycloak realm tuning |
+| [deploy_and_verify_advanced.sh](deploy_and_verify_advanced.sh) | One-shot deploy + CI-style verification |

--- a/authbridge/demos/weather-agent/demo-ui-advanced.md
+++ b/authbridge/demos/weather-agent/demo-ui-advanced.md
@@ -254,6 +254,9 @@ verifies **end-to-end** without relying on an LLM:
    often returns **406** even when AuthBridge already accepted the JWT). **HTTP
    401 is a hard failure**; a **2xx** response means the JWT was accepted and
    the initialize handshake completed.
+4. The same `initialize` request **without** an `Authorization` header must
+   return **401** (AuthBridge rejects the call before the MCP app runs).
+   `deploy_and_verify_advanced.sh` checks this as a negative test.
 
 Run from anywhere:
 

--- a/authbridge/demos/weather-agent/demo-ui.md
+++ b/authbridge/demos/weather-agent/demo-ui.md
@@ -9,7 +9,9 @@ This is the recommended **getting-started** demo for AuthBridge. It demonstrates
 inbound JWT validation and automatic identity registration with a simple agent
 that doesn't require token exchange. For a more advanced demo showing outbound
 token exchange and scope-based access control, see the
-[GitHub Issue Agent demo](../github-issue/demo.md).
+[GitHub Issue Agent demo](../github-issue/demo.md). For the same weather images
+with **token exchange and AuthBridge on the tool** (plus a CI-style verify script),
+see [Weather Agent — Advanced](demo-ui-advanced.md).
 
 ## What This Demo Shows
 

--- a/authbridge/demos/weather-agent/deploy_and_verify_advanced.sh
+++ b/authbridge/demos/weather-agent/deploy_and_verify_advanced.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# Deploy the Weather advanced AuthBridge demo and verify Keycloak token exchange
+# plus MCP ingress JWT validation on the tool.
+#
+# Prerequisites:
+#   - kubectl configured for a cluster with Kagenti + Keycloak + SPIRE + webhook
+#   - Namespace team1 (or override NAMESPACE) with installer ConfigMaps
+#   - jq installed on the machine running this script
+#   - Python 3.10+ with AuthBridge/requirements.txt (for setup_keycloak_weather_advanced.py)
+#   - Optional: Ollama on the host with the model from weather-service-advanced for full A2A
+#
+# Usage:
+#   ./deploy_and_verify_advanced.sh
+#   NAMESPACE=team1 ./deploy_and_verify_advanced.sh
+#   SKIP_DEPLOY=1 ./deploy_and_verify_advanced.sh    # verify only (resources must exist)
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AUTHBRIDGE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+NAMESPACE="${NAMESPACE:-team1}"
+SKIP_DEPLOY="${SKIP_DEPLOY:-0}"
+AGENT_SA="${AGENT_SA:-weather-service-advanced}"
+TOOL_SA="${TOOL_SA:-weather-tool-advanced}"
+SPIFFE_DOMAIN="${SPIFFE_DOMAIN:-localtest.me}"
+TOOL_SPIFFE="spiffe://${SPIFFE_DOMAIN}/ns/${NAMESPACE}/sa/${TOOL_SA}"
+AGENT_SPIFFE="spiffe://${SPIFFE_DOMAIN}/ns/${NAMESPACE}/sa/${AGENT_SA}"
+KC_INTERNAL="${KC_INTERNAL:-http://keycloak-service.keycloak.svc:8080}"
+KC_REALM="${KC_REALM:-kagenti}"
+# Default matches client created by setup_keycloak_weather_advanced.py (kagenti UI
+# client often has direct access grants disabled).
+KC_USER_CLIENT_ID="${KC_USER_CLIENT_ID:-weather-advanced-e2e}"
+# For confidential "kagenti" UI client, set KC_USER_CLIENT_SECRET in the environment.
+
+log() { printf '%s\n' "$*"; }
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+need_cmd() { command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"; }
+
+need_cmd kubectl
+need_cmd jq
+need_cmd curl
+
+if [[ "$SKIP_DEPLOY" != "1" ]]; then
+  log "Applying authproxy-routes ConfigMap..."
+  kubectl apply -f "$SCRIPT_DIR/k8s/configmaps-advanced.yaml"
+
+  log "Deploying weather tool (advanced)..."
+  kubectl apply -f "$SCRIPT_DIR/k8s/weather-tool-advanced.yaml"
+  log "Applying AgentRuntime (required in Kagenti 0.2+ for AuthBridge injection)..."
+  if kubectl get crd agentruntimes.agent.kagenti.dev &>/dev/null; then
+    kubectl apply -f "$SCRIPT_DIR/k8s/agentruntime-weather-tool-advanced.yaml"
+    log "Recreating tool pods so the webhook can inject now that AgentRuntime exists..."
+    kubectl rollout restart "deployment/weather-tool-advanced" -n "$NAMESPACE"
+  else
+    log "WARNING: agentruntimes.agent.kagenti.dev CRD not found — sidecars may not inject."
+  fi
+  kubectl rollout status "deployment/weather-tool-advanced" -n "$NAMESPACE" --timeout=300s
+
+  log "Running Keycloak setup (wait for tool client + enable token exchange)..."
+  (
+    cd "$AUTHBRIDGE_ROOT"
+    if [[ ! -d venv ]]; then
+      python3 -m venv venv
+    fi
+    # shellcheck disable=SC1091
+    source venv/bin/activate
+    pip install -q -r requirements.txt
+    python demos/weather-agent/setup_keycloak_weather_advanced.py \
+      -n "$NAMESPACE" \
+      -a "$AGENT_SA" \
+      -t "$TOOL_SA" \
+      --wait-tool-client \
+      --tool-client-timeout 300
+  )
+
+  log "Deploying weather agent (advanced)..."
+  kubectl apply -f "$SCRIPT_DIR/k8s/weather-service-advanced.yaml"
+  if kubectl get crd agentruntimes.agent.kagenti.dev &>/dev/null; then
+    kubectl apply -f "$SCRIPT_DIR/k8s/agentruntime-weather-service-advanced.yaml"
+    kubectl rollout restart "deployment/weather-service-advanced" -n "$NAMESPACE"
+  fi
+  kubectl rollout status "deployment/weather-service-advanced" -n "$NAMESPACE" --timeout=420s
+
+  log "Re-running Keycloak setup so the agent client receives optional exchange scopes..."
+  (
+    cd "$AUTHBRIDGE_ROOT"
+    # shellcheck disable=SC1091
+    source venv/bin/activate
+    python demos/weather-agent/setup_keycloak_weather_advanced.py \
+      -n "$NAMESPACE" \
+      -a "$AGENT_SA" \
+      -t "$TOOL_SA"
+  )
+else
+  log "SKIP_DEPLOY=1 — assuming ConfigMaps and Deployments already exist"
+fi
+
+log "Discovering AuthBridge log container name (envoy-proxy vs combined authbridge)..."
+ADV_TOOL_POD=$(kubectl get pods -n "$NAMESPACE" -l app.kubernetes.io/name=weather-tool-advanced \
+  -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+[[ -n "$ADV_TOOL_POD" ]] || die "no weather-tool-advanced pod found"
+
+ADV_AGENT_POD=$(kubectl get pods -n "$NAMESPACE" -l app.kubernetes.io/name=weather-service-advanced \
+  -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+[[ -n "$ADV_AGENT_POD" ]] || die "no weather-service-advanced pod found"
+
+pick_log_container() {
+  local pod=$1
+  local names
+  names=$(kubectl get pod -n "$NAMESPACE" "$pod" -o jsonpath='{.spec.containers[*].name}' | tr ' ' '\n')
+  if echo "$names" | grep -qx 'envoy-proxy'; then
+    echo envoy-proxy
+  elif echo "$names" | grep -qx 'authbridge'; then
+    echo authbridge
+  else
+    die "pod $pod has neither envoy-proxy nor authbridge container ($names)"
+  fi
+}
+
+TOOL_LOG_C=$(pick_log_container "$ADV_TOOL_POD")
+AGENT_LOG_C=$(pick_log_container "$ADV_AGENT_POD")
+log "Using log containers: tool=$TOOL_LOG_C agent=$AGENT_LOG_C"
+
+log "Running in-cluster verification (Keycloak + MCP) via netshoot..."
+VERIFY_SCRIPT=$(cat <<VERIFYEOS
+set -euo pipefail
+KC_INTERNAL='${KC_INTERNAL}'
+KC_REALM='${KC_REALM}'
+AGENT_SPIFFE='${AGENT_SPIFFE}'
+TOOL_SPIFFE='${TOOL_SPIFFE}'
+KC_USER_CLIENT_ID='${KC_USER_CLIENT_ID}'
+KC_USER_CLIENT_SECRET='${KC_USER_CLIENT_SECRET:-}'
+ADMIN_USER='${KEYCLOAK_ADMIN_USERNAME:-admin}'
+ADMIN_PASS='${KEYCLOAK_ADMIN_PASSWORD:-admin}'
+
+echo "Fetching admin token..."
+ADMIN_TOKEN=\$(curl -sS -X POST "\${KC_INTERNAL}/realms/master/protocol/openid-connect/token" \\
+  -d "grant_type=password" -d "client_id=admin-cli" \\
+  -d "username=\${ADMIN_USER}" -d "password=\${ADMIN_PASS}" | jq -r .access_token)
+test -n "\$ADMIN_TOKEN" && test "\$ADMIN_TOKEN" != "null"
+
+echo "Resolving agent client id..."
+CLIENT_JSON=\$(curl -sS -G "\${KC_INTERNAL}/admin/realms/\${KC_REALM}/clients" \\
+  -H "Authorization: Bearer \${ADMIN_TOKEN}" --data-urlencode "clientId=\${AGENT_SPIFFE}")
+AGENT_CLIENT_UUID=\$(echo "\$CLIENT_JSON" | jq -r '.[0].id // empty')
+test -n "\$AGENT_CLIENT_UUID"
+
+echo "Reading agent client secret..."
+SECRET_JSON=\$(curl -sS "\${KC_INTERNAL}/admin/realms/\${KC_REALM}/clients/\${AGENT_CLIENT_UUID}/client-secret" \\
+  -H "Authorization: Bearer \${ADMIN_TOKEN}")
+AGENT_CLIENT_SECRET=\$(echo "\$SECRET_JSON" | jq -r '.value // empty')
+test -n "\$AGENT_CLIENT_SECRET"
+
+echo "Password grant (alice)..."
+if test -n "\$KC_USER_CLIENT_SECRET"; then
+  USER_JSON=\$(curl -sS -u "\${KC_USER_CLIENT_ID}:\${KC_USER_CLIENT_SECRET}" -X POST \\
+    "\${KC_INTERNAL}/realms/\${KC_REALM}/protocol/openid-connect/token" \\
+    -d "grant_type=password" -d "username=alice" -d "password=alice123")
+else
+  USER_JSON=\$(curl -sS -X POST "\${KC_INTERNAL}/realms/\${KC_REALM}/protocol/openid-connect/token" \\
+    -d "grant_type=password" -d "client_id=\${KC_USER_CLIENT_ID}" \\
+    -d "username=alice" -d "password=alice123")
+fi
+USER_ACCESS=\$(echo "\$USER_JSON" | jq -r .access_token)
+if test -z "\$USER_ACCESS" || test "\$USER_ACCESS" = "null"; then
+  echo "\$USER_JSON" | jq . >&2 || true
+  echo "alice password grant failed" >&2
+  exit 1
+fi
+
+echo "RFC 8693 token exchange to tool SPIFFE audience..."
+# Use form client_id + client_secret (Keycloak rejects Basic auth usernames with '/' in SPIFFE).
+EXCHANGE_JSON=\$(curl -sS -X POST "\${KC_INTERNAL}/realms/\${KC_REALM}/protocol/openid-connect/token" \\
+  -H "Content-Type: application/x-www-form-urlencoded" \\
+  --data-urlencode "client_id=\${AGENT_SPIFFE}" \\
+  --data-urlencode "client_secret=\${AGENT_CLIENT_SECRET}" \\
+  --data-urlencode "grant_type=urn:ietf:params:oauth:grant-type:token-exchange" \\
+  --data-urlencode "requested_token_type=urn:ietf:params:oauth:token-type:access_token" \\
+  --data-urlencode "subject_token=\${USER_ACCESS}" \\
+  --data-urlencode "subject_token_type=urn:ietf:params:oauth:token-type:access_token" \\
+  --data-urlencode "audience=\${TOOL_SPIFFE}" \\
+  --data-urlencode "scope=openid weather-tool-exchange-aud")
+EXCHANGED=\$(echo "\$EXCHANGE_JSON" | jq -r .access_token)
+if test -z "\$EXCHANGED" || test "\$EXCHANGED" = "null"; then
+  echo "\$EXCHANGE_JSON" | jq . >&2 || true
+  echo "token exchange failed" >&2
+  exit 1
+fi
+
+echo "POST /mcp with exchanged token (expect not 401)..."
+HTTP_CODE=\$(curl -sS -o /tmp/mcp.body -w '%{http_code}' \\
+  -H "Authorization: Bearer \${EXCHANGED}" \\
+  -H "Content-Type: application/json" \\
+  -X POST "http://weather-tool-advanced-mcp:8000/mcp" \\
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"verify","version":"0.1"}}}')
+echo "MCP_HTTP_CODE=\${HTTP_CODE}"
+if test "\$HTTP_CODE" = "401"; then
+  echo "MCP returned 401" >&2
+  exit 1
+fi
+VERIFYEOS
+)
+
+VERIFY_B64=$(printf '%s' "$VERIFY_SCRIPT" | base64 | tr -d '\n')
+kubectl run "adv-verify-$$" --rm -i --restart=Never -n "$NAMESPACE" \
+  --image=nicolaka/netshoot:latest \
+  --command -- bash -lc "echo '${VERIFY_B64}' | base64 -d | bash" | tee /tmp/adv-verify.out
+
+grep -q 'MCP_HTTP_CODE=' /tmp/adv-verify.out || die "verify pod produced no MCP_HTTP_CODE line"
+HTTP_CODE=$(grep 'MCP_HTTP_CODE=' /tmp/adv-verify.out | tail -1 | cut -d= -f2)
+if [[ "$HTTP_CODE" == "401" ]]; then
+  die "MCP returned 401 — tool AuthBridge rejected the exchanged token"
+fi
+log "MCP HTTP status: ${HTTP_CODE} (non-401 means JWT was accepted at ingress)"
+
+log "Checking tool AuthBridge logs for successful inbound validation..."
+sleep 3
+TOOL_LOGS=$(kubectl logs -n "$NAMESPACE" "$ADV_TOOL_POD" -c "$TOOL_LOG_C" 2>&1 | tail -400 || true)
+if echo "$TOOL_LOGS" | grep -qE "Token validated|\[Inbound\]"; then
+  log "OK: found inbound validation log line on weather-tool-advanced."
+else
+  log "WARNING: could not find '[Inbound]' / 'Token validated' in recent tool logs (combined sidecar may use different text)."
+fi
+
+log "Checking agent AuthBridge logs for token exchange / outbound activity..."
+AGENT_LOGS=$(kubectl logs -n "$NAMESPACE" "$ADV_AGENT_POD" -c "$AGENT_LOG_C" 2>&1 | tail -400 || true)
+if echo "$AGENT_LOGS" | grep -qE "Resolver|exchange|Injecting token|Client Credentials"; then
+  log "OK: found outbound / exchange related log line on weather-service-advanced."
+else
+  log "WARNING: no obvious outbound exchange markers in recent agent logs (traffic may not have occurred yet)."
+fi
+
+log "SUCCESS: deploy_and_verify_advanced.sh completed."

--- a/authbridge/demos/weather-agent/deploy_and_verify_advanced.sh
+++ b/authbridge/demos/weather-agent/deploy_and_verify_advanced.sh
@@ -207,6 +207,19 @@ if ! [[ \${HTTP_CODE} =~ ^2[0-9][0-9]\$ ]]; then
   head -c 2000 /tmp/mcp.body >&2 || true
   exit 1
 fi
+
+echo "POST /mcp without Authorization (expect 401 from AuthBridge)..."
+NEG_CODE=\$(curl -sS -o /tmp/mcp.neg -w '%{http_code}' \\
+  -H "Content-Type: application/json" \\
+  -H "Accept: application/json, text/event-stream" \\
+  -X POST "http://weather-tool-advanced-mcp:8000/mcp" \\
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"verify-neg","version":"0.1"}}}')
+echo "MCP_NEG_HTTP_CODE=\${NEG_CODE}"
+if test "\$NEG_CODE" != "401"; then
+  echo "expected HTTP 401 without bearer token, got \${NEG_CODE}" >&2
+  head -c 2000 /tmp/mcp.neg >&2 || true
+  exit 1
+fi
 VERIFYEOS
 )
 
@@ -224,6 +237,13 @@ if ! [[ "$HTTP_CODE" =~ ^2[0-9][0-9]$ ]]; then
   die "MCP returned HTTP $HTTP_CODE — expected 2xx after initialize (401=auth, 406=missing Accept: application/json, text/event-stream)"
 fi
 log "MCP HTTP status: ${HTTP_CODE} (2xx: JWT accepted at ingress and streamable HTTP handshake OK)"
+
+grep -q 'MCP_NEG_HTTP_CODE=' /tmp/adv-verify.out || die "verify pod produced no MCP_NEG_HTTP_CODE line"
+NEG_HTTP_CODE=$(grep 'MCP_NEG_HTTP_CODE=' /tmp/adv-verify.out | tail -1 | cut -d= -f2)
+if [[ "$NEG_HTTP_CODE" != "401" ]]; then
+  die "negative check: without Authorization, expected HTTP 401 from tool ingress, got $NEG_HTTP_CODE"
+fi
+log "Negative check: unauthenticated MCP request returned 401 (expected)"
 
 log "Checking tool AuthBridge logs for successful inbound validation..."
 sleep 3

--- a/authbridge/demos/weather-agent/deploy_and_verify_advanced.sh
+++ b/authbridge/demos/weather-agent/deploy_and_verify_advanced.sh
@@ -188,15 +188,23 @@ if test -z "\$EXCHANGED" || test "\$EXCHANGED" = "null"; then
   exit 1
 fi
 
-echo "POST /mcp with exchanged token (expect not 401)..."
+echo "POST /mcp with exchanged token (streamable HTTP; expect 2xx)..."
+# FastMCP streamable transport rejects requests unless the client advertises support
+# for both JSON and SSE (HTTP 406 otherwise).
 HTTP_CODE=\$(curl -sS -o /tmp/mcp.body -w '%{http_code}' \\
   -H "Authorization: Bearer \${EXCHANGED}" \\
   -H "Content-Type: application/json" \\
+  -H "Accept: application/json, text/event-stream" \\
   -X POST "http://weather-tool-advanced-mcp:8000/mcp" \\
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"verify","version":"0.1"}}}')
 echo "MCP_HTTP_CODE=\${HTTP_CODE}"
 if test "\$HTTP_CODE" = "401"; then
   echo "MCP returned 401" >&2
+  exit 1
+fi
+if ! [[ \${HTTP_CODE} =~ ^2[0-9][0-9]\$ ]]; then
+  echo "MCP returned HTTP \${HTTP_CODE}" >&2
+  head -c 2000 /tmp/mcp.body >&2 || true
   exit 1
 fi
 VERIFYEOS
@@ -212,7 +220,10 @@ HTTP_CODE=$(grep 'MCP_HTTP_CODE=' /tmp/adv-verify.out | tail -1 | cut -d= -f2)
 if [[ "$HTTP_CODE" == "401" ]]; then
   die "MCP returned 401 — tool AuthBridge rejected the exchanged token"
 fi
-log "MCP HTTP status: ${HTTP_CODE} (non-401 means JWT was accepted at ingress)"
+if ! [[ "$HTTP_CODE" =~ ^2[0-9][0-9]$ ]]; then
+  die "MCP returned HTTP $HTTP_CODE — expected 2xx after initialize (401=auth, 406=missing Accept: application/json, text/event-stream)"
+fi
+log "MCP HTTP status: ${HTTP_CODE} (2xx: JWT accepted at ingress and streamable HTTP handshake OK)"
 
 log "Checking tool AuthBridge logs for successful inbound validation..."
 sleep 3

--- a/authbridge/demos/weather-agent/deploy_and_verify_advanced.sh
+++ b/authbridge/demos/weather-agent/deploy_and_verify_advanced.sh
@@ -225,7 +225,7 @@ VERIFYEOS
 
 VERIFY_B64=$(printf '%s' "$VERIFY_SCRIPT" | base64 | tr -d '\n')
 kubectl run "adv-verify-$$" --rm -i --restart=Never -n "$NAMESPACE" \
-  --image=nicolaka/netshoot:latest \
+  --image=nicolaka/netshoot:v0.15 \
   --command -- bash -lc "echo '${VERIFY_B64}' | base64 -d | bash" | tee /tmp/adv-verify.out
 
 grep -q 'MCP_HTTP_CODE=' /tmp/adv-verify.out || die "verify pod produced no MCP_HTTP_CODE line"

--- a/authbridge/demos/weather-agent/k8s/agentruntime-weather-service-advanced.yaml
+++ b/authbridge/demos/weather-agent/k8s/agentruntime-weather-service-advanced.yaml
@@ -1,0 +1,12 @@
+# AgentRuntime for the weather A2A agent (AuthBridge + SPIRE injection).
+apiVersion: agent.kagenti.dev/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: weather-service-advanced
+  namespace: team1
+spec:
+  type: agent
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: weather-service-advanced

--- a/authbridge/demos/weather-agent/k8s/agentruntime-weather-tool-advanced.yaml
+++ b/authbridge/demos/weather-agent/k8s/agentruntime-weather-tool-advanced.yaml
@@ -1,0 +1,19 @@
+# Binds the weather-tool-advanced Deployment to the platform AuthBridge injection
+# path. The mutating webhook skips sidecars unless a matching AgentRuntime exists
+# (Kagenti 0.2+ / operator chart with pod-mutator).
+#
+# Apply after weather-tool-advanced.yaml (same namespace).
+apiVersion: agent.kagenti.dev/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: weather-tool-advanced
+  namespace: team1
+# Use type "agent" so the operator does not force pod labels to kagenti.io/type=tool
+# (which skips injection when the injectTools feature gate is off). The workload
+# is still the MCP `weather_tool` by container image and Deployment name.
+spec:
+  type: agent
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: weather-tool-advanced

--- a/authbridge/demos/weather-agent/k8s/configmaps-advanced.yaml
+++ b/authbridge/demos/weather-agent/k8s/configmaps-advanced.yaml
@@ -3,11 +3,17 @@
 # Apply after the Kagenti platform has created the namespace and baseline
 # authbridge-config / envoy-config / spiffe-helper-config ConfigMaps.
 #
-# The authbridge-config patch below mirrors authbridge/demos/github-issue/k8s/configmaps.yaml
-# and adds explicit TOKEN_URL / JWKS_URL. Without TOKEN_URL, the ext_proc build used with
-# envoy-with-processor can log "inbound JWT validation disabled" and allow unauthenticated
-# requests to /mcp (HTTP 200). After applying, restart the weather deployment so pods pick
-# up the new environment variables.
+# `kubectl apply` replaces the entire `authbridge-config` ConfigMap. The `data` below
+# therefore **includes the same keys** as `charts/kagenti/templates/agent-namespaces.yaml`
+# in the kagenti repo (defaults: keycloak in `keycloak` namespace, realm `kagenti`, split
+# horizon `publicUrl`), plus the demo's explicit TOKEN_URL / JWKS_URL for the ext_proc
+# go-processor. If your install overrides `authBridge.clientAuthType`, `keycloak.publicUrl`,
+# or similar, merge those values into this manifest before applying.
+#
+# The advanced demo also adds explicit TOKEN_URL / JWKS_URL. Without TOKEN_URL, the ext_proc
+# build used with envoy-with-processor can log "inbound JWT validation disabled" and allow
+# unauthenticated requests to /mcp (HTTP 200). After applying, restart the weather
+# deployment so pods pick up the new environment variables.
 #
 # The host value must match the HTTP Host header the agent uses when calling
 # the MCP service — use the short Kubernetes Service name from MCP_URL.
@@ -26,10 +32,17 @@ metadata:
   name: authbridge-config
   namespace: team1
 data:
+  # — Same baseline keys as kagenti chart (agent-namespaces authbridge-config) —
   KEYCLOAK_URL: "http://keycloak-service.keycloak.svc:8080"
   KEYCLOAK_REALM: "kagenti"
+  KEYCLOAK_NAMESPACE: "keycloak"
   ISSUER: "http://keycloak.localtest.me:8080/realms/kagenti"
   SPIRE_ENABLED: "true"
+  CLIENT_AUTH_TYPE: "client-secret"
+  SPIFFE_IDP_ALIAS: "spire-spiffe"
+  JWT_AUDIENCE: "http://keycloak.localtest.me:8080/realms/kagenti"
+  EXPECTED_AUDIENCE: "http://keycloak.localtest.me:8080/realms/kagenti"
+  # — Weather advanced: explicit token + JWKS (ext_proc) —
   TOKEN_URL: "http://keycloak-service.keycloak.svc:8080/realms/kagenti/protocol/openid-connect/token"
   JWKS_URL: "http://keycloak-service.keycloak.svc:8080/realms/kagenti/protocol/openid-connect/certs"
 ---

--- a/authbridge/demos/weather-agent/k8s/configmaps-advanced.yaml
+++ b/authbridge/demos/weather-agent/k8s/configmaps-advanced.yaml
@@ -1,0 +1,45 @@
+# AuthBridge overrides for the Weather advanced demo (token exchange to tool).
+#
+# Apply after the Kagenti platform has created the namespace and baseline
+# authbridge-config / envoy-config / spiffe-helper-config ConfigMaps.
+#
+# The authbridge-config patch below mirrors authbridge/demos/github-issue/k8s/configmaps.yaml
+# and adds explicit TOKEN_URL / JWKS_URL. Without TOKEN_URL, the ext_proc build used with
+# envoy-with-processor can log "inbound JWT validation disabled" and allow unauthenticated
+# requests to /mcp (HTTP 200). After applying, restart the weather deployment so pods pick
+# up the new environment variables.
+#
+# The host value must match the HTTP Host header the agent uses when calling
+# the MCP service — use the short Kubernetes Service name from MCP_URL.
+#
+# target_audience is the weather tool Keycloak client ID, which equals its
+# SPIFFE ID once client-registration has run (ServiceAccount: weather-tool-advanced).
+#
+# Usage:
+#   kubectl apply -f configmaps-advanced.yaml
+#   kubectl rollout restart deploy/weather-tool-advanced -n team1
+#
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authbridge-config
+  namespace: team1
+data:
+  KEYCLOAK_URL: "http://keycloak-service.keycloak.svc:8080"
+  KEYCLOAK_REALM: "kagenti"
+  ISSUER: "http://keycloak.localtest.me:8080/realms/kagenti"
+  SPIRE_ENABLED: "true"
+  TOKEN_URL: "http://keycloak-service.keycloak.svc:8080/realms/kagenti/protocol/openid-connect/token"
+  JWKS_URL: "http://keycloak-service.keycloak.svc:8080/realms/kagenti/protocol/openid-connect/certs"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authproxy-routes
+  namespace: team1
+data:
+  routes.yaml: |
+    - host: "weather-tool-advanced-mcp"
+      target_audience: "spiffe://localtest.me/ns/team1/sa/weather-tool-advanced"
+      token_scopes: "openid weather-tool-exchange-aud"

--- a/authbridge/demos/weather-agent/k8s/weather-service-advanced.yaml
+++ b/authbridge/demos/weather-agent/k8s/weather-service-advanced.yaml
@@ -1,0 +1,116 @@
+# Weather A2A agent with AuthBridge + SPIRE and outbound token exchange to the
+# advanced weather tool (see configmaps-advanced.yaml and setup_keycloak_weather_advanced.py).
+#
+# Ollama on the host: set LLM_* env vars for your cluster. Port 11434 must be
+# excluded from AuthBridge interception (annotation below).
+#
+# Usage:
+#   kubectl apply -f weather-service-advanced.yaml
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: weather-service-advanced
+  namespace: team1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: weather-service-advanced
+  namespace: team1
+  labels:
+    app.kubernetes.io/name: weather-service-advanced
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: weather-service-advanced
+  template:
+    metadata:
+      labels:
+        kagenti.io/type: agent
+        protocol.kagenti.io/a2a: ""
+        app.kubernetes.io/name: weather-service-advanced
+        kagenti.io/inject: enabled
+        kagenti.io/spire: enabled
+        kagenti.io/client-registration-inject: "true"
+      annotations:
+        kagenti.io/outbound-ports-exclude: "11434"
+    spec:
+      serviceAccountName: weather-service-advanced
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: agent
+          image: ghcr.io/kagenti/agent-examples/weather_service:latest
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: cache
+              mountPath: /app/.cache
+            - name: marvin
+              mountPath: /.marvin
+          ports:
+            - containerPort: 8000
+              name: http
+          env:
+            - name: PORT
+              value: "8000"
+            - name: HOST
+              value: "0.0.0.0"
+            - name: UV_CACHE_DIR
+              value: "/app/.cache"
+            - name: MCP_URL
+              value: "http://weather-tool-advanced-mcp:8000/mcp"
+            # Default to host Ollama (Kind / Docker Desktop). Override for OpenAI.
+            - name: LLM_API_BASE
+              value: "http://host.docker.internal:11434/v1"
+            - name: LLM_API_KEY
+              value: "ollama"
+            - name: LLM_MODEL
+              value: "llama3.2:3b-instruct-fp16"
+            - name: LOG_LEVEL
+              value: "INFO"
+          readinessProbe:
+            tcpSocket:
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 30
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+      volumes:
+        - name: cache
+          emptyDir: {}
+        - name: marvin
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: weather-service-advanced
+  namespace: team1
+  labels:
+    app.kubernetes.io/name: weather-service-advanced
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: weather-service-advanced
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8000
+      protocol: TCP

--- a/authbridge/demos/weather-agent/k8s/weather-tool-advanced.yaml
+++ b/authbridge/demos/weather-agent/k8s/weather-tool-advanced.yaml
@@ -1,0 +1,123 @@
+# Weather MCP tool with AuthBridge + SPIRE (inbound JWT at Envoy before the MCP server).
+#
+# Prerequisites: Kagenti platform, webhook, SPIRE, namespace team1, ConfigMaps
+# from the installer (authbridge-config, envoy-config, spiffe-helper-config).
+#
+# The MCP server listens on port 8000. AuthBridge ext_proc listens on 9090
+# inside the pod, so there is no port collision (unlike the GitHub tool on 9090).
+#
+# The kagenti AuthBridge mutating webhook only injects sidecars for pod labels
+# kagenti.io/type: agent (see AuthBridge/demos/webhook/README.md). This workload is
+# still the weather MCP tool by image and name; the pod is labeled as agent so
+# client-registration runs and registers the tool SPIFFE in Keycloak.
+#
+# Usage:
+#   kubectl apply -f weather-tool-advanced.yaml
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: weather-tool-advanced
+  namespace: team1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: weather-tool-advanced
+  namespace: team1
+  labels:
+    app.kubernetes.io/name: weather-tool-advanced
+    app.kubernetes.io/component: mcp-tool
+    protocol.kagenti.io/mcp: ""
+    kagenti.io/transport: streamable_http
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: weather-tool-advanced
+  template:
+    metadata:
+      labels:
+        # SPIFFE → Keycloak client sidecar (label, not annotation — see kagenti backend constants)
+        kagenti.io/client-registration-inject: "true"
+        # Required for AuthBridge + SPIRE injection (webhook does not match type=tool)
+        kagenti.io/type: agent
+        app.kubernetes.io/name: weather-tool-advanced
+        app.kubernetes.io/component: mcp-tool
+        protocol.kagenti.io/mcp: ""
+        kagenti.io/transport: streamable_http
+        kagenti.io/inject: enabled
+        kagenti.io/spire: enabled
+    spec:
+      serviceAccountName: weather-tool-advanced
+      # Must match the image (Dockerfile USER 1001). Pod-level runAsNonRoot alone can
+      # leave the process with a different UID (e.g. namespace range), breaking
+      # read/execute of files under /app and causing CrashLoopBackOff.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: mcp
+          image: ghcr.io/kagenti/agent-examples/weather_tool:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: PORT
+              value: "8000"
+            - name: HOST
+              value: "0.0.0.0"
+            - name: UV_NO_CACHE
+              value: "1"
+          ports:
+            - containerPort: 8000
+              name: http
+              protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 24
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: false
+          volumeMounts:
+            - name: cache
+              mountPath: /app/.cache
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: cache
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: weather-tool-advanced-mcp
+  namespace: team1
+  labels:
+    app.kubernetes.io/name: weather-tool-advanced
+    protocol.kagenti.io/mcp: ""
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: weather-tool-advanced
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+      protocol: TCP

--- a/authbridge/demos/weather-agent/setup_keycloak_weather_advanced.py
+++ b/authbridge/demos/weather-agent/setup_keycloak_weather_advanced.py
@@ -1,0 +1,374 @@
+"""
+setup_keycloak_weather_advanced.py — Keycloak setup for the Weather Agent
+advanced AuthBridge demo (outbound token exchange + AuthBridge on the tool).
+
+Token exchange targets the weather tool's OAuth client ID, which matches its
+SPIFFE ID (written to /shared/client-id.txt by client-registration). That way
+tokens arriving at the tool pass AuthBridge inbound audience checks.
+
+Usage:
+  cd AuthBridge && source venv/bin/activate && pip install -r requirements.txt
+  python demos/weather-agent/setup_keycloak_weather_advanced.py
+
+  python demos/weather-agent/setup_keycloak_weather_advanced.py --wait-tool-client
+
+Security: uses default Keycloak admin credentials for local demos only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+
+from keycloak import KeycloakAdmin, KeycloakGetError, KeycloakPostError
+
+KEYCLOAK_URL = os.environ.get("KEYCLOAK_URL", "http://keycloak.localtest.me:8080")
+KEYCLOAK_REALM = os.environ.get("KEYCLOAK_REALM", "kagenti")
+KEYCLOAK_ADMIN_USERNAME = os.environ.get("KEYCLOAK_ADMIN_USERNAME", "admin")
+KEYCLOAK_ADMIN_PASSWORD = os.environ.get("KEYCLOAK_ADMIN_PASSWORD", "admin")
+
+SPIFFE_TRUST_DOMAIN = "localtest.me"
+UI_CLIENT_ID = os.environ.get("UI_CLIENT_ID", "kagenti")
+
+# Public client for automated tests (password grant) — the UI client often has
+# direct access grants disabled.
+E2E_PASSWORD_CLIENT_ID = "weather-advanced-e2e"
+
+DEMO_USER = {
+    "username": "alice",
+    "email": "alice@example.com",
+    "firstName": "Alice",
+    "lastName": "Demo",
+    "password": "alice123",
+}
+
+
+def get_spiffe_id(namespace: str, service_account: str) -> str:
+    return f"spiffe://{SPIFFE_TRUST_DOMAIN}/ns/{namespace}/sa/{service_account}"
+
+
+def get_or_create_realm(keycloak_admin, realm_name: str) -> None:
+    realms = keycloak_admin.get_realms()
+    for realm in realms:
+        if realm["realm"] == realm_name:
+            print(f"Realm '{realm_name}' already exists.")
+            return
+    keycloak_admin.create_realm({"realm": realm_name, "enabled": True, "displayName": realm_name})
+    print(f"Created realm '{realm_name}'.")
+
+
+def get_or_create_client_scope(keycloak_admin, scope_payload: dict) -> str:
+    scope_name = scope_payload.get("name")
+    scopes = keycloak_admin.get_client_scopes()
+    for scope in scopes:
+        if scope["name"] == scope_name:
+            print(f"Client scope '{scope_name}' already exists (id={scope['id']}).")
+            return scope["id"]
+    scope_id = keycloak_admin.create_client_scope(scope_payload)
+    print(f"Created client scope '{scope_name}': {scope_id}")
+    return scope_id
+
+
+def add_audience_mapper(keycloak_admin, scope_id: str, mapper_name: str, audience: str) -> None:
+    mapper_payload = {
+        "name": mapper_name,
+        "protocol": "openid-connect",
+        "protocolMapper": "oidc-audience-mapper",
+        "consentRequired": False,
+        "config": {
+            "included.custom.audience": audience,
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "false",
+        },
+    }
+    try:
+        keycloak_admin.add_mapper_to_client_scope(scope_id, mapper_payload)
+        print(f"Added audience mapper '{mapper_name}' for audience '{audience}'")
+    except Exception as e:
+        print(f"Note: could not add mapper '{mapper_name}' (may already exist): {e}")
+
+
+def get_or_create_client(keycloak_admin, client_payload: dict) -> str:
+    client_id = client_payload["clientId"]
+    internal_id = keycloak_admin.get_client_id(client_id)
+    if internal_id:
+        print(f"Client '{client_id}' already exists.")
+        return internal_id
+    internal_id = keycloak_admin.create_client(client_payload)
+    print(f"Created client '{client_id}'.")
+    return internal_id
+
+
+def get_or_create_user(keycloak_admin, user_config: dict) -> str:
+    username = user_config["username"]
+    users = keycloak_admin.get_users({"username": username})
+    existing = next((u for u in users if u.get("username") == username), None)
+    if existing:
+        print(f"User '{username}' already exists.")
+        return existing["id"]
+    user_id = keycloak_admin.create_user(
+        {
+            "username": username,
+            "email": user_config["email"],
+            "firstName": user_config["firstName"],
+            "lastName": user_config["lastName"],
+            "enabled": True,
+            "emailVerified": True,
+            "credentials": [
+                {
+                    "type": "password",
+                    "value": user_config["password"],
+                    "temporary": False,
+                }
+            ],
+        }
+    )
+    print(f"Created user '{username}' with id={user_id}")
+    return user_id
+
+
+def enable_token_exchange_on_client(keycloak_admin, client_identifier: str) -> bool:
+    """Enable standard OAuth token exchange for a realm client (by clientId string)."""
+    internal_id = keycloak_admin.get_client_id(client_identifier)
+    if not internal_id:
+        return False
+    try:
+        client = keycloak_admin.get_client(internal_id)
+        attrs = dict(client.get("attributes") or {})
+        if attrs.get("standard.token.exchange.enabled") == "true":
+            print(f"Token exchange already enabled for client '{client_identifier}'.")
+            return True
+        attrs["standard.token.exchange.enabled"] = "true"
+        keycloak_admin.update_client(internal_id, {"attributes": attrs})
+        print(f"Enabled token exchange for client '{client_identifier}'.")
+        return True
+    except Exception as e:
+        print(f"Note: could not enable token exchange on '{client_identifier}': {e}")
+        return False
+
+
+def wait_for_client(keycloak_admin, client_identifier: str, timeout_s: int = 300) -> bool:
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if keycloak_admin.get_client_id(client_identifier):
+            print(f"Keycloak client '{client_identifier}' is present.")
+            return True
+        print(f"Waiting for Keycloak client '{client_identifier}' ... ({int(deadline - time.time())}s left)")
+        time.sleep(5)
+    return False
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Keycloak setup for Weather advanced AuthBridge demo")
+    parser.add_argument("-n", "--namespace", default="team1", help="Kubernetes namespace")
+    parser.add_argument(
+        "-a",
+        "--agent-service-account",
+        default="weather-service-advanced",
+        help="Agent ServiceAccount name (SPIFFE sa segment)",
+    )
+    parser.add_argument(
+        "-t",
+        "--tool-service-account",
+        default="weather-tool-advanced",
+        help="Tool ServiceAccount name (SPIFFE sa segment)",
+    )
+    parser.add_argument(
+        "--wait-tool-client",
+        action="store_true",
+        help="Wait until the tool's SPIFFE client is registered in Keycloak",
+    )
+    parser.add_argument(
+        "--tool-client-timeout",
+        type=int,
+        default=300,
+        help="Seconds to wait for tool client when --wait-tool-client is set",
+    )
+    args = parser.parse_args()
+
+    ns = args.namespace
+    agent_sa = args.agent_service_account
+    tool_sa = args.tool_service_account
+    agent_spiffe = get_spiffe_id(ns, agent_sa)
+    tool_spiffe = get_spiffe_id(ns, tool_sa)
+
+    if KEYCLOAK_ADMIN_USERNAME == "admin" and KEYCLOAK_ADMIN_PASSWORD == "admin":
+        print(
+            "WARNING: Using default Keycloak admin credentials. Not for production.",
+            file=sys.stderr,
+        )
+
+    print("=" * 72)
+    print("Weather Agent (advanced) — Keycloak setup")
+    print("=" * 72)
+    print(f"Namespace:     {ns}")
+    print(f"Agent SPIFFE:  {agent_spiffe}")
+    print(f"Tool SPIFFE:   {tool_spiffe}")
+
+    print(f"\nConnecting to Keycloak at {KEYCLOAK_URL} ...")
+    try:
+        master_admin = KeycloakAdmin(
+            server_url=KEYCLOAK_URL,
+            username=KEYCLOAK_ADMIN_USERNAME,
+            password=KEYCLOAK_ADMIN_PASSWORD,
+            realm_name="master",
+            user_realm_name="master",
+        )
+    except Exception as e:
+        print(f"Failed to connect to Keycloak: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    get_or_create_realm(master_admin, KEYCLOAK_REALM)
+
+    keycloak_admin = KeycloakAdmin(
+        server_url=KEYCLOAK_URL,
+        username=KEYCLOAK_ADMIN_USERNAME,
+        password=KEYCLOAK_ADMIN_PASSWORD,
+        realm_name=KEYCLOAK_REALM,
+        user_realm_name="master",
+    )
+
+    # --- Agent audience (realm default): tokens for the agent include agent SPIFFE in aud ---
+    agent_aud_scope_name = f"agent-{ns}-{agent_sa}-aud"
+    print(f"\n--- Client scope: {agent_aud_scope_name} ---")
+    agent_aud_scope_id = get_or_create_client_scope(
+        keycloak_admin,
+        {
+            "name": agent_aud_scope_name,
+            "protocol": "openid-connect",
+            "attributes": {
+                "include.in.token.scope": "true",
+                "display.on.consent.screen": "true",
+            },
+        },
+    )
+    add_audience_mapper(keycloak_admin, agent_aud_scope_id, agent_aud_scope_name, agent_spiffe)
+
+    try:
+        keycloak_admin.add_default_default_client_scope(agent_aud_scope_id)
+        print(f"Added '{agent_aud_scope_name}' as realm default client scope.")
+    except Exception as e:
+        print(f"Note: could not add realm default scope '{agent_aud_scope_name}': {e}")
+
+    # --- Optional scope: adds tool SPIFFE to exchanged tokens ---
+    exchange_scope_name = "weather-tool-exchange-aud"
+    print(f"\n--- Client scope: {exchange_scope_name} (optional) ---")
+    exchange_scope_id = get_or_create_client_scope(
+        keycloak_admin,
+        {
+            "name": exchange_scope_name,
+            "protocol": "openid-connect",
+            "attributes": {
+                "include.in.token.scope": "true",
+                "display.on.consent.screen": "true",
+            },
+        },
+    )
+    add_audience_mapper(
+        keycloak_admin,
+        exchange_scope_id,
+        f"{exchange_scope_name}-mapper",
+        tool_spiffe,
+    )
+    try:
+        keycloak_admin.add_default_optional_client_scope(exchange_scope_id)
+        print(f"Added '{exchange_scope_name}' as realm OPTIONAL client scope.")
+    except Exception as e:
+        print(f"Note: could not add optional scope '{exchange_scope_name}': {e}")
+
+    # --- E2E public client (password grant for deploy_and_verify_advanced.sh) ---
+    print(f"\n--- E2E client '{E2E_PASSWORD_CLIENT_ID}' (password grant) ---")
+    get_or_create_client(
+        keycloak_admin,
+        {
+            "clientId": E2E_PASSWORD_CLIENT_ID,
+            "name": "Weather advanced E2E (direct access grants)",
+            "enabled": True,
+            "publicClient": True,
+            "standardFlowEnabled": True,
+            "directAccessGrantsEnabled": True,
+        },
+    )
+    e2e_internal = keycloak_admin.get_client_id(E2E_PASSWORD_CLIENT_ID)
+    if e2e_internal:
+        try:
+            keycloak_admin.add_client_default_client_scope(e2e_internal, agent_aud_scope_id, {})
+            print(f"Added '{agent_aud_scope_name}' as default scope on '{E2E_PASSWORD_CLIENT_ID}'.")
+        except Exception as e:
+            print(f"Note: could not add default scope to E2E client: {e}")
+
+    # --- UI client: ensure tokens include agent audience ---
+    print(f"\n--- UI client '{UI_CLIENT_ID}' ---")
+    ui_internal = keycloak_admin.get_client_id(UI_CLIENT_ID)
+    if ui_internal:
+        try:
+            keycloak_admin.add_client_default_client_scope(ui_internal, agent_aud_scope_id, {})
+            print(f"Added '{agent_aud_scope_name}' as default scope on UI client.")
+        except Exception as e:
+            print(f"Note: could not add default scope to UI client: {e}")
+    else:
+        print(f"Warning: UI client '{UI_CLIENT_ID}' not found.")
+
+    # --- Tool client: token exchange target must allow exchange ---
+    if args.wait_tool_client:
+        if not wait_for_client(keycloak_admin, tool_spiffe, timeout_s=args.tool_client_timeout):
+            print(f"Timeout waiting for tool client '{tool_spiffe}'.", file=sys.stderr)
+            sys.exit(1)
+    if keycloak_admin.get_client_id(tool_spiffe):
+        enable_token_exchange_on_client(keycloak_admin, tool_spiffe)
+    else:
+        print(
+            f"\nNote: tool client '{tool_spiffe}' not registered yet. "
+            "Deploy the tool pod, then re-run this script with --wait-tool-client "
+            "or run again after the tool registers."
+        )
+
+    # --- Agent dynamic client (if already registered) ---
+    print("\n--- Agent Keycloak client (if registered) ---")
+    agent_internal = keycloak_admin.get_client_id(agent_spiffe)
+    if agent_internal:
+        enable_token_exchange_on_client(keycloak_admin, agent_spiffe)
+        try:
+            keycloak_admin.add_client_default_client_scope(agent_internal, agent_aud_scope_id, {})
+            print(f"Added '{agent_aud_scope_name}' as default on agent client.")
+        except Exception as e:
+            print(f"Note: could not add default scope on agent client: {e}")
+        for name, sid in [(exchange_scope_name, exchange_scope_id)]:
+            try:
+                keycloak_admin.add_client_optional_client_scope(agent_internal, sid, {})
+                print(f"Added '{name}' as optional scope on agent client.")
+            except Exception as e:
+                print(f"Note: could not add optional '{name}' on agent client: {e}")
+    else:
+        print(
+            f"Agent client '{agent_spiffe}' not found yet. "
+            "Deploy the agent, then re-run this script so optional exchange scopes apply."
+        )
+
+    # --- Demo user ---
+    print("\n--- Demo user ---")
+    get_or_create_user(keycloak_admin, DEMO_USER)
+    try:
+        uid = keycloak_admin.get_user_id(DEMO_USER["username"])
+        keycloak_admin.set_user_password(uid, DEMO_USER["password"], temporary=False)
+        print("Ensured password for 'alice' (for E2E password grant).")
+    except Exception as e:
+        print(f"Note: could not set password for alice: {e}")
+    try:
+        admin_role = keycloak_admin.get_realm_role("admin")
+        uid = keycloak_admin.get_user_id(DEMO_USER["username"])
+        keycloak_admin.assign_realm_roles(uid, [admin_role])
+        print("Assigned realm role 'admin' to 'alice'.")
+    except (KeycloakGetError, KeycloakPostError, TypeError) as e:
+        print(f"Note: could not assign admin role to alice: {e}")
+
+    print("\n" + "=" * 72)
+    print("SETUP COMPLETE")
+    print("=" * 72)
+
+
+if __name__ == "__main__":
+    main()

--- a/authbridge/demos/weather-agent/setup_keycloak_weather_advanced.py
+++ b/authbridge/demos/weather-agent/setup_keycloak_weather_advanced.py
@@ -32,9 +32,9 @@ KEYCLOAK_ADMIN_PASSWORD = os.environ.get("KEYCLOAK_ADMIN_PASSWORD", "admin")
 SPIFFE_TRUST_DOMAIN = "localtest.me"
 UI_CLIENT_ID = os.environ.get("UI_CLIENT_ID", "kagenti")
 
-# Public client for automated tests (password grant) — the UI client often has
-# direct access grants disabled.
-E2E_PASSWORD_CLIENT_ID = "weather-advanced-e2e"
+# Public client for automated tests (ROPC / direct access) — the UI client often
+# has direct access grants disabled.
+E2E_ROPC_CLIENT_ID = "weather-advanced-e2e"
 
 DEMO_USER = {
     "username": "alice",
@@ -279,12 +279,12 @@ def main() -> None:
     except Exception as e:
         print(f"Note: could not add optional scope '{exchange_scope_name}': {e}")
 
-    # --- E2E public client (password grant for deploy_and_verify_advanced.sh) ---
-    print(f"\n--- E2E client '{E2E_PASSWORD_CLIENT_ID}' (password grant) ---")
+    # --- E2E public client (ROPC for deploy_and_verify_advanced.sh) ---
+    print(f"\n--- E2E client '{E2E_ROPC_CLIENT_ID}' (ROPC / direct access) ---")
     get_or_create_client(
         keycloak_admin,
         {
-            "clientId": E2E_PASSWORD_CLIENT_ID,
+            "clientId": E2E_ROPC_CLIENT_ID,
             "name": "Weather advanced E2E (direct access grants)",
             "enabled": True,
             "publicClient": True,
@@ -292,11 +292,11 @@ def main() -> None:
             "directAccessGrantsEnabled": True,
         },
     )
-    e2e_internal = keycloak_admin.get_client_id(E2E_PASSWORD_CLIENT_ID)
+    e2e_internal = keycloak_admin.get_client_id(E2E_ROPC_CLIENT_ID)
     if e2e_internal:
         try:
             keycloak_admin.add_client_default_client_scope(e2e_internal, agent_aud_scope_id, {})
-            print(f"Added '{agent_aud_scope_name}' as default scope on '{E2E_PASSWORD_CLIENT_ID}'.")
+            print(f"Added '{agent_aud_scope_name}' as default scope on '{E2E_ROPC_CLIENT_ID}'.")
         except Exception as e:
             print(f"Note: could not add default scope to E2E client: {e}")
 
@@ -354,9 +354,9 @@ def main() -> None:
     try:
         uid = keycloak_admin.get_user_id(DEMO_USER["username"])
         keycloak_admin.set_user_password(uid, DEMO_USER["password"], temporary=False)
-        print("Ensured password for 'alice' (for E2E password grant).")
+        print("Ensured demo user 'alice' credential (for E2E ROPC / direct access).")
     except Exception as e:
-        print(f"Note: could not set password for alice: {e}")
+        print(f"Note: could not update user credential for alice: {e}")
     try:
         admin_role = keycloak_admin.get_realm_role("admin")
         uid = keycloak_admin.get_user_id(DEMO_USER["username"])


### PR DESCRIPTION
## Merge order (downstream)

**Merge this PR first.** The main platform CI work is in a follow-up:

- **Downstream:** [kagenti/kagenti#1313](https://github.com/kagenti/kagenti/pull/1313) adds Kind E2E (`.github/scripts/kind/91-run-authbridge-weather-e2e.sh`) that clones **kagenti-extensions** at `main` and runs `authbridge/demos/weather-agent/deploy_and_verify_advanced.sh`. That job **requires** the files and paths added in **this** PR to exist on `main`.

Do **not** merge kagenti #1313 until **this** PR (#343) is merged to `kagenti/kagenti-extensions` `main` (or the downstream workflow will fail on missing `deploy_and_verify_advanced.sh`).

---

## Summary

Adds an **intermediate** "Weather advanced" path alongside the existing UI beginner doc: same images, **separate `*-advanced` Deployments**, **inbound** AuthBridge on **agent and tool**, **outbound** token exchange to the tool’s SPIFFE audience, Keycloak setup, k8s manifests, and a **CI-style** in-cluster verify script.

## What’s included

- `authbridge/demos/weather-agent/demo-ui-advanced.md` — full walkthrough, troubleshooting, and links to assets.
- `authbridge/demos/weather-agent/setup_keycloak_weather_advanced.py` — realm clients/scopes, optional `--wait-tool-client`, `weather-advanced-e2e` for password grant.
- `authbridge/demos/weather-agent/k8s/*` — tool + service deployments, `AgentRuntime` CRs, `configmaps-advanced.yaml` (**`authbridge-config` with `TOKEN_URL` + `JWKS_URL` + `authproxy-routes`**) so ext_proc does not skip inbound JWT on `/mcp`.
- `authbridge/demos/weather-agent/deploy_and_verify_advanced.sh` — admin API → agent secret → password grant → RFC 8693 exchange → `POST /mcp`; `SKIP_DEPLOY=1` for verify-only; log heuristics for inbound/outbound.
- `authbridge/demos/README.md` — new row + "Weather (advanced)" in the narrative.
- `authbridge/demos/weather-agent/demo-ui.md` — link to the advanced doc.

## How to test

- From `authbridge/demos/weather-agent`: run `./deploy_and_verify_advanced.sh` (or `SKIP_DEPLOY=1` if already deployed).
- Unauthenticated `curl` to `weather-tool-advanced-mcp:8000/mcp` should return **401** when inbound is enforced; `MCP_HTTP_CODE=406` in the script is treated as **non-401 = JWT accepted** at ingress.

## Notes for reviewers

- `configmaps-advanced.yaml` **replaces/merges** `authbridge-config` in the namespace; operators using Helm may want the same keys in values long-term to avoid drift.
- Agent log "outbound" warning in the script is **heuristic** when no agent traffic was generated during the test window.
