### PR TITLE
feat: Add inference-parser plugin for outbound LLM traffic

### DIFF
--- a/authbridge/authlib/pipeline/context.go
+++ b/authbridge/authlib/pipeline/context.go
@@ -30,6 +30,11 @@ type Context struct {
 	Claims *validation.Claims    // nil before jwt-validation runs
 	Route  *routing.ResolvedRoute
 
+	// Response-phase fields (populated by listener before RunResponse).
+	StatusCode      int
+	ResponseHeaders http.Header
+	ResponseBody    []byte // nil unless at least one plugin declares BodyAccess: true
+
 	Extensions Extensions
 }
 

--- a/authbridge/authlib/pipeline/extensions.go
+++ b/authbridge/authlib/pipeline/extensions.go
@@ -9,6 +9,7 @@ type Extensions struct {
 	A2A        *A2AExtension
 	Security   *SecurityExtension
 	Delegation *DelegationExtension
+	Inference  *InferenceExtension
 	Custom     map[string]any
 }
 
@@ -33,6 +34,22 @@ type A2AExtension struct {
 type A2APart struct {
 	Kind    string // "text", "file", "data"
 	Content string // text content, file URI, or serialized data
+}
+
+// InferenceExtension carries parsed LLM inference request metadata.
+type InferenceExtension struct {
+	Model       string             // model name (e.g., "llama3.1", "gpt-4")
+	Messages    []InferenceMessage // conversation messages
+	Temperature *float64           // sampling temperature (nil if not set)
+	MaxTokens   *int               // max tokens to generate (nil if not set)
+	Stream      bool               // whether streaming is requested
+	Tools       []string           // tool/function names declared
+}
+
+// InferenceMessage represents a single message in the conversation.
+type InferenceMessage struct {
+	Role    string // "system", "user", "assistant", "tool"
+	Content string
 }
 
 // SecurityExtension carries guardrail output.

--- a/authbridge/authlib/pipeline/pipeline.go
+++ b/authbridge/authlib/pipeline/pipeline.go
@@ -17,6 +17,7 @@ var defaultSlots = map[string]bool{
 	"a2a":        true,
 	"security":   true,
 	"delegation": true,
+	"inference":  true,
 	"custom":     true,
 }
 

--- a/authbridge/authlib/plugins/inferenceparser.go
+++ b/authbridge/authlib/plugins/inferenceparser.go
@@ -1,0 +1,95 @@
+package plugins
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+
+	"github.com/kagenti/kagenti-extensions/authbridge/authlib/pipeline"
+)
+
+// InferenceParser parses outbound OpenAI-compatible LLM inference requests
+// and populates pctx.Extensions.Inference for downstream policy plugins.
+type InferenceParser struct{}
+
+func NewInferenceParser() *InferenceParser { return &InferenceParser{} }
+
+func (p *InferenceParser) Name() string { return "inference-parser" }
+
+func (p *InferenceParser) Capabilities() pipeline.PluginCapabilities {
+	return pipeline.PluginCapabilities{
+		Writes:     []string{"inference"},
+		BodyAccess: true,
+	}
+}
+
+func (p *InferenceParser) OnRequest(_ context.Context, pctx *pipeline.Context) pipeline.Action {
+	if pctx.Path != "/v1/chat/completions" && pctx.Path != "/v1/completions" {
+		return pipeline.Action{Type: pipeline.Continue}
+	}
+
+	if len(pctx.Body) == 0 {
+		slog.Debug("inference-parser: no body, skipping")
+		return pipeline.Action{Type: pipeline.Continue}
+	}
+
+	var req inferenceRequest
+	if err := json.Unmarshal(pctx.Body, &req); err != nil {
+		slog.Debug("inference-parser: invalid JSON", "error", err)
+		return pipeline.Action{Type: pipeline.Continue}
+	}
+
+	ext := &pipeline.InferenceExtension{
+		Model:       req.Model,
+		Temperature: req.Temperature,
+		MaxTokens:   req.MaxTokens,
+		Stream:      req.Stream,
+	}
+
+	for _, msg := range req.Messages {
+		ext.Messages = append(ext.Messages, pipeline.InferenceMessage{
+			Role:    msg.Role,
+			Content: msg.Content,
+		})
+	}
+
+	for _, tool := range req.Tools {
+		if tool.Function.Name != "" {
+			ext.Tools = append(ext.Tools, tool.Function.Name)
+		}
+	}
+
+	pctx.Extensions.Inference = ext
+
+	slog.Info("inference-parser", "model", ext.Model)
+	slog.Debug("inference-parser: extracted", "model", ext.Model, "messages", len(ext.Messages), "stream", ext.Stream, "tools", len(ext.Tools))
+
+	return pipeline.Action{Type: pipeline.Continue}
+}
+
+func (p *InferenceParser) OnResponse(_ context.Context, _ *pipeline.Context) pipeline.Action {
+	return pipeline.Action{Type: pipeline.Continue}
+}
+
+type inferenceRequest struct {
+	Model       string             `json:"model"`
+	Messages    []inferenceMessage `json:"messages"`
+	Temperature *float64           `json:"temperature"`
+	MaxTokens   *int               `json:"max_tokens"`
+	Stream      bool               `json:"stream"`
+	Tools       []inferenceTool    `json:"tools"`
+}
+
+type inferenceMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type inferenceTool struct {
+	Type     string            `json:"type"`
+	Function inferenceFunction `json:"function"`
+}
+
+type inferenceFunction struct {
+	Name string `json:"name"`
+}

