### PR TITLE
fix: Pin cryptography<47 to fix ARM64 crash in client-registration

### DIFF
--- a/authbridge/client-registration/requirements.txt
+++ b/authbridge/client-registration/requirements.txt
@@ -1,3 +1,4 @@
 python-keycloak==7.1.1
 pyjwt==2.12.1
+# cryptography 47.0.0 causes Illegal Instruction (SIGILL) on ARM64 when importing cryptography.hazmat.primitives
 cryptography<47

--- a/authbridge/client-registration/requirements.txt
+++ b/authbridge/client-registration/requirements.txt
@@ -1,2 +1,3 @@
- python-keycloak==7.1.1
- pyjwt==2.12.1
+python-keycloak==7.1.1
+pyjwt==2.12.1
+cryptography<47


### PR DESCRIPTION
## Summary
- `cryptography` 47.0.0 causes `Illegal Instruction (SIGILL)` on ARM64 when importing `cryptography.hazmat.primitives`
- This breaks client-registration on ARM64 Kind clusters — the container crashes before writing `/shared/client-secret.txt`
- Without the secret, authbridge falls back to empty config and inbound JWT validation fails with "aud not satisfied"
- Pin `cryptography<47` in requirements.txt (resolves to 46.x which works on ARM64)

## Root cause
`python-keycloak` → `jwcrypto` → `cryptography` → native Rust/C extension. The 47.0.0 release ships ARM64 wheels with instructions not available on all ARM64 platforms (confirmed: crashes under Kind on Apple Silicon).

## Verification
```bash
# Before fix (alpha.7):
podman run --rm --platform linux/arm64 ghcr.io/kagenti/kagenti-extensions/client-registration:v0.5.0-alpha.7   python -c "from cryptography.hazmat.primitives.ciphers import Cipher"
# Exit code 132 (SIGILL)

# After fix:
podman build --platform linux/arm64 -t test:fix authbridge/client-registration/
podman run --rm --platform linux/arm64 test:fix   python -c "from cryptography.hazmat.primitives.ciphers import Cipher; import keycloak; print('ok')"
# ok
```

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>