### PR TITLE
feat: Add session-aware pipeline infrastructure

### DIFF
--- a/authbridge/authlib/config/config.go
+++ b/authbridge/authlib/config/config.go
@@ -19,7 +19,18 @@ type Config struct {
 	Bypass   BypassConfig   `yaml:"bypass" json:"bypass"`
 	Routes   RoutesConfig   `yaml:"routes" json:"routes"`
 	Pipeline PipelineConfig `yaml:"pipeline" json:"pipeline"`
+	Session  SessionConfig  `yaml:"session" json:"session"`
 	Stats    StatsConfig    `yaml:"stats" json:"stats"`
+}
+
+// SessionConfig controls in-memory session tracking for cross-request correlation.
+// When enabled, the framework records inbound intents and outbound tool calls so
+// that guardrail plugins can evaluate sequences across request boundaries.
+type SessionConfig struct {
+	Enabled     bool   `yaml:"enabled" json:"enabled"`
+	TTL         string `yaml:"ttl" json:"ttl"`                   // duration string (e.g., "5m"); default: 5m
+	MaxEvents   int    `yaml:"max_events" json:"max_events"`     // max events per session; default: 100
+	MaxSessions int    `yaml:"max_sessions" json:"max_sessions"` // max concurrent sessions; default: 1000 (0 = unlimited)
 }
 
 // PipelineConfig holds the plugin pipeline composition.

--- a/authbridge/authlib/pipeline/context.go
+++ b/authbridge/authlib/pipeline/context.go
@@ -26,14 +26,16 @@ type Context struct {
 	Headers   http.Header
 	Body      []byte // nil unless at least one plugin declares BodyAccess: true
 
-	Agent  *AgentIdentity
-	Claims *validation.Claims    // nil before jwt-validation runs
-	Route  *routing.ResolvedRoute
+	Agent   *AgentIdentity
+	Claims  *validation.Claims    // nil before jwt-validation runs
+	Route   *routing.ResolvedRoute
+	Session *SessionView // nil unless session tracking is enabled
 
 	// Response-phase fields (populated by listener before RunResponse).
+	// ResponseBody may be nil even during response phase if no plugin declared BodyAccess.
 	StatusCode      int
 	ResponseHeaders http.Header
-	ResponseBody    []byte // nil unless at least one plugin declares BodyAccess: true
+	ResponseBody    []byte
 
 	Extensions Extensions
 }