--- a/authbridge/authlib/plugins/inferenceparser_test.go
+++ b/authbridge/authlib/plugins/inferenceparser_test.go
@@ -1,0 +1,259 @@
+package plugins
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kagenti/kagenti-extensions/authbridge/authlib/pipeline"
+)
+
+func TestInferenceParser_Capabilities(t *testing.T) {
+	p := NewInferenceParser()
+
+	if p.Name() != "inference-parser" {
+		t.Errorf("Name() = %q, want %q", p.Name(), "inference-parser")
+	}
+
+	caps := p.Capabilities()
+	if !caps.BodyAccess {
+		t.Error("BodyAccess should be true")
+	}
+	if len(caps.Writes) != 1 || caps.Writes[0] != "inference" {
+		t.Errorf("Writes = %v, want [inference]", caps.Writes)
+	}
+}
+
+func TestInferenceParser_ChatCompletions(t *testing.T) {
+	p := NewInferenceParser()
+	pctx := &pipeline.Context{
+		Path: "/v1/chat/completions",
+		Body: []byte(`{
+			"model": "llama3.1",
+			"messages": [
+				{"role": "system", "content": "You are a helpful assistant."},
+				{"role": "user", "content": "What is the weather in NYC?"}
+			],
+			"temperature": 0.7,
+			"max_tokens": 1024,
+			"stream": false,
+			"tools": [
+				{"type": "function", "function": {"name": "get_weather"}},
+				{"type": "function", "function": {"name": "get_forecast"}}
+			]
+		}`),
+	}
+
+	action := p.OnRequest(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	ext := pctx.Extensions.Inference
+	if ext == nil {
+		t.Fatal("Extensions.Inference is nil")
+	}
+	if ext.Model != "llama3.1" {
+		t.Errorf("Model = %q, want %q", ext.Model, "llama3.1")
+	}
+	if len(ext.Messages) != 2 {
+		t.Fatalf("Messages len = %d, want 2", len(ext.Messages))
+	}
+	if ext.Messages[0].Role != "system" || ext.Messages[0].Content != "You are a helpful assistant." {
+		t.Errorf("Messages[0] = %+v", ext.Messages[0])
+	}
+	if ext.Messages[1].Role != "user" || ext.Messages[1].Content != "What is the weather in NYC?" {
+		t.Errorf("Messages[1] = %+v", ext.Messages[1])
+	}
+	if ext.Temperature == nil || *ext.Temperature != 0.7 {
+		t.Errorf("Temperature = %v, want 0.7", ext.Temperature)
+	}
+	if ext.MaxTokens == nil || *ext.MaxTokens != 1024 {
+		t.Errorf("MaxTokens = %v, want 1024", ext.MaxTokens)
+	}
+	if ext.Stream {
+		t.Error("Stream should be false")
+	}
+	if len(ext.Tools) != 2 || ext.Tools[0] != "get_weather" || ext.Tools[1] != "get_forecast" {
+		t.Errorf("Tools = %v, want [get_weather get_forecast]", ext.Tools)
+	}
+}
+
+func TestInferenceParser_StreamRequest(t *testing.T) {
+	p := NewInferenceParser()
+	pctx := &pipeline.Context{
+		Path: "/v1/chat/completions",
+		Body: []byte(`{"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}], "stream": true}`),
+	}
+
+	action := p.OnRequest(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	if pctx.Extensions.Inference == nil {
+		t.Fatal("Extensions.Inference is nil")
+	}
+	if !pctx.Extensions.Inference.Stream {
+		t.Error("Stream should be true")
+	}
+}
+
+func TestInferenceParser_SystemMessage(t *testing.T) {
+	p := NewInferenceParser()
+	pctx := &pipeline.Context{
+		Path: "/v1/chat/completions",
+		Body: []byte(`{
+			"model": "llama3.1",
+			"messages": [
+				{"role": "system", "content": "You are a weather expert."},
+				{"role": "user", "content": "Tell me about hurricanes."},
+				{"role": "assistant", "content": "Hurricanes are..."},
+				{"role": "user", "content": "What about typhoons?"}
+			]
+		}`),
+	}
+
+	action := p.OnRequest(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	ext := pctx.Extensions.Inference
+	if ext == nil {
+		t.Fatal("Extensions.Inference is nil")
+	}
+	if len(ext.Messages) != 4 {
+		t.Fatalf("Messages len = %d, want 4", len(ext.Messages))
+	}
+	if ext.Messages[0].Role != "system" {
+		t.Errorf("Messages[0].Role = %q, want %q", ext.Messages[0].Role, "system")
+	}
+	if ext.Messages[2].Role != "assistant" {
+		t.Errorf("Messages[2].Role = %q, want %q", ext.Messages[2].Role, "assistant")
+	}
+}
+
+func TestInferenceParser_WithTools(t *testing.T) {
+	p := NewInferenceParser()
+	pctx := &pipeline.Context{
+		Path: "/v1/chat/completions",
+		Body: []byte(`{
+			"model": "llama3.1",
+			"messages": [{"role": "user", "content": "check weather"}],
+			"tools": [
+				{"type": "function", "function": {"name": "get_weather", "parameters": {"type": "object"}}},
+				{"type": "function", "function": {"name": "search_web"}}
+			]
+		}`),
+	}
+
+	action := p.OnRequest(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	ext := pctx.Extensions.Inference
+	if ext == nil {
+		t.Fatal("Extensions.Inference is nil")
+	}
+	if len(ext.Tools) != 2 {
+		t.Fatalf("Tools len = %d, want 2", len(ext.Tools))
+	}
+	if ext.Tools[0] != "get_weather" {
+		t.Errorf("Tools[0] = %q, want %q", ext.Tools[0], "get_weather")
+	}
+	if ext.Tools[1] != "search_web" {
+		t.Errorf("Tools[1] = %q, want %q", ext.Tools[1], "search_web")
+	}
+}
+
+func TestInferenceParser_NonMatchingPath(t *testing.T) {
+	p := NewInferenceParser()
+	pctx := &pipeline.Context{
+		Path: "/api/other",
+		Body: []byte(`{"model": "llama3.1", "messages": [{"role": "user", "content": "hi"}]}`),
+	}
+
+	action := p.OnRequest(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	if pctx.Extensions.Inference != nil {
+		t.Error("Extensions.Inference should be nil for non-matching path")
+	}
+}
+
+func TestInferenceParser_NilBody(t *testing.T) {
+	p := NewInferenceParser()
+	pctx := &pipeline.Context{
+		Path: "/v1/chat/completions",
+		Body: nil,
+	}
+
+	action := p.OnRequest(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	if pctx.Extensions.Inference != nil {
+		t.Error("Extensions.Inference should be nil when body is nil")
+	}
+}
+
+func TestInferenceParser_EmptyBody(t *testing.T) {
+	p := NewInferenceParser()
+	pctx := &pipeline.Context{
+		Path: "/v1/chat/completions",
+		Body: []byte{},
+	}
+
+	action := p.OnRequest(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	if pctx.Extensions.Inference != nil {
+		t.Error("Extensions.Inference should be nil when body is empty")
+	}
+}
+
+func TestInferenceParser_InvalidJSON(t *testing.T) {
+	p := NewInferenceParser()
+	pctx := &pipeline.Context{
+		Path: "/v1/chat/completions",
+		Body: []byte("not valid json"),
+	}
+
+	action := p.OnRequest(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	if pctx.Extensions.Inference != nil {
+		t.Error("Extensions.Inference should be nil for invalid JSON")
+	}
+}
+
+func TestInferenceParser_LegacyCompletions(t *testing.T) {
+	p := NewInferenceParser()
+	pctx := &pipeline.Context{
+		Path: "/v1/completions",
+		Body: []byte(`{"model": "codellama", "prompt": "Write a function that", "max_tokens": 256}`),
+	}
+
+	action := p.OnRequest(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	ext := pctx.Extensions.Inference
+	if ext == nil {
+		t.Fatal("Extensions.Inference is nil")
+	}
+	if ext.Model != "codellama" {
+		t.Errorf("Model = %q, want %q", ext.Model, "codellama")
+	}
+	if ext.MaxTokens == nil || *ext.MaxTokens != 256 {
+		t.Errorf("MaxTokens = %v, want 256", ext.MaxTokens)
+	}
+}
+
+func TestInferenceParser_OnResponse(t *testing.T) {
+	p := NewInferenceParser()
+	action := p.OnResponse(context.Background(), &pipeline.Context{})
+	if action.Type != pipeline.Continue {
+		t.Errorf("OnResponse should return Continue, got %v", action.Type)
+	}
+}

--- a/authbridge/authlib/plugins/mcpparser.go
+++ b/authbridge/authlib/plugins/mcpparser.go
@@ -58,6 +58,16 @@ type jsonRPCRequest struct {
 	Params map[string]any `json:"params"`
 }
 
+func (r *jsonRPCRequest) stringParam(key string) string {
+	v, _ := r.Params[key].(string)
+	return v
+}
+
+func (r *jsonRPCRequest) mapParam(key string) map[string]any {
+	v, _ := r.Params[key].(map[string]any)
+	return v
+}
+
 func truncate(s string, max int) string {
 	if len(s) <= max {
 		return s

--- a/authbridge/authlib/plugins/registry.go
+++ b/authbridge/authlib/plugins/registry.go
@@ -11,10 +11,11 @@ import (
 type PluginFactory func(a *auth.Auth) pipeline.Plugin
 
 var registry = map[string]PluginFactory{
-	"jwt-validation": func(a *auth.Auth) pipeline.Plugin { return NewJWTValidation(a) },
-	"token-exchange": func(a *auth.Auth) pipeline.Plugin { return NewTokenExchange(a) },
-	"mcp-parser":     func(_ *auth.Auth) pipeline.Plugin { return NewMCPParser() },
-	"a2a-parser":     func(_ *auth.Auth) pipeline.Plugin { return NewA2AParser() },
+	"jwt-validation":   func(a *auth.Auth) pipeline.Plugin { return NewJWTValidation(a) },
+	"token-exchange":   func(a *auth.Auth) pipeline.Plugin { return NewTokenExchange(a) },
+	"mcp-parser":       func(_ *auth.Auth) pipeline.Plugin { return NewMCPParser() },
+	"a2a-parser":       func(_ *auth.Auth) pipeline.Plugin { return NewA2AParser() },
+	"inference-parser": func(_ *auth.Auth) pipeline.Plugin { return NewInferenceParser() },
 }
 
 // Build constructs a pipeline from an ordered list of plugin names.

--- a/authbridge/cmd/authbridge/listener/forwardproxy/server.go
+++ b/authbridge/cmd/authbridge/listener/forwardproxy/server.go
@@ -109,7 +109,7 @@ func (s *Server) handleRequest(w http.ResponseWriter, r *http.Request) {
 	pctx.StatusCode = resp.StatusCode
 	pctx.ResponseHeaders = resp.Header.Clone()
 
-	if s.OutboundPipeline.NeedsResponseBody() && resp.Body != nil {
+	if s.OutboundPipeline.NeedsBody() && resp.Body != nil {
 		respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxBodySize+1))
 		if err != nil {
 			slog.Warn("forward-proxy: response body read error", "host", r.Host, "error", err)
@@ -135,7 +135,7 @@ func (s *Server) handleRequest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// If a plugin mutated ResponseBody, use the mutated version.
-	if s.OutboundPipeline.NeedsResponseBody() && pctx.ResponseBody != nil {
+	if s.OutboundPipeline.NeedsBody() && pctx.ResponseBody != nil {
 		resp.Body = io.NopCloser(bytes.NewReader(pctx.ResponseBody))
 		resp.ContentLength = int64(len(pctx.ResponseBody))
 		resp.Header.Set("Content-Length", fmt.Sprintf("%d", len(pctx.ResponseBody)))

--- a/authbridge/cmd/authbridge/listener/forwardproxy/server.go
+++ b/authbridge/cmd/authbridge/listener/forwardproxy/server.go
@@ -6,6 +6,7 @@ package forwardproxy
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -103,6 +104,42 @@ func (s *Server) handleRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer resp.Body.Close()
+
+	// Response phase: populate pctx and run plugins in reverse order.
+	pctx.StatusCode = resp.StatusCode
+	pctx.ResponseHeaders = resp.Header.Clone()
+
+	if s.OutboundPipeline.NeedsResponseBody() && resp.Body != nil {
+		respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxBodySize+1))
+		if err != nil {
+			slog.Warn("forward-proxy: response body read error", "host", r.Host, "error", err)
+			http.Error(w, `{"error":"response body read error"}`, http.StatusBadGateway)
+			return
+		}
+		if len(respBody) > maxBodySize {
+			slog.Warn("forward-proxy: response body too large", "host", r.Host, "len", len(respBody))
+			http.Error(w, `{"error":"response body too large"}`, http.StatusBadGateway)
+			return
+		}
+		pctx.ResponseBody = respBody
+		resp.Body = io.NopCloser(bytes.NewReader(respBody))
+	}
+
+	respAction := s.OutboundPipeline.RunResponse(r.Context(), pctx)
+	if respAction.Type == pipeline.Reject {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(respAction.Status)
+		body, _ := json.Marshal(map[string]string{"error": respAction.Reason})
+		w.Write(body)
+		return
+	}
+
+	// If a plugin mutated ResponseBody, use the mutated version.
+	if s.OutboundPipeline.NeedsResponseBody() && pctx.ResponseBody != nil {
+		resp.Body = io.NopCloser(bytes.NewReader(pctx.ResponseBody))
+		resp.ContentLength = int64(len(pctx.ResponseBody))
+		resp.Header.Set("Content-Length", fmt.Sprintf("%d", len(pctx.ResponseBody)))
+	}
 
 	for key, values := range resp.Header {
 		for _, value := range values {


### PR DESCRIPTION
## Summary

- Adds `inference-parser` plugin that parses outbound OpenAI-compatible LLM requests (`/v1/chat/completions`, `/v1/completions`)
- Populates `pctx.Extensions.Inference` with model, messages, temperature, max_tokens, stream, and tool names
- Registers `"inference"` extension slot in `defaultSlots` and factory in plugin registry
- Path-based detection ensures only LLM traffic is parsed (MCP, A2A, and other outbound traffic is unaffected)

Completes the Phase 2 protocol parser triad:
- **Inbound**: `mcp-parser` (MCP JSON-RPC), `a2a-parser` (A2A JSON-RPC)
- **Outbound**: `inference-parser` (OpenAI REST)

## Motivation

Kagenti agents call LLMs (Ollama, vLLM) via the OpenAI-compatible `/v1/chat/completions` endpoint. This plugin gives the outbound pipeline visibility into inference request content, enabling future downstream plugins for:
- Prompt guardrails (block PII, enforce content policy, limit prompt size)
- Audit/observability (log model usage, token patterns)

## Pipeline Placement

```yaml
pipeline:
  outbound:
    plugins:
      - inference-parser   # parse LLM request body
      - token-exchange     # exchange token for LLM audience
      # future: prompt-guardrails (reads "inference" extension slot)
```

Not added to default pipelines — users opt in via config.

## Test plan

- [x] `go test ./plugins/... -run Inference -v` — 11 tests pass
- [x] `go test ./...` — all authlib tests pass
- [x] `go build ./...` — binary builds cleanly
- [ ] End-to-end: configure `inference-parser` in outbound pipeline, send chat through UI, verify `inference-parser model=llama3.1` in logs

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
