### PR TITLE
fix: Correct ext_proc body-phase responses and enable allow_mode_override

### DIFF
--- a/authbridge/authproxy/Dockerfile.init
+++ b/authbridge/authproxy/Dockerfile.init
@@ -1,8 +1,10 @@
 FROM docker.io/library/alpine:3.23
 
-# Installs both iptables-legacy and iptables-nft; init-iptables.sh auto-detects
-# the correct backend at runtime (prefers legacy for Kind/kubeadm compatibility)
-RUN apk add --no-cache iptables
+# Install both iptables-nft and iptables-legacy; init-iptables.sh auto-detects
+# the correct backend at runtime (prefers legacy for Kind/kubeadm compatibility).
+# The separate 'iptables-legacy' package is required — Alpine's base 'iptables'
+# only provides nft binaries since Alpine 3.20+.
+RUN apk add --no-cache iptables iptables-legacy
 
 COPY init-iptables.sh /usr/local/bin/init-iptables.sh
 

--- a/authbridge/authproxy/k8s/auth-proxy-deployment.yaml
+++ b/authbridge/authproxy/k8s/auth-proxy-deployment.yaml
@@ -190,6 +190,7 @@ data:
                     envoy_grpc:
                       cluster_name: ext_proc_cluster
                     timeout: 30s
+                  allow_mode_override: true
                   processing_mode:
                     request_header_mode: SEND
                     response_header_mode: SKIP
@@ -242,6 +243,7 @@ data:
                     envoy_grpc:
                       cluster_name: ext_proc_cluster
                     timeout: 30s
+                  allow_mode_override: true
                   processing_mode:
                     request_header_mode: SEND
                     response_header_mode: SKIP

--- a/authbridge/cmd/authbridge/listener/extproc/server.go
+++ b/authbridge/cmd/authbridge/listener/extproc/server.go
@@ -63,7 +63,7 @@ func (s *Server) Process(stream extprocv3.ExternalProcessor_ProcessServer) error
 				p = s.InboundPipeline
 			}
 