--- a/authbridge/authlib/pipeline/session.go
+++ b/authbridge/authlib/pipeline/session.go
@@ -1,0 +1,98 @@
+package pipeline
+
+import "time"
+
+// SessionPhase distinguishes request from response events.
+type SessionPhase int
+
+const (
+	SessionRequest SessionPhase = iota
+	SessionResponse
+)
+
+func (p SessionPhase) String() string {
+	switch p {
+	case SessionRequest:
+		return "request"
+	case SessionResponse:
+		return "response"
+	default:
+		return "unknown"
+	}
+}
+
+// SessionEvent represents a single pipeline event captured by the session store.
+// Exactly one of A2A, MCP, or Inference is non-nil.
+type SessionEvent struct {
+	At        time.Time
+	Direction Direction
+	Phase     SessionPhase
+	A2A       *A2AExtension
+	MCP       *MCPExtension
+	Inference *InferenceExtension
+}
+
+// SessionView is a read-only snapshot of a session, safe to pass to plugins.
+// It contains a copy of events — plugins cannot mutate the store.
+type SessionView struct {
+	ID     string
+	Events []SessionEvent
+}
+
+// Intents returns only inbound A2A request events (user messages).
+func (v *SessionView) Intents() []SessionEvent {
+	var out []SessionEvent
+	for _, e := range v.Events {
+		if e.Direction == Inbound && e.Phase == SessionRequest && e.A2A != nil {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// ToolCalls returns only outbound MCP request events.
+func (v *SessionView) ToolCalls() []SessionEvent {
+	var out []SessionEvent
+	for _, e := range v.Events {
+		if e.Direction == Outbound && e.Phase == SessionRequest && e.MCP != nil {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// ToolResponses returns only outbound MCP response events.
+func (v *SessionView) ToolResponses() []SessionEvent {
+	var out []SessionEvent
+	for _, e := range v.Events {
+		if e.Direction == Outbound && e.Phase == SessionResponse && e.MCP != nil {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// InferenceRequests returns only outbound inference request events.
+func (v *SessionView) InferenceRequests() []SessionEvent {
+	var out []SessionEvent
+	for _, e := range v.Events {
+		if e.Direction == Outbound && e.Phase == SessionRequest && e.Inference != nil {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// LastIntent returns the most recent inbound A2A user message, or nil.
+func (v *SessionView) LastIntent() *SessionEvent {
+	for i := len(v.Events) - 1; i >= 0; i-- {
+		e := v.Events[i]
+		if e.Direction == Inbound && e.Phase == SessionRequest && e.A2A != nil {
+			return &v.Events[i]
+		}
+	}
+	return nil
+}
+
+// Len returns total event count.
+func (v *SessionView) Len() int { return len(v.Events) }

--- a/authbridge/authlib/plugins/mcpparser.go
+++ b/authbridge/authlib/plugins/mcpparser.go
@@ -58,6 +58,7 @@ type jsonRPCRequest struct {
 	Params map[string]any `json:"params"`
 }
 
+// stringParam and mapParam are shared helpers used by both mcp-parser and a2a-parser.
 func (r *jsonRPCRequest) stringParam(key string) string {
 	v, _ := r.Params[key].(string)
 	return v

--- a/authbridge/authlib/session/store.go
+++ b/authbridge/authlib/session/store.go
@@ -1,0 +1,194 @@
+// Package session provides an in-memory session store for correlating
+// inbound user intents with outbound tool calls across request boundaries.
+// The store is per-pod (AuthBridge sidecar) and does not persist across restarts.
+package session
+
+import (
+	"sync"
+	"time"
+
+	"github.com/kagenti/kagenti-extensions/authbridge/authlib/pipeline"
+)
+
+// DefaultSessionID is used when no explicit A2A SessionID is present and no
+// active session exists. This collapses all such requests into one shared session,
+// which is correct for single-agent pods but may cause cross-user correlation in
+// multi-tenant deployments. Future work: derive session ID from JWT claims.
+const DefaultSessionID = "default"
+
+// entry holds the events for one conversation.
+type entry struct {
+	ID        string
+	Events    []pipeline.SessionEvent
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+const maxSessionIDLen = 256
+
+// Store is an in-memory, per-pod session store. It is safe for concurrent use.
+type Store struct {
+	mu          sync.RWMutex
+	sessions    map[string]*entry
+	ttl         time.Duration
+	maxEvents   int
+	maxSessions int
+	activeID    string
+	stop        chan struct{}
+	closeOnce   sync.Once
+}
+
+// New creates a Store with the given TTL, per-session event limit, and max
+// concurrent sessions. A background goroutine runs cleanup every TTL/2.
+// Call Close() during graceful shutdown to stop the background goroutine.
+func New(ttl time.Duration, maxEvents int, maxSessions int) *Store {
+	s := &Store{
+		sessions:    make(map[string]*entry),
+		ttl:         ttl,
+		maxEvents:   maxEvents,
+		maxSessions: maxSessions,
+		stop:        make(chan struct{}),
+	}
+	go s.backgroundCleanup()
+	return s
+}
+
+// Close stops the background cleanup goroutine. Safe to call multiple times.
+func (s *Store) Close() {
+	s.closeOnce.Do(func() { close(s.stop) })
+}
+
+func (s *Store) backgroundCleanup() {
+	interval := s.ttl / 2
+	if interval < time.Second {
+		interval = time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.stop:
+			return
+		case <-ticker.C:
+			s.Cleanup()
+		}
+	}
+}
+
+// Append adds an event to the named session. Creates the session if it
+// doesn't exist. Updates activeID to this session. Evicts the oldest event
+// if the session exceeds maxEvents.
+func (s *Store) Append(sessionID string, event pipeline.SessionEvent) {
+	if len(sessionID) > maxSessionIDLen {
+		sessionID = sessionID[:maxSessionIDLen]
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now()
+
+	sess, ok := s.sessions[sessionID]
+	if !ok {
+		sess = &entry{
+			ID:        sessionID,
+			CreatedAt: now,
+		}
+		s.sessions[sessionID] = sess
+	}
+
+	sess.Events = append(sess.Events, event)
+	sess.UpdatedAt = now
+	s.activeID = sessionID
+
+	if s.maxEvents > 0 && len(sess.Events) > s.maxEvents {
+		excess := len(sess.Events) - s.maxEvents
+		trimmed := make([]pipeline.SessionEvent, s.maxEvents)
+		copy(trimmed, sess.Events[excess:])
+		sess.Events = trimmed
+	}
+
+	// Evict oldest session if cap is exceeded.
+	if s.maxSessions > 0 && len(s.sessions) > s.maxSessions {
+		s.evictOldestLocked()
+	}
+}
+
+// View returns a read-only snapshot of the session's events.
+// Returns nil if the session doesn't exist or is expired.
+func (s *Store) View(sessionID string) *pipeline.SessionView {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	sess, ok := s.sessions[sessionID]
+	if !ok {
+		return nil
+	}
+	if s.isExpired(sess, time.Now()) {
+		return nil
+	}
+
+	events := make([]pipeline.SessionEvent, len(sess.Events))
+	copy(events, sess.Events)
+	return &pipeline.SessionView{ID: sessionID, Events: events}
+}
+
+// ActiveSession returns the most recently updated session ID.
+// Used for outbound correlation when no explicit session ID is available.
+func (s *Store) ActiveSession() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.activeID == "" {
+		return ""
+	}
+	sess, ok := s.sessions[s.activeID]
+	if !ok || s.isExpired(sess, time.Now()) {
+		return ""
+	}
+	return s.activeID
+}
+
+// Cleanup removes expired sessions. Safe for concurrent use.
+func (s *Store) Cleanup() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cleanupLocked(time.Now())
+}
+
+func (s *Store) cleanupLocked(now time.Time) {
+	for id, sess := range s.sessions {
+		if s.isExpired(sess, now) {
+			delete(s.sessions, id)
+			if s.activeID == id {
+				s.activeID = ""
+			}
+		}
+	}
+}
+
+func (s *Store) evictOldestLocked() {
+	var oldestID string
+	var oldestTime time.Time
+	for id, sess := range s.sessions {
+		if id == s.activeID {
+			continue
+		}
+		if oldestID == "" || sess.UpdatedAt.Before(oldestTime) {
+			oldestID = id
+			oldestTime = sess.UpdatedAt
+		}
+	}
+	if oldestID == "" {
+		// All sessions are the active session — evict it as last resort.
+		oldestID = s.activeID
+		s.activeID = ""
+	}
+	if oldestID != "" {
+		delete(s.sessions, oldestID)
+	}
+}
+
+func (s *Store) isExpired(sess *entry, now time.Time) bool {
+	return now.Sub(sess.UpdatedAt) > s.ttl
+}

--- a/authbridge/authlib/session/store_test.go
+++ b/authbridge/authlib/session/store_test.go
@@ -1,0 +1,322 @@
+package session
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kagenti/kagenti-extensions/authbridge/authlib/pipeline"
+)
+
+func TestStore_AppendAndView(t *testing.T) {
+	s := New(5*time.Minute, 100, 0)
+
+	ev := pipeline.SessionEvent{
+		At:        time.Now(),
+		Direction: pipeline.Inbound,
+		Phase:     pipeline.SessionRequest,
+		A2A:       &pipeline.A2AExtension{Method: "message/send"},
+	}
+	s.Append("sess-1", ev)
+
+	v := s.View("sess-1")
+	if v == nil {
+		t.Fatal("View returned nil")
+	}
+	if v.ID != "sess-1" {
+		t.Errorf("View.ID = %q, want %q", v.ID, "sess-1")
+	}
+	if len(v.Events) != 1 {
+		t.Fatalf("View.Events len = %d, want 1", len(v.Events))
+	}
+	if v.Events[0].A2A.Method != "message/send" {
+		t.Errorf("Event.A2A.Method = %q, want %q", v.Events[0].A2A.Method, "message/send")
+	}
+}
+
+func TestStore_ActiveSession(t *testing.T) {
+	s := New(5*time.Minute, 100, 0)
+
+	if id := s.ActiveSession(); id != "" {
+		t.Errorf("ActiveSession() = %q, want empty", id)
+	}
+
+	s.Append("sess-1", pipeline.SessionEvent{At: time.Now(), Direction: pipeline.Inbound, Phase: pipeline.SessionRequest})
+	if id := s.ActiveSession(); id != "sess-1" {
+		t.Errorf("ActiveSession() = %q, want %q", id, "sess-1")
+	}
+
+	s.Append("sess-2", pipeline.SessionEvent{At: time.Now(), Direction: pipeline.Inbound, Phase: pipeline.SessionRequest})
+	if id := s.ActiveSession(); id != "sess-2" {
+		t.Errorf("ActiveSession() = %q, want %q", id, "sess-2")
+	}
+}
+
+func TestStore_MultipleSessions(t *testing.T) {
+	s := New(5*time.Minute, 100, 0)
+
+	s.Append("sess-1", pipeline.SessionEvent{At: time.Now(), Direction: pipeline.Inbound, Phase: pipeline.SessionRequest, A2A: &pipeline.A2AExtension{Method: "m1"}})
+	s.Append("sess-2", pipeline.SessionEvent{At: time.Now(), Direction: pipeline.Inbound, Phase: pipeline.SessionRequest, A2A: &pipeline.A2AExtension{Method: "m2"}})
+
+	v1 := s.View("sess-1")
+	v2 := s.View("sess-2")
+	if v1 == nil || v2 == nil {
+		t.Fatal("expected both sessions to exist")
+	}
+	if len(v1.Events) != 1 || v1.Events[0].A2A.Method != "m1" {
+		t.Errorf("sess-1 unexpected content: %+v", v1.Events)
+	}
+	if len(v2.Events) != 1 || v2.Events[0].A2A.Method != "m2" {
+		t.Errorf("sess-2 unexpected content: %+v", v2.Events)
+	}
+}
+
+func TestStore_TTLExpiry(t *testing.T) {
+	s := New(50*time.Millisecond, 100, 0)
+
+	s.Append("sess-1", pipeline.SessionEvent{At: time.Now(), Direction: pipeline.Inbound, Phase: pipeline.SessionRequest})
+
+	v := s.View("sess-1")
+	if v == nil {
+		t.Fatal("expected View to return session before expiry")
+	}
+
+	time.Sleep(60 * time.Millisecond)
+
+	v = s.View("sess-1")
+	if v != nil {
+		t.Error("expected View to return nil after TTL expiry")
+	}
+
+	if id := s.ActiveSession(); id != "" {
+		t.Errorf("ActiveSession() = %q, want empty after expiry", id)
+	}
+}
+
+func TestStore_MaxEvents(t *testing.T) {
+	s := New(5*time.Minute, 3, 0)
+
+	for i := 0; i < 5; i++ {
+		s.Append("sess-1", pipeline.SessionEvent{
+			At:        time.Now(),
+			Direction: pipeline.Outbound,
+			Phase:     pipeline.SessionRequest,
+			MCP:       &pipeline.MCPExtension{Method: string(rune('a' + i))},
+		})
+	}
+
+	v := s.View("sess-1")
+	if v == nil {
+		t.Fatal("View returned nil")
+	}
+	if len(v.Events) != 3 {
+		t.Fatalf("Events len = %d, want 3 (capped at maxEvents)", len(v.Events))
+	}
+	if v.Events[0].MCP.Method != "c" {
+		t.Errorf("Events[0].MCP.Method = %q, want %q (oldest evicted)", v.Events[0].MCP.Method, "c")
+	}
+}
+
+func TestStore_ConcurrentAccess(t *testing.T) {
+	s := New(5*time.Minute, 1000, 0)
+	var wg sync.WaitGroup
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				s.Append("sess-concurrent", pipeline.SessionEvent{
+					At:        time.Now(),
+					Direction: pipeline.Outbound,
+					Phase:     pipeline.SessionRequest,
+					MCP:       &pipeline.MCPExtension{Method: "tools/call"},
+				})
+			}
+		}()
+	}
+
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				s.View("sess-concurrent")
+				s.ActiveSession()
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	v := s.View("sess-concurrent")
+	if v == nil {
+		t.Fatal("expected session to exist after concurrent access")
+	}
+	if len(v.Events) != 1000 {
+		t.Errorf("Events len = %d, want 1000", len(v.Events))
+	}
+}
+
+func TestStore_Cleanup(t *testing.T) {
+	s := New(50*time.Millisecond, 100, 0)
+
+	s.Append("sess-old", pipeline.SessionEvent{At: time.Now(), Direction: pipeline.Inbound, Phase: pipeline.SessionRequest})
+	time.Sleep(60 * time.Millisecond)
+
+	s.Append("sess-new", pipeline.SessionEvent{At: time.Now(), Direction: pipeline.Inbound, Phase: pipeline.SessionRequest})
+
+	if v := s.View("sess-old"); v != nil {
+		t.Error("expected sess-old to be cleaned up")
+	}
+	if v := s.View("sess-new"); v == nil {
+		t.Error("expected sess-new to still exist")
+	}
+}
+
+func TestStore_ViewNonExistent(t *testing.T) {
+	s := New(5*time.Minute, 100, 0)
+	if v := s.View("does-not-exist"); v != nil {
+		t.Error("expected nil for non-existent session")
+	}
+}
+
+func TestView_Intents(t *testing.T) {
+	v := &pipeline.SessionView{
+		ID: "test",
+		Events: []pipeline.SessionEvent{
+			{Direction: pipeline.Inbound, Phase: pipeline.SessionRequest, A2A: &pipeline.A2AExtension{Method: "message/send"}},
+			{Direction: pipeline.Outbound, Phase: pipeline.SessionRequest, MCP: &pipeline.MCPExtension{Method: "tools/call"}},
+			{Direction: pipeline.Inbound, Phase: pipeline.SessionRequest, A2A: &pipeline.A2AExtension{Method: "message/send"}},
+			{Direction: pipeline.Outbound, Phase: pipeline.SessionResponse, MCP: &pipeline.MCPExtension{Method: "tools/call"}},
+		},
+	}
+
+	intents := v.Intents()
+	if len(intents) != 2 {
+		t.Fatalf("Intents() len = %d, want 2", len(intents))
+	}
+	for _, e := range intents {
+		if e.Direction != pipeline.Inbound || e.Phase != pipeline.SessionRequest || e.A2A == nil {
+			t.Errorf("unexpected intent event: %+v", e)
+		}
+	}
+}
+
+func TestView_ToolCalls(t *testing.T) {
+	v := &pipeline.SessionView{
+		ID: "test",
+		Events: []pipeline.SessionEvent{
+			{Direction: pipeline.Inbound, Phase: pipeline.SessionRequest, A2A: &pipeline.A2AExtension{}},
+			{Direction: pipeline.Outbound, Phase: pipeline.SessionRequest, MCP: &pipeline.MCPExtension{Method: "tools/call"}},
+			{Direction: pipeline.Outbound, Phase: pipeline.SessionResponse, MCP: &pipeline.MCPExtension{Method: "tools/call"}},
+			{Direction: pipeline.Outbound, Phase: pipeline.SessionRequest, Inference: &pipeline.InferenceExtension{Model: "llama3.1"}},
+		},
+	}
+
+	calls := v.ToolCalls()
+	if len(calls) != 1 {
+		t.Fatalf("ToolCalls() len = %d, want 1", len(calls))
+	}
+	if calls[0].MCP.Method != "tools/call" {
+		t.Errorf("ToolCalls()[0].MCP.Method = %q, want %q", calls[0].MCP.Method, "tools/call")
+	}
+}
+
+func TestView_ToolResponses(t *testing.T) {
+	v := &pipeline.SessionView{
+		ID: "test",
+		Events: []pipeline.SessionEvent{
+			{Direction: pipeline.Outbound, Phase: pipeline.SessionRequest, MCP: &pipeline.MCPExtension{Method: "tools/call"}},
+			{Direction: pipeline.Outbound, Phase: pipeline.SessionResponse, MCP: &pipeline.MCPExtension{Method: "tools/call"}},
+			{Direction: pipeline.Outbound, Phase: pipeline.SessionResponse, Inference: &pipeline.InferenceExtension{}},
+		},
+	}
+
+	responses := v.ToolResponses()
+	if len(responses) != 1 {
+		t.Fatalf("ToolResponses() len = %d, want 1", len(responses))
+	}
+}
+
+func TestView_LastIntent(t *testing.T) {
+	v := &pipeline.SessionView{
+		ID: "test",
+		Events: []pipeline.SessionEvent{
+			{Direction: pipeline.Inbound, Phase: pipeline.SessionRequest, A2A: &pipeline.A2AExtension{Method: "first"}},
+			{Direction: pipeline.Outbound, Phase: pipeline.SessionRequest, MCP: &pipeline.MCPExtension{}},
+			{Direction: pipeline.Inbound, Phase: pipeline.SessionRequest, A2A: &pipeline.A2AExtension{Method: "second"}},
+		},
+	}
+
+	last := v.LastIntent()
+	if last == nil {
+		t.Fatal("LastIntent() returned nil")
+	}
+	if last.A2A.Method != "second" {
+		t.Errorf("LastIntent().A2A.Method = %q, want %q", last.A2A.Method, "second")
+	}
+}
+
+func TestView_LastIntent_Empty(t *testing.T) {
+	v := &pipeline.SessionView{
+		ID: "test",
+		Events: []pipeline.SessionEvent{
+			{Direction: pipeline.Outbound, Phase: pipeline.SessionRequest, MCP: &pipeline.MCPExtension{}},
+		},
+	}
+
+	if last := v.LastIntent(); last != nil {
+		t.Error("LastIntent() should be nil when no A2A inbound events exist")
+	}
+}
+
+func TestStore_MaxSessionsEviction(t *testing.T) {
+	s := New(5*time.Minute, 100, 2)
+	defer s.Close()
+
+	s.Append("sess-1", pipeline.SessionEvent{At: time.Now(), A2A: &pipeline.A2AExtension{Method: "m1"}})
+	time.Sleep(time.Millisecond)
+	s.Append("sess-2", pipeline.SessionEvent{At: time.Now(), A2A: &pipeline.A2AExtension{Method: "m2"}})
+	time.Sleep(time.Millisecond)
+	s.Append("sess-3", pipeline.SessionEvent{At: time.Now(), A2A: &pipeline.A2AExtension{Method: "m3"}})
+
+	if v := s.View("sess-1"); v != nil {
+		t.Error("sess-1 should have been evicted (oldest)")
+	}
+	if v := s.View("sess-2"); v == nil {
+		t.Error("sess-2 should still exist")
+	}
+	if v := s.View("sess-3"); v == nil {
+		t.Error("sess-3 should still exist")
+	}
+}
+
+func TestStore_Close(t *testing.T) {
+	s := New(50*time.Millisecond, 100, 0)
+	s.Close()
+	// Should not panic after close
+	s.Append("sess", pipeline.SessionEvent{At: time.Now(), A2A: &pipeline.A2AExtension{Method: "m"}})
+	if v := s.View("sess"); v == nil {
+		t.Error("store should still function after Close (only background cleanup stops)")
+	}
+}
+
+func TestView_InferenceRequests(t *testing.T) {
+	v := &pipeline.SessionView{
+		ID: "test",
+		Events: []pipeline.SessionEvent{
+			{Direction: pipeline.Outbound, Phase: pipeline.SessionRequest, Inference: &pipeline.InferenceExtension{Model: "llama3.1"}},
+			{Direction: pipeline.Outbound, Phase: pipeline.SessionResponse, Inference: &pipeline.InferenceExtension{}},
+			{Direction: pipeline.Outbound, Phase: pipeline.SessionRequest, MCP: &pipeline.MCPExtension{}},
+		},
+	}
+
+	reqs := v.InferenceRequests()
+	if len(reqs) != 1 {
+		t.Fatalf("InferenceRequests() len = %d, want 1", len(reqs))
+	}
+	if reqs[0].Inference.Model != "llama3.1" {
+		t.Errorf("InferenceRequests()[0].Model = %q, want %q", reqs[0].Inference.Model, "llama3.1")
+	}
+}

--- a/authbridge/cmd/authbridge/listener/extproc/server.go
+++ b/authbridge/cmd/authbridge/listener/extproc/server.go
@@ -4,10 +4,13 @@
 package extproc
 
 import (
+	"context"
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
+	"time"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extprocfilterv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
@@ -17,6 +20,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/pipeline"
+	"github.com/kagenti/kagenti-extensions/authbridge/authlib/session"
 )
 
 const maxBodySize = 1 << 20 // 1MB — matches Envoy's default per_stream_buffer_limit_bytes
@@ -26,6 +30,7 @@ type Server struct {
 	extprocv3.UnimplementedExternalProcessorServer
 	InboundPipeline  *pipeline.Pipeline
 	OutboundPipeline *pipeline.Pipeline
+	Sessions         *session.Store // nil when session tracking is disabled
 }
 
 // Process handles the bidirectional ext_proc stream.
@@ -38,6 +43,11 @@ func (s *Server) Process(stream extprocv3.ExternalProcessor_ProcessServer) error
 	// is a single request — no interleaving or stale state is possible.
 	var pendingHeaders *corev3.HeaderMap
 	var pendingDirection string
+
+	// pctx and requestDirection survive from the request phase to the response
+	// phase so that RunResponse can see the full request+response context.
+	var pctx *pipeline.Context
+	var requestDirection string
 
 	for {
 		select {
@@ -69,9 +79,11 @@ func (s *Server) Process(stream extprocv3.ExternalProcessor_ProcessServer) error
 				pendingDirection = direction
 				resp = requestBodyResponse()
 			} else if direction == "inbound" {
-				resp = s.handleInbound(stream, headers, nil)
+				resp, pctx = s.handleInbound(stream, headers, nil)
+				requestDirection = direction
 			} else {
-				resp = s.handleOutbound(stream, headers, nil)
+				resp, pctx = s.handleOutbound(stream, headers, nil)
+				requestDirection = direction
 			}
 
 		case *extprocv3.ProcessingRequest_RequestBody:
@@ -81,19 +93,20 @@ func (s *Server) Process(stream extprocv3.ExternalProcessor_ProcessServer) error
 				slog.Warn("ext_proc: request body too large", "direction", pendingDirection, "bodyLen", len(body))
 				resp = immediateResponse(http.StatusRequestEntityTooLarge, "request body too large")
 			} else if pendingDirection == "inbound" {
-				resp = s.handleInboundBody(stream, pendingHeaders, body)
+				resp, pctx = s.handleInboundBody(stream, pendingHeaders, body)
+				requestDirection = pendingDirection
 			} else {
-				resp = s.handleOutboundBody(stream, pendingHeaders, body)
+				resp, pctx = s.handleOutboundBody(stream, pendingHeaders, body)
+				requestDirection = pendingDirection
 			}
 			pendingHeaders = nil
 			pendingDirection = ""
 
 		case *extprocv3.ProcessingRequest_ResponseHeaders:
-			resp = &extprocv3.ProcessingResponse{
-				Response: &extprocv3.ProcessingResponse_ResponseHeaders{
-					ResponseHeaders: &extprocv3.HeadersResponse{},
-				},
-			}
+			resp = s.handleResponseHeaders(ctx, r.ResponseHeaders.Headers, pctx, requestDirection)
+
+		case *extprocv3.ProcessingRequest_ResponseBody:
+			resp = s.handleResponseBody(ctx, r.ResponseBody.Body, pctx, requestDirection)
 
 		default:
 			resp = &extprocv3.ProcessingResponse{}
@@ -105,7 +118,7 @@ func (s *Server) Process(stream extprocv3.ExternalProcessor_ProcessServer) error
 	}
 }
 
-func (s *Server) handleInbound(stream extprocv3.ExternalProcessor_ProcessServer, headers *corev3.HeaderMap, body []byte) *extprocv3.ProcessingResponse {
+func (s *Server) handleInbound(stream extprocv3.ExternalProcessor_ProcessServer, headers *corev3.HeaderMap, body []byte) (*extprocv3.ProcessingResponse, *pipeline.Context) {
 	ctx := stream.Context()
 	pctx := &pipeline.Context{
 		Direction: pipeline.Inbound,
@@ -117,13 +130,14 @@ func (s *Server) handleInbound(stream extprocv3.ExternalProcessor_ProcessServer,
 	action := s.InboundPipeline.Run(ctx, pctx)
 	if action.Type == pipeline.Reject {
 		return denyResponse(typev3.StatusCode(action.Status),
-			jsonError("unauthorized", action.Reason))
+			jsonError("unauthorized", action.Reason)), nil
 	}
 
-	return allowResponse()
+	s.recordInboundSession(pctx)
+	return allowResponse(), pctx
 }
 
-func (s *Server) handleInboundBody(stream extprocv3.ExternalProcessor_ProcessServer, headers *corev3.HeaderMap, body []byte) *extprocv3.ProcessingResponse {
+func (s *Server) handleInboundBody(stream extprocv3.ExternalProcessor_ProcessServer, headers *corev3.HeaderMap, body []byte) (*extprocv3.ProcessingResponse, *pipeline.Context) {
 	ctx := stream.Context()
 	pctx := &pipeline.Context{
 		Direction: pipeline.Inbound,
@@ -135,13 +149,53 @@ func (s *Server) handleInboundBody(stream extprocv3.ExternalProcessor_ProcessSer
 	action := s.InboundPipeline.Run(ctx, pctx)
 	if action.Type == pipeline.Reject {
 		return denyResponse(typev3.StatusCode(action.Status),
-			jsonError("unauthorized", action.Reason))
+			jsonError("unauthorized", action.Reason)), nil
 	}
 
-	return allowBodyResponse()
+	s.recordInboundSession(pctx)
+	return allowBodyResponse(), pctx
 }
 
-func (s *Server) handleOutbound(stream extprocv3.ExternalProcessor_ProcessServer, headers *corev3.HeaderMap, body []byte) *extprocv3.ProcessingResponse {
+func (s *Server) recordInboundSession(pctx *pipeline.Context) {
+	if s.Sessions == nil || pctx.Extensions.A2A == nil {
+		return
+	}
+	sid := pctx.Extensions.A2A.SessionID
+	if sid == "" {
+		sid = s.Sessions.ActiveSession()
+	}
+	if sid == "" {
+		sid = session.DefaultSessionID
+	}
+	s.Sessions.Append(sid, pipeline.SessionEvent{
+		At:        time.Now(),
+		Direction: pipeline.Inbound,
+		Phase:     pipeline.SessionRequest,
+		A2A:       pctx.Extensions.A2A,
+	})
+}
+
+func (s *Server) recordOutboundSession(pctx *pipeline.Context) {
+	if s.Sessions == nil {
+		return
+	}
+	sid := s.Sessions.ActiveSession()
+	if sid == "" {
+		sid = session.DefaultSessionID
+	}
+	ev := pipeline.SessionEvent{
+		At:        time.Now(),
+		Direction: pipeline.Outbound,
+		Phase:     pipeline.SessionRequest,
+		MCP:       pctx.Extensions.MCP,
+		Inference: pctx.Extensions.Inference,
+	}
+	if ev.MCP != nil || ev.Inference != nil {
+		s.Sessions.Append(sid, ev)
+	}
+}
+
+func (s *Server) handleOutbound(stream extprocv3.ExternalProcessor_ProcessServer, headers *corev3.HeaderMap, body []byte) (*extprocv3.ProcessingResponse, *pipeline.Context) {
 	ctx := stream.Context()
 	pctx := &pipeline.Context{
 		Direction: pipeline.Outbound,
@@ -153,21 +207,29 @@ func (s *Server) handleOutbound(stream extprocv3.ExternalProcessor_ProcessServer
 		pctx.Host = getHeader(headers, "host")
 	}
 
+	if s.Sessions != nil {
+		if aid := s.Sessions.ActiveSession(); aid != "" {
+			pctx.Session = s.Sessions.View(aid)
+		}
+	}
+
 	originalAuth := pctx.Headers.Get("Authorization")
 	action := s.OutboundPipeline.Run(ctx, pctx)
 	if action.Type == pipeline.Reject {
 		return denyResponse(typev3.StatusCode_ServiceUnavailable,
-			jsonError("token_acquisition_failed", action.Reason))
+			jsonError("token_acquisition_failed", action.Reason)), nil
 	}
+
+	s.recordOutboundSession(pctx)
 
 	newAuth := pctx.Headers.Get("Authorization")
 	if newAuth != originalAuth {
-		return replaceTokenResponse(extractBearer(newAuth))
+		return replaceTokenResponse(extractBearer(newAuth)), pctx
 	}
-	return passResponse()
+	return passResponse(), pctx
 }
 
-func (s *Server) handleOutboundBody(stream extprocv3.ExternalProcessor_ProcessServer, headers *corev3.HeaderMap, body []byte) *extprocv3.ProcessingResponse {
+func (s *Server) handleOutboundBody(stream extprocv3.ExternalProcessor_ProcessServer, headers *corev3.HeaderMap, body []byte) (*extprocv3.ProcessingResponse, *pipeline.Context) {
 	ctx := stream.Context()
 	pctx := &pipeline.Context{
 		Direction: pipeline.Outbound,
@@ -179,18 +241,112 @@ func (s *Server) handleOutboundBody(stream extprocv3.ExternalProcessor_ProcessSe
 		pctx.Host = getHeader(headers, "host")
 	}
 
+	if s.Sessions != nil {
+		if aid := s.Sessions.ActiveSession(); aid != "" {
+			pctx.Session = s.Sessions.View(aid)
+		}
+	}
+
 	originalAuth := pctx.Headers.Get("Authorization")
 	action := s.OutboundPipeline.Run(ctx, pctx)
 	if action.Type == pipeline.Reject {
 		return denyResponse(typev3.StatusCode_ServiceUnavailable,
-			jsonError("token_acquisition_failed", action.Reason))
+			jsonError("token_acquisition_failed", action.Reason)), nil
 	}
+
+	s.recordOutboundSession(pctx)
 
 	newAuth := pctx.Headers.Get("Authorization")
 	if newAuth != originalAuth {
-		return replaceTokenBodyResponse(extractBearer(newAuth))
+		return replaceTokenBodyResponse(extractBearer(newAuth)), pctx
 	}
-	return passBodyResponse()
+	return passBodyResponse(), pctx
+}
+
+func (s *Server) handleResponseHeaders(ctx context.Context, headers *corev3.HeaderMap, pctx *pipeline.Context, direction string) *extprocv3.ProcessingResponse {
+	if pctx == nil {
+		return &extprocv3.ProcessingResponse{
+			Response: &extprocv3.ProcessingResponse_ResponseHeaders{
+				ResponseHeaders: &extprocv3.HeadersResponse{},
+			},
+		}
+	}
+
+	statusStr := getHeader(headers, ":status")
+	pctx.StatusCode, _ = strconv.Atoi(statusStr)
+	pctx.ResponseHeaders = headerMapToHTTP(headers)
+
+	p := s.OutboundPipeline
+	if direction == "inbound" {
+		p = s.InboundPipeline
+	}
+
+	if p.NeedsBody() {
+		return &extprocv3.ProcessingResponse{
+			Response: &extprocv3.ProcessingResponse_ResponseHeaders{
+				ResponseHeaders: &extprocv3.HeadersResponse{},
+			},
+			ModeOverride: &extprocfilterv3.ProcessingMode{
+				ResponseBodyMode: extprocfilterv3.ProcessingMode_BUFFERED,
+			},
+		}
+	}
+
+	action := p.RunResponse(ctx, pctx)
+	if action.Type == pipeline.Reject {
+		return denyResponse(typev3.StatusCode(action.Status),
+			jsonError("response_blocked", action.Reason))
+	}
+	return &extprocv3.ProcessingResponse{
+		Response: &extprocv3.ProcessingResponse_ResponseHeaders{
+			ResponseHeaders: &extprocv3.HeadersResponse{},
+		},
+	}
+}
+
+func (s *Server) handleResponseBody(ctx context.Context, body []byte, pctx *pipeline.Context, direction string) *extprocv3.ProcessingResponse {
+	if pctx == nil {
+		return &extprocv3.ProcessingResponse{
+			Response: &extprocv3.ProcessingResponse_ResponseBody{
+				ResponseBody: &extprocv3.BodyResponse{},
+			},
+		}
+	}
+
+	pctx.ResponseBody = body
+
+	p := s.OutboundPipeline
+	if direction == "inbound" {
+		p = s.InboundPipeline
+	}
+
+	action := p.RunResponse(ctx, pctx)
+	if action.Type == pipeline.Reject {
+		return denyResponse(typev3.StatusCode(action.Status),
+			jsonError("response_blocked", action.Reason))
+	}
+
+	if string(pctx.ResponseBody) != string(body) {
+		return &extprocv3.ProcessingResponse{
+			Response: &extprocv3.ProcessingResponse_ResponseBody{
+				ResponseBody: &extprocv3.BodyResponse{
+					Response: &extprocv3.CommonResponse{
+						BodyMutation: &extprocv3.BodyMutation{
+							Mutation: &extprocv3.BodyMutation_Body{
+								Body: pctx.ResponseBody,
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	return &extprocv3.ProcessingResponse{
+		Response: &extprocv3.ProcessingResponse_ResponseBody{
+			ResponseBody: &extprocv3.BodyResponse{},
+		},
+	}
 }
 
 func headerMapToHTTP(headers *corev3.HeaderMap) http.Header {

--- a/authbridge/cmd/authbridge/listener/forwardproxy/server.go
+++ b/authbridge/cmd/authbridge/listener/forwardproxy/server.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/pipeline"
+	"github.com/kagenti/kagenti-extensions/authbridge/authlib/session"
 )
 
 const maxBodySize = 1 << 20 // 1MB — matches Envoy's default per_stream_buffer_limit_bytes
@@ -21,13 +22,15 @@ const maxBodySize = 1 << 20 // 1MB — matches Envoy's default per_stream_buffer
 // Server is an HTTP forward proxy that performs token exchange on outbound requests.
 type Server struct {
 	OutboundPipeline *pipeline.Pipeline
+	Sessions         *session.Store // nil when session tracking is disabled
 	Client           *http.Client
 }
 
 // NewServer creates a forward proxy server with a default HTTP client.
-func NewServer(outbound *pipeline.Pipeline) *Server {
+func NewServer(outbound *pipeline.Pipeline, sessions *session.Store) *Server {
 	return &Server{
 		OutboundPipeline: outbound,
+		Sessions:         sessions,
 		Client: &http.Client{
 			Timeout: 30 * time.Second,
 			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
@@ -68,6 +71,12 @@ func (s *Server) handleRequest(w http.ResponseWriter, r *http.Request) {
 		slog.Debug("forward-proxy: buffered request body", "host", r.Host, "bodyLen", len(body))
 	}
 
+	if s.Sessions != nil {
+		if aid := s.Sessions.ActiveSession(); aid != "" {
+			pctx.Session = s.Sessions.View(aid)
+		}
+	}
+
 	originalAuth := pctx.Headers.Get("Authorization")
 	action := s.OutboundPipeline.Run(r.Context(), pctx)
 
@@ -77,6 +86,23 @@ func (s *Server) handleRequest(w http.ResponseWriter, r *http.Request) {
 		body, _ := json.Marshal(map[string]string{"error": action.Reason})
 		w.Write(body)
 		return
+	}
+
+	if s.Sessions != nil {
+		sid := s.Sessions.ActiveSession()
+		if sid == "" {
+			sid = session.DefaultSessionID
+		}
+		ev := pipeline.SessionEvent{
+			At:        time.Now(),
+			Direction: pipeline.Outbound,
+			Phase:     pipeline.SessionRequest,
+			MCP:       pctx.Extensions.MCP,
+			Inference: pctx.Extensions.Inference,
+		}
+		if ev.MCP != nil || ev.Inference != nil {
+			s.Sessions.Append(sid, ev)
+		}
 	}
 
 	newAuth := pctx.Headers.Get("Authorization")
@@ -139,6 +165,23 @@ func (s *Server) handleRequest(w http.ResponseWriter, r *http.Request) {
 		resp.Body = io.NopCloser(bytes.NewReader(pctx.ResponseBody))
 		resp.ContentLength = int64(len(pctx.ResponseBody))
 		resp.Header.Set("Content-Length", fmt.Sprintf("%d", len(pctx.ResponseBody)))
+	}
+
+	if s.Sessions != nil {
+		sid := s.Sessions.ActiveSession()
+		if sid == "" {
+			sid = session.DefaultSessionID
+		}
+		ev := pipeline.SessionEvent{
+			At:        time.Now(),
+			Direction: pipeline.Outbound,
+			Phase:     pipeline.SessionResponse,
+			MCP:       pctx.Extensions.MCP,
+			Inference: pctx.Extensions.Inference,
+		}
+		if ev.MCP != nil || ev.Inference != nil {
+			s.Sessions.Append(sid, ev)
+		}
 	}
 
 	for key, values := range resp.Header {

--- a/authbridge/cmd/authbridge/listener/forwardproxy/server_test.go
+++ b/authbridge/cmd/authbridge/listener/forwardproxy/server_test.go
@@ -95,7 +95,7 @@ func TestForwardProxy_Exchange(t *testing.T) {
 
 func TestForwardProxy_CONNECT_Rejected(t *testing.T) {
 	a := auth.New(auth.Config{})
-	srv := NewServer(outboundPipelineFromAuth(t, a))
+	srv := NewServer(outboundPipelineFromAuth(t, a), nil)
 	proxy := httptest.NewServer(srv.Handler())
 	defer proxy.Close()
 
@@ -116,7 +116,7 @@ func TestForwardProxy_Deny(t *testing.T) {
 		NoTokenPolicy: auth.NoTokenPolicyDeny,
 	})
 
-	srv := NewServer(outboundPipelineFromAuth(t, a))
+	srv := NewServer(outboundPipelineFromAuth(t, a), nil)
 	proxy := httptest.NewServer(srv.Handler())
 	defer proxy.Close()
 

--- a/authbridge/cmd/authbridge/listener/reverseproxy/server.go
+++ b/authbridge/cmd/authbridge/listener/reverseproxy/server.go
@@ -5,36 +5,55 @@ package reverseproxy
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"time"
 
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/pipeline"
+	"github.com/kagenti/kagenti-extensions/authbridge/authlib/session"
 )
 
 const maxBodySize = 1 << 20 // 1MB — matches Envoy's default per_stream_buffer_limit_bytes
 
+type pctxKey struct{}
+
+type responseRejectedError struct {
+	status int
+	reason string
+}
+
+func (e *responseRejectedError) Error() string { return e.reason }
+
 // Server is an HTTP reverse proxy with inbound JWT validation.
 type Server struct {
 	InboundPipeline *pipeline.Pipeline
+	Sessions        *session.Store // nil when session tracking is disabled
 	proxy           *httputil.ReverseProxy
 	backend         string
 }
 
 // NewServer creates a reverse proxy that forwards to the given backend URL.
-func NewServer(inbound *pipeline.Pipeline, backendURL string) (*Server, error) {
+func NewServer(inbound *pipeline.Pipeline, sessions *session.Store, backendURL string) (*Server, error) {
 	target, err := url.Parse(backendURL)
 	if err != nil {
 		return nil, err
 	}
-	return &Server{
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	s := &Server{
 		InboundPipeline: inbound,
-		proxy:           httputil.NewSingleHostReverseProxy(target),
+		Sessions:        sessions,
+		proxy:           proxy,
 		backend:         backendURL,
-	}, nil
+	}
+	proxy.ModifyResponse = s.modifyResponse
+	proxy.ErrorHandler = s.errorHandler
+	return s, nil
 }
 
 // Handler returns the HTTP handler for the reverse proxy.
@@ -72,5 +91,68 @@ func (s *Server) handleRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if s.Sessions != nil && pctx.Extensions.A2A != nil {
+		sid := pctx.Extensions.A2A.SessionID
+		if sid == "" {
+			sid = s.Sessions.ActiveSession()
+		}
+		if sid == "" {
+			sid = session.DefaultSessionID
+		}
+		s.Sessions.Append(sid, pipeline.SessionEvent{
+			At:        time.Now(),
+			Direction: pipeline.Inbound,
+			Phase:     pipeline.SessionRequest,
+			A2A:       pctx.Extensions.A2A,
+		})
+	}
+
+	r = r.WithContext(context.WithValue(r.Context(), pctxKey{}, pctx))
 	s.proxy.ServeHTTP(w, r)
+}
+
+func (s *Server) modifyResponse(resp *http.Response) error {
+	pctx, _ := resp.Request.Context().Value(pctxKey{}).(*pipeline.Context)
+	if pctx == nil {
+		return nil
+	}
+
+	pctx.StatusCode = resp.StatusCode
+	pctx.ResponseHeaders = resp.Header.Clone()
+
+	if s.InboundPipeline.NeedsBody() && resp.Body != nil {
+		body, err := io.ReadAll(io.LimitReader(resp.Body, maxBodySize+1))
+		if err != nil {
+			return err
+		}
+		resp.Body.Close()
+		if len(body) > maxBodySize {
+			return fmt.Errorf("response body too large (%d bytes)", len(body))
+		}
+		pctx.ResponseBody = body
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+	}
+
+	action := s.InboundPipeline.RunResponse(resp.Request.Context(), pctx)
+	if action.Type == pipeline.Reject {
+		return &responseRejectedError{status: action.Status, reason: action.Reason}
+	}
+
+	// If a plugin mutated ResponseBody, use the mutated version.
+	if s.InboundPipeline.NeedsBody() && pctx.ResponseBody != nil {
+		resp.Body = io.NopCloser(bytes.NewReader(pctx.ResponseBody))
+		resp.ContentLength = int64(len(pctx.ResponseBody))
+		resp.Header.Set("Content-Length", fmt.Sprintf("%d", len(pctx.ResponseBody)))
+	}
+	return nil
+}
+
+func (s *Server) errorHandler(w http.ResponseWriter, _ *http.Request, err error) {
+	if rErr, ok := err.(*responseRejectedError); ok {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(rErr.status)
+		json.NewEncoder(w).Encode(map[string]string{"error": rErr.reason})
+		return
+	}
+	http.Error(w, `{"error":"bad gateway"}`, http.StatusBadGateway)
 }

--- a/authbridge/cmd/authbridge/listener/reverseproxy/server_test.go
+++ b/authbridge/cmd/authbridge/listener/reverseproxy/server_test.go
@@ -44,7 +44,7 @@ func TestReverseProxy_AllowedRequest(t *testing.T) {
 		Verifier: &mockVerifier{claims: &validation.Claims{Subject: "user"}},
 		Identity: auth.IdentityConfig{Audience: "my-app"},
 	})
-	srv, err := NewServer(inboundPipelineFromAuth(t, a), backend.URL)
+	srv, err := NewServer(inboundPipelineFromAuth(t, a), nil, backend.URL)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,7 +68,7 @@ func TestReverseProxy_DeniedRequest(t *testing.T) {
 		Verifier: &mockVerifier{err: fmt.Errorf("invalid token")},
 		Identity: auth.IdentityConfig{Audience: "my-app"},
 	})
-	srv, _ := NewServer(inboundPipelineFromAuth(t, a), "http://localhost:9999")
+	srv, _ := NewServer(inboundPipelineFromAuth(t, a), nil, "http://localhost:9999")
 
 	proxy := httptest.NewServer(srv.Handler())
 	defer proxy.Close()
@@ -93,7 +93,7 @@ func TestReverseProxy_BypassPath(t *testing.T) {
 		Verifier: &mockVerifier{err: fmt.Errorf("should not be called")},
 		Bypass:   matcher,
 	})
-	srv, _ := NewServer(inboundPipelineFromAuth(t, a), backend.URL)
+	srv, _ := NewServer(inboundPipelineFromAuth(t, a), nil, backend.URL)
 
 	proxy := httptest.NewServer(srv.Handler())
 	defer proxy.Close()
@@ -137,7 +137,7 @@ func TestReverseProxy_BodyBuffering(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	srv, err := NewServer(p, backend.URL)
+	srv, err := NewServer(p, nil, backend.URL)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -172,7 +172,7 @@ func TestReverseProxy_BodyTooLarge(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	srv, err := NewServer(p, backend.URL)
+	srv, err := NewServer(p, nil, backend.URL)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -202,7 +202,7 @@ func TestReverseProxy_BodyNotBuffered_WhenNotNeeded(t *testing.T) {
 		Verifier: &mockVerifier{claims: &validation.Claims{Subject: "user"}},
 		Identity: auth.IdentityConfig{Audience: "test"},
 	})
-	srv, err := NewServer(inboundPipelineFromAuth(t, a), backend.URL)
+	srv, err := NewServer(inboundPipelineFromAuth(t, a), nil, backend.URL)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/authbridge/cmd/authbridge/main.go
+++ b/authbridge/cmd/authbridge/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/observe"
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/pipeline"
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/plugins"
+	"github.com/kagenti/kagenti-extensions/authbridge/authlib/session"
 	"github.com/kagenti/kagenti-extensions/authbridge/cmd/authbridge/listener/extauthz"
 	"github.com/kagenti/kagenti-extensions/authbridge/cmd/authbridge/listener/extproc"
 	"github.com/kagenti/kagenti-extensions/authbridge/cmd/authbridge/listener/forwardproxy"
@@ -121,6 +122,29 @@ func main() {
 		}
 	}
 
+	// Build session store if enabled (nil when disabled — zero overhead)
+	var sessions *session.Store
+	if cfg.Session.Enabled {
+		ttl := 5 * time.Minute
+		if cfg.Session.TTL != "" {
+			if d, err := time.ParseDuration(cfg.Session.TTL); err == nil {
+				ttl = d
+			} else {
+				slog.Warn("invalid session.ttl, using default", "value", cfg.Session.TTL, "error", err)
+			}
+		}
+		maxEvents := 100
+		if cfg.Session.MaxEvents > 0 {
+			maxEvents = cfg.Session.MaxEvents
+		}
+		maxSessions := 1000
+		if cfg.Session.MaxSessions > 0 {
+			maxSessions = cfg.Session.MaxSessions
+		}
+		sessions = session.New(ttl, maxEvents, maxSessions)
+		slog.Info("session tracking enabled", "ttl", ttl, "maxEvents", maxEvents, "maxSessions", maxSessions)
+	}
+
 	// Track servers for graceful shutdown
 	var grpcServers []*grpc.Server
 	var httpServers []*http.Server
@@ -128,19 +152,19 @@ func main() {
 	// Start listeners FIRST — before credential resolution
 	switch cfg.Mode {
 	case config.ModeEnvoySidecar:
-		grpcServers = append(grpcServers, startGRPCExtProc(inboundPipeline, outboundPipeline, cfg.Listener.ExtProcAddr))
+		grpcServers = append(grpcServers, startGRPCExtProc(inboundPipeline, outboundPipeline, sessions, cfg.Listener.ExtProcAddr))
 
 	case config.ModeWaypoint:
 		grpcServers = append(grpcServers, startGRPCExtAuthz(inboundPipeline, outboundPipeline, cfg.Listener.ExtAuthzAddr))
-		httpServers = append(httpServers, startHTTPServer("forward-proxy", forwardproxy.NewServer(outboundPipeline).Handler(), cfg.Listener.ForwardProxyAddr))
+		httpServers = append(httpServers, startHTTPServer("forward-proxy", forwardproxy.NewServer(outboundPipeline, sessions).Handler(), cfg.Listener.ForwardProxyAddr))
 
 	case config.ModeProxySidecar:
-		rpSrv, err := reverseproxy.NewServer(inboundPipeline, cfg.Listener.ReverseProxyBackend)
+		rpSrv, err := reverseproxy.NewServer(inboundPipeline, sessions, cfg.Listener.ReverseProxyBackend)
 		if err != nil {
 			log.Fatalf("creating reverse proxy: %v", err)
 		}
 		httpServers = append(httpServers, startHTTPServer("reverse-proxy", rpSrv.Handler(), cfg.Listener.ReverseProxyAddr))
-		httpServers = append(httpServers, startHTTPServer("forward-proxy", forwardproxy.NewServer(outboundPipeline).Handler(), cfg.Listener.ForwardProxyAddr))
+		httpServers = append(httpServers, startHTTPServer("forward-proxy", forwardproxy.NewServer(outboundPipeline, sessions).Handler(), cfg.Listener.ForwardProxyAddr))
 
 	default:
 		log.Fatalf("unhandled mode %q", cfg.Mode)
@@ -192,6 +216,9 @@ func main() {
 		srv.Shutdown(shutdownCtx)
 	}
 	statSrv.Shutdown(shutdownCtx)
+	if sessions != nil {
+		sessions.Close()
+	}
 }
 
 func buildInboundPipeline(cfg *config.Config, handler *auth.Auth) (*pipeline.Pipeline, error) {
@@ -211,11 +238,12 @@ func buildOutboundPipeline(cfg *config.Config, handler *auth.Auth) (*pipeline.Pi
 	return plugins.DefaultOutboundPipeline(handler)
 }
 
-func startGRPCExtProc(inbound, outbound *pipeline.Pipeline, addr string) *grpc.Server {
+func startGRPCExtProc(inbound, outbound *pipeline.Pipeline, sessions *session.Store, addr string) *grpc.Server {
 	srv := grpc.NewServer()
 	extprocv3.RegisterExternalProcessorServer(srv, &extproc.Server{
 		InboundPipeline:  inbound,
 		OutboundPipeline: outbound,
+		Sessions:         sessions,
 	})
 	registerHealth(srv)
 	reflection.Register(srv)


### PR DESCRIPTION
## Summary

- Adds in-memory session store (`authbridge/authlib/session/`) that correlates inbound A2A user intents with outbound MCP tool calls and inference requests across request boundaries
- Introduces `pctx.Session` field on `pipeline.Context` so guardrail plugins can read conversation history without coupling to parser plugins
- Integrates session tracking into all three listeners (ext_proc, forward proxy, reverse proxy) with append-after-allow semantics
- Adds `SessionConfig` to enable/configure via runtime YAML (`session.enabled: true`)

## Design

- **Zero overhead when disabled** — `session.enabled` defaults to false; store is nil, no allocations
- **Framework-managed** — session is infrastructure (like identity/routing), not a plugin concern
- **Append-after-allow** — only records events that pass the pipeline; rejected requests are not stored
- **Outbound correlation** — uses A2A `SessionID` as primary key; falls back to most recently active session heuristic for outbound calls that don't carry session IDs

## Configuration

```yaml
session:
  enabled: true
  ttl: 5m
  max_events: 100
```

## Multi-Turn Scenario: Intent-Based Guardrail

Below is a concrete example of how session history enables a guardrail plugin to evaluate tool calls against the original user intent across multiple turns.

### Setup

An agent has the following outbound pipeline configured:

```yaml
pipeline:
  inbound:
    plugins: [jwt-validation, a2a-parser]
  outbound:
    plugins: [mcp-parser, inference-parser, intent-guardrail, token-exchange]
```

### Turn 1: User sends a request via A2A

**Inbound A2A request:**
```json
{"method": "message/send", "params": {"message": {"parts": [{"kind": "text", "text": "What is the weather in NYC?"}]}}}
```

After the inbound pipeline allows this request, the framework appends:

```
Session "sess-abc" events:
  [0] Inbound/Request  A2A{Method: "message/send", Parts: ["What is the weather in NYC?"]}
```

### Turn 2: Agent calls the weather tool via MCP

The agent decides to call the `get_weather` tool. AuthBridge intercepts the outbound MCP request.

**Before the outbound pipeline runs**, the framework populates `pctx.Session` with a snapshot of the session. The `intent-guardrail` plugin now sees:

```go
func (g *IntentGuardrail) OnRequest(ctx context.Context, pctx *pipeline.Context) pipeline.Action {
    if pctx.Session == nil || pctx.Extensions.MCP == nil {
        return pipeline.Action{Type: pipeline.Continue}
    }

    // Read the user's original intent
    lastIntent := pctx.Session.LastIntent()
    // lastIntent.A2A.Parts = ["What is the weather in NYC?"]

    // Read the current tool call
    toolName := pctx.Extensions.MCP.Tool.Name
    // toolName = "get_weather"

    // Evaluate: does "get_weather" align with "What is the weather in NYC?"
    // (evaluation strategy is up to the plugin: LLM, OPA, rules, etc.)
    if !g.isAligned(lastIntent, toolName) {
        return pipeline.Action{Type: pipeline.Reject, Status: 403, Reason: "tool call does not match user intent"}
    }
    return pipeline.Action{Type: pipeline.Continue}
}
```

The guardrail allows it. After the pipeline completes, the framework appends:

```
Session "sess-abc" events:
  [0] Inbound/Request   A2A{"What is the weather in NYC?"}
  [1] Outbound/Request  MCP{tools/call, Tool: "get_weather", Args: {"city": "NYC"}}
```

### Turn 3: Tool response returns

The forward proxy receives the response from the weather MCP server and appends:

```
Session "sess-abc" events:
  [0] Inbound/Request   A2A{"What is the weather in NYC?"}
  [1] Outbound/Request  MCP{tools/call, Tool: "get_weather", Args: {"city": "NYC"}}
  [2] Outbound/Response MCP{tools/call, Tool: "get_weather"}
```

### Turn 4: Agent calls the LLM to generate a response

The agent sends the tool result to an LLM for summarization. The guardrail sees the full history:

```go
// pctx.Session.Events has [0..2] — the full conversation so far
// pctx.Extensions.Inference.Model = "llama3.1"
// pctx.Extensions.Inference.Messages includes the tool result

// Guardrail can verify:
// 1. The inference request references data from an allowed tool call
// 2. The model being used is permitted for this agent
// 3. No prompt injection in the tool result that changes intent
```

Allowed. Framework appends:

```
Session "sess-abc" events:
  [0] Inbound/Request   A2A{"What is the weather in NYC?"}
  [1] Outbound/Request  MCP{tools/call, Tool: "get_weather", Args: {"city": "NYC"}}
  [2] Outbound/Response MCP{tools/call, Tool: "get_weather"}
  [3] Outbound/Request  Inference{model: "llama3.1", messages: [...]}
```

### Turn 5: Multi-turn — user asks a follow-up

A new A2A message arrives: `"What about tomorrow's forecast?"`

```
Session "sess-abc" events:
  [0] Inbound/Request   A2A{"What is the weather in NYC?"}
  [1] Outbound/Request  MCP{tools/call, Tool: "get_weather"}
  [2] Outbound/Response MCP{tools/call, Tool: "get_weather"}
  [3] Outbound/Request  Inference{model: "llama3.1"}
  [4] Inbound/Request   A2A{"What about tomorrow's forecast?"}
```

The agent now calls `get_forecast`. The guardrail sees the full multi-turn context:

```go
// pctx.Session.Intents() returns events [0] and [4]
// pctx.Session.ToolCalls() returns event [1]
// pctx.Extensions.MCP.Tool.Name = "get_forecast"

// The guardrail can reason about the SEQUENCE:
// - User asked about weather → allowed get_weather → now asks about forecast → get_forecast is aligned
```

### Turn 6: Blocked — agent tries an unrelated tool

Suppose the agent (due to a prompt injection or hallucination) tries to call `delete_user`:

```go
// pctx.Session.LastIntent().A2A.Parts = ["What about tomorrow's forecast?"]
// pctx.Extensions.MCP.Tool.Name = "delete_user"

// The guardrail sees the full session:
// - All intents are about weather
// - Past tool calls are all weather-related
// - "delete_user" has no alignment with any intent in the session
// → REJECT
```

Result: `pipeline.Action{Type: pipeline.Reject, Status: 403, Reason: "tool call does not match user intent"}`

The rejected call is **not** appended to the session (append-after-allow), so the session history remains clean.

### Key Takeaways

| Property | How it works |
|----------|-------------|
| No agent code changes | Framework captures events transparently via sidecar traffic interception |
| No plugin coupling | Guardrail reads `pctx.Session` (framework-provided) + `pctx.Extensions.MCP` (parser-provided) — neither knows about the other |
| Multi-turn context | Session accumulates across requests; guardrail sees the full conversation |
| Clean history | Only allowed requests are recorded — no pollution from rejected attempts |
| Configurable scope | TTL and max_events prevent unbounded growth |

## Test plan

- [x] 14 unit tests in `session/store_test.go` covering: append/view, active session, multiple sessions, TTL expiry, max events eviction, concurrent access, cleanup, view helpers
- [x] All existing listener tests pass with nil session store (no behavioral change when disabled)
- [x] `go vet` clean across both modules
- [x] `go build` succeeds for authlib and cmd/authbridge

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>