### PR TITLE
Feat: Support gRPC Reflection API

### DIFF
--- a/authbridge/cmd/authbridge/main.go
+++ b/authbridge/cmd/authbridge/main.go
@@ -195,6 +195,7 @@ func startGRPCExtAuthz(handler *auth.Auth, addr string) *grpc.Server {
 	srv := grpc.NewServer()
 	authv3.RegisterAuthorizationServer(srv, &extauthz.Server{Auth: handler})
 	registerHealth(srv)
+	reflection.Register(srv)
 
 	go func() {
 		lis, err := net.Listen("tcp", addr)

--- a/authbridge/cmd/authbridge/main.go
+++ b/authbridge/cmd/authbridge/main.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
 
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/auth"
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/config"
@@ -175,6 +176,7 @@ func startGRPCExtProc(handler *auth.Auth, addr string) *grpc.Server {
 	srv := grpc.NewServer()
 	extprocv3.RegisterExternalProcessorServer(srv, &extproc.Server{Auth: handler})
 	registerHealth(srv)
+	reflection.Register(srv)
 
 	go func() {
 		lis, err := net.Listen("tcp", addr)


### PR DESCRIPTION
## Summary

Resolves #338

## (Optional) Testing Instructions

Start AuthBridge (either locally using the mechanism of #340 or by port-forwarding a running agent's sidecar)

```
grpcurl --plaintext localhost:9090 list

envoy.service.ext_proc.v3.ExternalProcessor
grpc.health.v1.Health
grpc.reflection.v1.ServerReflection
grpc.reflection.v1alpha.ServerReflection

grpcurl --plaintext localhost:9090 describe envoy.service.ext_proc.v3.ExternalProcessor
envoy.service.ext_proc.v3.ExternalProcessor is a service:
service ExternalProcessor {
  rpc Process ( stream .envoy.service.ext_proc.v3.ProcessingRequest ) returns ( stream .envoy.service.ext_proc.v3.ProcessingResponse );
}
```