-			if p.NeedsBody() {
+			if p.NeedsBody() && requestHasBody(headers) {
 				slog.Debug("ext_proc: requesting body from Envoy", "direction", direction)
 				pendingHeaders = headers
 				pendingDirection = direction
@@ -81,9 +81,9 @@ func (s *Server) Process(stream extprocv3.ExternalProcessor_ProcessServer) error
 				slog.Warn("ext_proc: request body too large", "direction", pendingDirection, "bodyLen", len(body))
 				resp = immediateResponse(http.StatusRequestEntityTooLarge, "request body too large")
 			} else if pendingDirection == "inbound" {
-				resp = s.handleInbound(stream, pendingHeaders, body)
+				resp = s.handleInboundBody(stream, pendingHeaders, body)
 			} else {
-				resp = s.handleOutbound(stream, pendingHeaders, body)
+				resp = s.handleOutboundBody(stream, pendingHeaders, body)
 			}
 			pendingHeaders = nil
 			pendingDirection = ""
@@ -123,6 +123,24 @@ func (s *Server) handleInbound(stream extprocv3.ExternalProcessor_ProcessServer,
 	return allowResponse()
 }
 
+func (s *Server) handleInboundBody(stream extprocv3.ExternalProcessor_ProcessServer, headers *corev3.HeaderMap, body []byte) *extprocv3.ProcessingResponse {
+	ctx := stream.Context()
+	pctx := &pipeline.Context{
+		Direction: pipeline.Inbound,
+		Path:      getHeader(headers, ":path"),
+		Headers:   headerMapToHTTP(headers),
+		Body:      body,
+	}
+
+	action := s.InboundPipeline.Run(ctx, pctx)
+	if action.Type == pipeline.Reject {
+		return denyResponse(typev3.StatusCode(action.Status),
+			jsonError("unauthorized", action.Reason))
+	}
+
+	return allowBodyResponse()
+}
+
 func (s *Server) handleOutbound(stream extprocv3.ExternalProcessor_ProcessServer, headers *corev3.HeaderMap, body []byte) *extprocv3.ProcessingResponse {
 	ctx := stream.Context()
 	pctx := &pipeline.Context{
@@ -147,6 +165,32 @@ func (s *Server) handleOutbound(stream extprocv3.ExternalProcessor_ProcessServer
 		return replaceTokenResponse(extractBearer(newAuth))
 	}
 	return passResponse()
+}
+
+func (s *Server) handleOutboundBody(stream extprocv3.ExternalProcessor_ProcessServer, headers *corev3.HeaderMap, body []byte) *extprocv3.ProcessingResponse {
+	ctx := stream.Context()
+	pctx := &pipeline.Context{
+		Direction: pipeline.Outbound,
+		Host:      getHeader(headers, ":authority"),
+		Headers:   headerMapToHTTP(headers),
+		Body:      body,
+	}
+	if pctx.Host == "" {
+		pctx.Host = getHeader(headers, "host")
+	}
+
+	originalAuth := pctx.Headers.Get("Authorization")
+	action := s.OutboundPipeline.Run(ctx, pctx)
+	if action.Type == pipeline.Reject {
+		return denyResponse(typev3.StatusCode_ServiceUnavailable,
+			jsonError("token_acquisition_failed", action.Reason))
+	}
+
+	newAuth := pctx.Headers.Get("Authorization")
+	if newAuth != originalAuth {
+		return replaceTokenBodyResponse(extractBearer(newAuth))
+	}
+	return passBodyResponse()
 }
 
 func headerMapToHTTP(headers *corev3.HeaderMap) http.Header {
@@ -199,6 +243,49 @@ func passResponse() *extprocv3.ProcessingResponse {
 	}
 }
 
+func passBodyResponse() *extprocv3.ProcessingResponse {
+	return &extprocv3.ProcessingResponse{
+		Response: &extprocv3.ProcessingResponse_RequestBody{
+			RequestBody: &extprocv3.BodyResponse{},
+		},
+	}
+}
+
+func allowBodyResponse() *extprocv3.ProcessingResponse {
+	return &extprocv3.ProcessingResponse{
+		Response: &extprocv3.ProcessingResponse_RequestBody{
+			RequestBody: &extprocv3.BodyResponse{
+				Response: &extprocv3.CommonResponse{
+					HeaderMutation: &extprocv3.HeaderMutation{
+						RemoveHeaders: []string{"x-authbridge-direction"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func replaceTokenBodyResponse(token string) *extprocv3.ProcessingResponse {
+	return &extprocv3.ProcessingResponse{
+		Response: &extprocv3.ProcessingResponse_RequestBody{
+			RequestBody: &extprocv3.BodyResponse{
+				Response: &extprocv3.CommonResponse{
+					HeaderMutation: &extprocv3.HeaderMutation{
+						SetHeaders: []*corev3.HeaderValueOption{
+							{
+								Header: &corev3.HeaderValue{
+									Key:      "authorization",
+									RawValue: []byte("Bearer " + token),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func replaceTokenResponse(token string) *extprocv3.ProcessingResponse {
 	return &extprocv3.ProcessingResponse{
 		Response: &extprocv3.ProcessingResponse_RequestHeaders{
@@ -246,6 +333,19 @@ func immediateResponse(httpStatus int, reason string) *extprocv3.ProcessingRespo
 func jsonError(errorCode, message string) string {
 	b, _ := json.Marshal(map[string]string{"error": errorCode, "message": message})
 	return string(b)
+}
+
+func requestHasBody(headers *corev3.HeaderMap) bool {
+	method := getHeader(headers, ":method")
+	if method == "GET" || method == "HEAD" || method == "OPTIONS" || method == "DELETE" {
+		return false
+	}
+	cl := getHeader(headers, "content-length")
+	if cl != "" && cl != "0" {
+		return true
+	}
+	te := getHeader(headers, "transfer-encoding")
+	return te != ""
 }
 
 func getHeader(headers *corev3.HeaderMap, key string) string {

--- a/authbridge/cmd/authbridge/listener/extproc/server_test.go
+++ b/authbridge/cmd/authbridge/listener/extproc/server_test.go
@@ -390,7 +390,9 @@ func TestExtProc_BodyBuffering_Inbound(t *testing.T) {
 		requests: []*extprocv3.ProcessingRequest{
 			inboundRequest(makeHeaders(
 				"x-authbridge-direction", "inbound",
+				":method", "POST",
 				":path", "/mcp",
+				"content-length", fmt.Sprintf("%d", len(body)),
 			)),
 			{
 				Request: &extprocv3.ProcessingRequest_RequestBody{
@@ -419,10 +421,10 @@ func TestExtProc_BodyBuffering_Inbound(t *testing.T) {
 		t.Errorf("RequestBodyMode = %v, want BUFFERED", first.ModeOverride.RequestBodyMode)
 	}
 
-	// Second response should be the pipeline result (allow)
+	// Second response should be the body-phase pipeline result (RequestBody response)
 	second := stream.responses[1]
-	if second.GetRequestHeaders() == nil && second.GetImmediateResponse() == nil {
-		t.Fatal("second response should be a pipeline result")
+	if second.GetRequestBody() == nil && second.GetImmediateResponse() == nil {
+		t.Fatal("second response should be a body-phase pipeline result")
 	}
 
 	// Plugin should have received the body
@@ -453,8 +455,10 @@ func TestExtProc_BodyBuffering_Outbound(t *testing.T) {
 		ctx: context.Background(),
 		requests: []*extprocv3.ProcessingRequest{
 			outboundRequest(makeHeaders(
+				":method", "POST",
 				":authority", "target-svc",
 				"authorization", "Bearer token",
+				"content-length", fmt.Sprintf("%d", len(body)),
 			)),
 			{
 				Request: &extprocv3.ProcessingRequest_RequestBody{
@@ -501,7 +505,9 @@ func TestExtProc_BodyTooLarge(t *testing.T) {
 		requests: []*extprocv3.ProcessingRequest{
 			inboundRequest(makeHeaders(
 				"x-authbridge-direction", "inbound",
+				":method", "POST",
 				":path", "/mcp",
+				"content-length", fmt.Sprintf("%d", len(bigBody)),
 			)),
 			{
 				Request: &extprocv3.ProcessingRequest_RequestBody{

--- a/authbridge/demos/mcp-parser/README.md
+++ b/authbridge/demos/mcp-parser/README.md
@@ -1,8 +1,8 @@
 # MCP Parser Plugin Demo
 
 This guide shows how to enable the `mcp-parser` plugin so AuthBridge
-parses MCP JSON-RPC requests and logs tool calls, resource reads, and
-prompt invocations.
+parses outbound MCP JSON-RPC requests and logs tool calls, resource
+reads, and prompt invocations.
 
 ## Prerequisites
 
@@ -16,7 +16,12 @@ prompt invocations.
 
 ## How It Works
 
-The `mcp-parser` plugin:
+The `mcp-parser` plugin runs on the **outbound** pipeline. Agents use the
+MCP protocol to call tools — these are outbound HTTP requests from the
+agent to tool services. Inbound requests to the agent use A2A protocol,
+not MCP.
+
+The plugin:
 1. Declares `BodyAccess: true`, which triggers body buffering in all
    listener modes
 2. Parses the request body as JSON-RPC 2.0
@@ -25,9 +30,36 @@ The `mcp-parser` plugin:
 4. Returns `Continue` unconditionally (never rejects)
 
 In envoy-sidecar mode, AuthBridge uses ext_proc `ModeOverride` to
-dynamically request the body from Envoy. No Envoy configuration changes
-are needed — the default `request_body_mode: NONE` is overridden
-per-stream when `mcp-parser` is in the pipeline.
+dynamically request the body from Envoy when a POST request has a body.
+GET/HEAD/OPTIONS/DELETE requests skip body buffering entirely (these
+methods have no body).
+
+### Envoy Configuration Requirement
+
+The outbound ext_proc filter **must** have `allow_mode_override: true`
+for dynamic body buffering to work. Without it, Envoy ignores the
+`ModeOverride` and never sends the request body to authbridge.
+
+```yaml
+# In the outbound_listener's ext_proc filter:
+- name: envoy.filters.http.ext_proc
+  typed_config:
+    "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+    grpc_service:
+      envoy_grpc:
+        cluster_name: ext_proc_cluster
+      timeout: 300s
+    allow_mode_override: true          # Required for mcp-parser
+    processing_mode:
+      request_header_mode: SEND
+      response_header_mode: SKIP
+      request_body_mode: NONE
+      response_body_mode: NONE
+```
+
+If you are using the kagenti-operator v0.5.0-alpha.8+, this is already
+set in the default `envoy-config` ConfigMap. For earlier versions, patch
+the ConfigMap manually.
 
 ## Step 1: Patch the Runtime Config
 
@@ -66,6 +98,9 @@ data:
       inbound:
         plugins:
           - jwt-validation
+      outbound:
+        plugins:
+          - token-exchange
           - mcp-parser
 EOF
 ```
@@ -74,11 +109,11 @@ EOF
 > should match your existing `authbridge-runtime-config`. If you use
 > `client-secret` identity type instead of `spiffe`, adjust accordingly.
 
-The `mcp-parser` is placed **after** `jwt-validation` in the inbound
+The `mcp-parser` is placed **after** `token-exchange` in the outbound
 pipeline. This means:
-- Unauthenticated requests are rejected before body buffering occurs
-- Only validated requests have their body parsed (no wasted work)
-- Future policy plugins can read both `pctx.Claims` and
+- Token exchange runs first (injecting credentials for routed hosts)
+- The MCP body is parsed after auth decisions are made
+- Future policy plugins can read both token metadata and
   `pctx.Extensions.MCP`
 
 ## Step 2: Enable Debug Logging (Optional)
@@ -95,8 +130,19 @@ kubectl patch configmap authbridge-config -n team1 \
 Or toggle at runtime without restart:
 
 ```bash
-# Send SIGUSR1 to the authbridge process (PID 1 inside the container)
-kubectl exec deploy/<agent-name> -n team1 -c authbridge-proxy -- kill -USR1 1
+# Find the authbridge PID (not PID 1, which is entrypoint.sh in the
+# combined envoy-proxy container):
+ABPID=$(kubectl exec deploy/<agent-name> -n team1 -c envoy-proxy -- \
+  sh -c 'for f in /proc/[0-9]*/cmdline; do
+    if cat "$f" 2>/dev/null | tr "\0" " " | head -c 100 | \
+       cat - /dev/null | sh -c "read x; case \$x in *authbridge*) exit 0;; *) exit 1;; esac"; then
+      echo "${f%/cmdline}" | tr -dc "0-9"; break
+    fi
+  done')
+kubectl exec deploy/<agent-name> -n team1 -c envoy-proxy -- kill -USR1 $ABPID
+
+# Or if you know the PID (typically 14 in the combined image):
+kubectl exec deploy/<agent-name> -n team1 -c envoy-proxy -- kill -USR1 14
 ```
 
 ## Step 3: Restart the Agent Pod
@@ -116,25 +162,24 @@ kubectl rollout status deploy/<agent-name> -n team1
 ## Step 4: Send a Request Through the Agent
 
 Use the Kagenti UI or curl to trigger a tool call through the agent.
-For the weather agent:
+For the weather agent, simply ask it a weather question — the agent
+will call the weather-tool-mcp service over MCP (outbound):
 
 ```bash
 # Via the Kagenti UI:
-# Navigate to the agent, type "What's the weather in NYC?"
-
-# Or via curl (replace TOKEN with a valid Keycloak access token):
-curl -X POST http://<agent-host>/mcp \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"get_weather","arguments":{"city":"NYC"}}}'
+# Navigate to the weather agent, type "What's the weather in NYC?"
 ```
+
+The agent receives an A2A request (inbound, validated by jwt-validation),
+then makes an outbound MCP `tools/call` to the weather tool. The
+mcp-parser sees this outbound call.
 
 ## Step 5: Verify in Logs
 
-Check the authbridge container logs for MCP parsing output:
+Check the envoy-proxy container logs for MCP parsing output:
 
 ```bash
-kubectl logs deploy/<agent-name> -n team1 -c authbridge-proxy | grep mcp-parser
+kubectl logs deploy/<agent-name> -n team1 -c envoy-proxy | grep mcp-parser
 ```
 
 ### Expected Output (LOG_LEVEL=info)
@@ -153,15 +198,20 @@ level=INFO msg="mcp-parser: parsed resources/read" uri=file:///tmp/data.csv
 
 ### Expected Output (LOG_LEVEL=debug)
 
-With debug enabled, you also see:
+With debug enabled, you also see the body buffering flow:
 
 ```
-level=DEBUG msg="ext_proc: requesting body from Envoy" direction=inbound
-level=DEBUG msg="ext_proc: received request body" direction=inbound bodyLen=87
-level=DEBUG msg="pipeline: plugin completed" plugin=jwt-validation
+level=DEBUG msg="ext_proc: requesting body from Envoy" direction=""
+level=DEBUG msg="ext_proc: received request body" direction="" bodyLen=106
+level=INFO  msg="outbound passthrough" host=weather-tool-mcp:9090 reason="no matching route"
+level=DEBUG msg="pipeline: plugin completed" plugin=token-exchange
 level=INFO  msg="mcp-parser: parsed tools/call" tool=get_weather
 level=DEBUG msg="pipeline: plugin completed" plugin=mcp-parser
 ```
+
+The `direction=""` (empty) indicates outbound — only inbound requests
+have the `x-authbridge-direction: inbound` header set by Envoy's Lua
+filter.
 
 ### Requests That Are NOT MCP
 
@@ -171,7 +221,7 @@ Non-JSON or non-MCP requests pass through silently at debug level:
 level=DEBUG msg="mcp-parser: body is not valid JSON-RPC" error="invalid character..." bodyLen=42
 ```
 
-Or if the body is empty (e.g., GET requests):
+Or if the request has no body (e.g., GET requests skip body buffering):
 
 ```
 level=DEBUG msg="mcp-parser: no body, skipping"
@@ -195,15 +245,40 @@ This fatal error means you configured `mcp-parser` in waypoint mode.
 ext_authz cannot forward request bodies (hard Envoy constraint). Use
 envoy-sidecar or proxy-sidecar mode instead.
 
+### "Spurious response message received on gRPC stream"
+
+This Envoy warning means ext_proc sent a response that Envoy wasn't
+expecting. Two common causes:
+
+1. **Missing `allow_mode_override: true`** — Envoy ignores the
+   `ModeOverride` in the headers response, never sends RequestBody, but
+   authbridge already replied to RequestHeaders. The next request on the
+   same stream then gets a stale response. Fix: add
+   `allow_mode_override: true` to the ext_proc filter config.
+
+2. **Wrong response phase** — If authbridge sends a
+   `ProcessingResponse_RequestHeaders` when Envoy expects a
+   `ProcessingResponse_RequestBody` (because body buffering was
+   requested), Envoy logs this warning. This was fixed in
+   v0.5.0-alpha.9+.
+
 ### Body not reaching the parser
 
 If you see `mcp-parser: no body, skipping` for requests that should
 have a body, check:
-1. The request is POST with a JSON body (GET requests have no body)
-2. The `Content-Length` header is present (some clients omit it for
-   chunked encoding)
+1. The request is POST with a `Content-Length` or `Transfer-Encoding`
+   header (GET/HEAD/OPTIONS/DELETE requests skip body buffering)
+2. The `allow_mode_override: true` is set on the ext_proc filter in the
+   envoy-config ConfigMap (check both outbound and inbound listeners)
 3. Envoy's `per_stream_buffer_limit_bytes` isn't set too low (default
    1MB is fine for MCP)
+
+Verify the envoy config:
+```bash
+kubectl exec deploy/<agent-name> -n team1 -c envoy-proxy -- \
+  cat /etc/envoy/envoy.yaml | grep allow_mode_override
+```
+You should see `allow_mode_override: true` for each ext_proc filter.
 
 ## What This Enables (Future)
 

--- a/authbridge/demos/multi-target/k8s/authbridge-deployment-no-spiffe.yaml
+++ b/authbridge/demos/multi-target/k8s/authbridge-deployment-no-spiffe.yaml
@@ -117,6 +117,7 @@ data:
                   grpc_service:
                     envoy_grpc:
                       cluster_name: go_processor
+                  allow_mode_override: true
                   processing_mode:
                     request_header_mode: SEND
                     response_header_mode: SEND

--- a/authbridge/demos/multi-target/k8s/authbridge-deployment.yaml
+++ b/authbridge/demos/multi-target/k8s/authbridge-deployment.yaml
@@ -146,6 +146,7 @@ data:
                   grpc_service:
                     envoy_grpc:
                       cluster_name: go_processor
+                  allow_mode_override: true
                   processing_mode:
                     request_header_mode: SEND
                     response_header_mode: SEND

--- a/authbridge/demos/single-target/k8s/authbridge-deployment-no-spiffe.yaml
+++ b/authbridge/demos/single-target/k8s/authbridge-deployment-no-spiffe.yaml
@@ -144,6 +144,7 @@ data:
                     envoy_grpc:
                       cluster_name: ext_proc_cluster
                     timeout: 30s
+                  allow_mode_override: true
                   processing_mode:
                     request_header_mode: SEND
                     response_header_mode: SKIP
@@ -195,6 +196,7 @@ data:
                     envoy_grpc:
                       cluster_name: ext_proc_cluster
                     timeout: 30s
+                  allow_mode_override: true
                   processing_mode:
                     request_header_mode: SEND
                     response_header_mode: SKIP

--- a/authbridge/demos/single-target/k8s/authbridge-deployment.yaml
+++ b/authbridge/demos/single-target/k8s/authbridge-deployment.yaml
@@ -168,6 +168,7 @@ data:
                     envoy_grpc:
                       cluster_name: ext_proc_cluster
                     timeout: 30s
+                  allow_mode_override: true
                   processing_mode:
                     request_header_mode: SEND
                     response_header_mode: SKIP
@@ -219,6 +220,7 @@ data:
                     envoy_grpc:
                       cluster_name: ext_proc_cluster
                     timeout: 30s
+                  allow_mode_override: true
                   processing_mode:
                     request_header_mode: SEND
                     response_header_mode: SKIP

--- a/authbridge/demos/webhook/k8s/configmaps-webhook.yaml
+++ b/authbridge/demos/webhook/k8s/configmaps-webhook.yaml
@@ -158,6 +158,7 @@ data:
                     envoy_grpc:
                       cluster_name: ext_proc_cluster
                     timeout: 30s
+                  allow_mode_override: true
                   processing_mode:
                     request_header_mode: SEND
                     response_header_mode: SKIP
@@ -209,6 +210,7 @@ data:
                     envoy_grpc:
                       cluster_name: ext_proc_cluster
                     timeout: 30s
+                  allow_mode_override: true
                   processing_mode:
                     request_header_mode: SEND
                     response_header_mode: SKIP


### PR DESCRIPTION
## Summary

- Fix ext_proc to use `ProcessingResponse_RequestBody` when responding after the body phase (fixes "Spurious response message" warnings that broke MCP tool calls)
- Skip body buffering for GET/HEAD/OPTIONS/DELETE requests (prevents stream hangs for bodyless methods)
- Add `allow_mode_override: true` to all envoy-config templates (required for dynamic body buffering via ModeOverride)
- Fix proxy-init Dockerfile to install `iptables-legacy` (Alpine 3.20+ only ships nft binaries in base package)
- Correct mcp-parser demo docs: outbound pipeline placement, accurate log examples, troubleshooting for common issues

## Test plan

- [x] Verified end-to-end on Kind cluster: weather agent → weather-tool-mcp outbound MCP `tools/call` parsed successfully
- [x] No "Spurious response message" warnings in Envoy logs after fix
- [x] GET requests (e.g., `/.well-known/agent-card.json`) pass through without hanging
- [x] Inbound A2A requests still validated by jwt-validation
- [x] `go build ./...` passes for cmd/authbridge
- [ ] CI tests pass

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>