### PR TITLE
authbridge(weather): fix Kind E2E (Deployment progress deadline)

### DIFF
--- a/authbridge/demos/weather-agent/deploy_and_verify_advanced.sh
+++ b/authbridge/demos/weather-agent/deploy_and_verify_advanced.sh
@@ -15,9 +15,10 @@
 #   SKIP_DEPLOY=1 ./deploy_and_verify_advanced.sh    # verify only (resources must exist)
 #
 # Timeouts (optional, for slow clusters / GitHub Kind: image pull + many sidecars):
-#   WEATHER_TOOL_ROLLOUT_TIMEOUT  kubectl rollout status for the tool (default: 900s)
-#   WEATHER_AGENT_ROLLOUT_TIMEOUT kubectl rollout status for the agent (default: 600s)
-#   WEATHER_TOOL_KC_CLIENT_SEC    setup_keycloak --tool-client-timeout, seconds (default: 600)
+#   WEATHER_TOOL_ROLLOUT_TIMEOUT  kubectl rollout status for the tool (default: 1800s;
+#                                 should be >= spec.progressDeadlineSeconds in the YAML)
+#   WEATHER_AGENT_ROLLOUT_TIMEOUT kubectl rollout status for the agent (default: 1800s)
+#   WEATHER_TOOL_KC_CLIENT_SEC    setup_keycloak --tool-client-timeout, seconds (default: 900)
 #
 set -euo pipefail
 
@@ -37,11 +38,11 @@ KC_REALM="${KC_REALM:-kagenti}"
 KC_USER_CLIENT_ID="${KC_USER_CLIENT_ID:-weather-advanced-e2e}"
 # For confidential "kagenti" UI client, set KC_USER_CLIENT_SECRET in the environment.
 #
-# Rollout: defaults are higher than 5m so Kind CI (cold ghcr.io pulls + 4+ containers) does
-# not fail on kubectl rollout status. Override when testing on fast clusters.
-WEATHER_TOOL_ROLLOUT_TIMEOUT="${WEATHER_TOOL_ROLLOUT_TIMEOUT:-900s}"
-WEATHER_AGENT_ROLLOUT_TIMEOUT="${WEATHER_AGENT_ROLLOUT_TIMEOUT:-600s}"
-WEATHER_TOOL_KC_CLIENT_SEC="${WEATHER_TOOL_KC_CLIENT_SEC:-600}"
+# Rollout: align with spec.progressDeadlineSeconds: 1800 on the tool/agent Deployments (Kind
+# can exceed 600s default) and with kubectl --timeout below.
+WEATHER_TOOL_ROLLOUT_TIMEOUT="${WEATHER_TOOL_ROLLOUT_TIMEOUT:-1800s}"
+WEATHER_AGENT_ROLLOUT_TIMEOUT="${WEATHER_AGENT_ROLLOUT_TIMEOUT:-1800s}"
+WEATHER_TOOL_KC_CLIENT_SEC="${WEATHER_TOOL_KC_CLIENT_SEC:-900}"
 
 log() { printf '%s\n' "$*"; }
 die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }

--- a/authbridge/demos/weather-agent/k8s/weather-service-advanced.yaml
+++ b/authbridge/demos/weather-agent/k8s/weather-service-advanced.yaml
@@ -21,6 +21,8 @@ metadata:
   labels:
     app.kubernetes.io/name: weather-service-advanced
 spec:
+  # Match tool deployment: slow Kind rollouts can hit the 600s default.
+  progressDeadlineSeconds: 1800
   replicas: 1
   selector:
     matchLabels:

--- a/authbridge/demos/weather-agent/k8s/weather-service-advanced.yaml
+++ b/authbridge/demos/weather-agent/k8s/weather-service-advanced.yaml
@@ -24,6 +24,8 @@ spec:
   # Match tool deployment: slow Kind rollouts can hit the 600s default.
   progressDeadlineSeconds: 1800
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: weather-service-advanced

--- a/authbridge/demos/weather-agent/k8s/weather-tool-advanced.yaml
+++ b/authbridge/demos/weather-agent/k8s/weather-tool-advanced.yaml
@@ -35,6 +35,10 @@ spec:
   # sidecars in Kind can exceed that before the old ReplicaSet pod drains.
   progressDeadlineSeconds: 1800
   replicas: 1
+  # Default RollingUpdate can leave the new pod Pending (Insufficient cpu) on a
+  # single Kind node while the old multi-sidecar pod still runs. Recreate serializes.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: weather-tool-advanced

--- a/authbridge/demos/weather-agent/k8s/weather-tool-advanced.yaml
+++ b/authbridge/demos/weather-agent/k8s/weather-tool-advanced.yaml
@@ -31,6 +31,9 @@ metadata:
     protocol.kagenti.io/mcp: ""
     kagenti.io/transport: streamable_http
 spec:
+  # Default Deployment progress deadline is 600s; cold ghcr + webhook restart + many
+  # sidecars in Kind can exceed that before the old ReplicaSet pod drains.
+  progressDeadlineSeconds: 1800
   replicas: 1
   selector:
     matchLabels:


### PR DESCRIPTION
The **AuthBridge Weather (advanced) E2E** job on Kind was still failing with `deployment ... exceeded its progress deadline` (~600s) while the controller waited on old ReplicaSet termination and cold image pulls.

**Change**
- Set `spec.progressDeadlineSeconds: 1800` on the advanced **tool** and **agent** Deployments.
- Raise default `kubectl rollout status` waits and `--tool-client-timeout` in `deploy_and_verify_advanced.sh` to match (1800s / 1800s / 900s).

A matching update to the kagenti Kind wrapper script (`91-run-authbridge-weather-e2e.sh`) is on the kagenti PR that consumes this. Merge **kagenti-extensions** first, then re-run the failing workflow on kagenti.