### PR TITLE
feat: Add response-side parsers and session enrichment

### DIFF
--- a/authbridge/authlib/config/config.go
+++ b/authbridge/authlib/config/config.go
@@ -26,11 +26,23 @@ type Config struct {
 // SessionConfig controls in-memory session tracking for cross-request correlation.
 // When enabled, the framework records inbound intents and outbound tool calls so
 // that guardrail plugins can evaluate sequences across request boundaries.
+//
+// Enabled is a pointer so the loader can distinguish "unset" (apply default)
+// from "explicitly false" (user opted out). Default when unset: enabled.
 type SessionConfig struct {
-	Enabled     bool   `yaml:"enabled" json:"enabled"`
-	TTL         string `yaml:"ttl" json:"ttl"`                   // duration string (e.g., "5m"); default: 5m
+	Enabled     *bool  `yaml:"enabled" json:"enabled"`
+	TTL         string `yaml:"ttl" json:"ttl"`                   // duration string; default: 30m
 	MaxEvents   int    `yaml:"max_events" json:"max_events"`     // max events per session; default: 100
-	MaxSessions int    `yaml:"max_sessions" json:"max_sessions"` // max concurrent sessions; default: 1000 (0 = unlimited)
+	MaxSessions int    `yaml:"max_sessions" json:"max_sessions"` // max concurrent sessions; default: 100 (0 = unlimited)
+}
+
+// SessionEnabled returns true when session tracking should run. Defaults to true
+// when Enabled is unset, so operators need to explicitly opt out.
+func (s SessionConfig) SessionEnabled() bool {
+	if s.Enabled == nil {
+		return true
+	}
+	return *s.Enabled
 }
 
 // PipelineConfig holds the plugin pipeline composition.

--- a/authbridge/authlib/config/config.go
+++ b/authbridge/authlib/config/config.go
@@ -30,6 +30,9 @@ type Config struct {
 // Enabled is a pointer so the loader can distinguish "unset" (apply default)
 // from "explicitly false" (user opted out). Default when unset: enabled.
 type SessionConfig struct {
+	// Enabled: nil means "unset → default on". Explicit `false` opts out.
+	// Do not change to a plain bool — losing the nil sentinel would collapse
+	// "user didn't say" with "user said false" and silently flip the default.
 	Enabled     *bool  `yaml:"enabled" json:"enabled"`
 	TTL         string `yaml:"ttl" json:"ttl"`                   // duration string; default: 30m
 	MaxEvents   int    `yaml:"max_events" json:"max_events"`     // max events per session; default: 100

--- a/authbridge/authlib/config/config_test.go
+++ b/authbridge/authlib/config/config_test.go
@@ -336,3 +336,26 @@ func validProxySidecarConfig() *Config {
 		Listener: ListenerConfig{ReverseProxyBackend: "http://localhost:8081"},
 	}
 }
+
+func TestSessionConfig_SessionEnabled(t *testing.T) {
+	t.Run("unset defaults to enabled", func(t *testing.T) {
+		var s SessionConfig
+		if !s.SessionEnabled() {
+			t.Error("unset Enabled should default to true")
+		}
+	})
+	t.Run("explicit true", func(t *testing.T) {
+		b := true
+		s := SessionConfig{Enabled: &b}
+		if !s.SessionEnabled() {
+			t.Error("explicit true should be true")
+		}
+	})
+	t.Run("explicit false disables", func(t *testing.T) {
+		b := false
+		s := SessionConfig{Enabled: &b}
+		if s.SessionEnabled() {
+			t.Error("explicit false should opt out")
+		}
+	})
+}

--- a/authbridge/authlib/pipeline/context.go
+++ b/authbridge/authlib/pipeline/context.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/routing"
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/validation"
@@ -25,6 +26,11 @@ type Context struct {
 	Path      string
 	Headers   http.Header
 	Body      []byte // nil unless at least one plugin declares BodyAccess: true
+
+	// StartedAt is the wall-clock time this context was constructed by the
+	// listener at the start of a request. Used on the response path to
+	// compute SessionEvent.Duration without walking the event history.
+	StartedAt time.Time
 
 	Agent   *AgentIdentity
 	Claims  *validation.Claims    // nil before jwt-validation runs

--- a/authbridge/authlib/pipeline/extensions.go
+++ b/authbridge/authlib/pipeline/extensions.go
@@ -37,7 +37,8 @@ type A2APart struct {
 	Content string // text content, file URI, or serialized data
 }
 
-// InferenceExtension carries parsed LLM inference request metadata.
+// InferenceExtension carries parsed LLM inference request and response metadata.
+// Request fields are populated by OnRequest; response fields by OnResponse.
 type InferenceExtension struct {
 	Model       string             // model name (e.g., "llama3.1", "gpt-4")
 	Messages    []InferenceMessage // conversation messages
@@ -45,6 +46,13 @@ type InferenceExtension struct {
 	MaxTokens   *int               // max tokens to generate (nil if not set)
 	Stream      bool               // whether streaming is requested
 	Tools       []string           // tool/function names declared
+
+	// Response fields (populated after OnResponse runs).
+	Completion       string // assistant's response text (concatenated across SSE deltas)
+	FinishReason     string // "stop", "length", "tool_calls", "content_filter", etc.
+	PromptTokens     int    // tokens consumed by the prompt
+	CompletionTokens int    // tokens generated in the response
+	TotalTokens      int    // PromptTokens + CompletionTokens (as reported by the server)
 }
 
 // InferenceMessage represents a single message in the conversation.

--- a/authbridge/authlib/pipeline/extensions.go
+++ b/authbridge/authlib/pipeline/extensions.go
@@ -14,11 +14,20 @@ type Extensions struct {
 }
 
 // MCPExtension carries parsed MCP JSON-RPC metadata.
+// Result and Err are mutually exclusive: a response sets exactly one.
 type MCPExtension struct {
 	Method string         // JSON-RPC method (e.g. "tools/call", "resources/read", "initialize")
 	RPCID  any            // JSON-RPC id for request-response correlation
 	Params map[string]any // raw params from the JSON-RPC request
-	Result map[string]any // parsed result from the JSON-RPC response (nil until OnResponse runs)
+	Result map[string]any // parsed successful result; nil on error or before OnResponse runs
+	Err    *MCPError      // non-nil when the server returned a JSON-RPC error
+}
+
+// MCPError mirrors a JSON-RPC 2.0 error object.
+type MCPError struct {
+	Code    int    // JSON-RPC error code (e.g. -32601 method not found)
+	Message string // human-readable error message
+	Data    any    // optional structured error data (implementation-defined)
 }
 
 // A2AExtension carries parsed A2A protocol metadata from inbound requests.

--- a/authbridge/authlib/pipeline/extensions.go
+++ b/authbridge/authlib/pipeline/extensions.go
@@ -18,6 +18,7 @@ type MCPExtension struct {
 	Method string         // JSON-RPC method (e.g. "tools/call", "resources/read", "initialize")
 	RPCID  any            // JSON-RPC id for request-response correlation
 	Params map[string]any // raw params from the JSON-RPC request
+	Result map[string]any // parsed result from the JSON-RPC response (nil until OnResponse runs)
 }
 
 // A2AExtension carries parsed A2A protocol metadata from inbound requests.

--- a/authbridge/authlib/pipeline/session.go
+++ b/authbridge/authlib/pipeline/session.go
@@ -46,6 +46,24 @@ type SessionEvent struct {
 	// successful requests and 2xx responses. Populated for non-2xx responses,
 	// guardrail blocks, and parse failures.
 	Error *EventError
+
+	// Host is the HTTP :authority (or Host header) of the event. For inbound
+	// events it's the agent's own address; for outbound events it's the
+	// target service, which is the useful case — a session with many
+	// outbound calls can be attributed to the tool / LLM / target each
+	// landed on. Empty when the listener didn't populate pctx.Host.
+	Host string
+
+	// TargetAudience is the OAuth audience the outbound request was routed
+	// to, or empty when no route matched (passthrough) or the event is
+	// inbound. Useful for policy plugins that care which target scope a
+	// call was made against, independent of host (which can be a glob).
+	TargetAudience string
+
+	// Duration is the wall-clock time from request entry into the listener
+	// to response recording. Zero on request-phase events. On response
+	// events it's computed as now - matching-request.At.
+	Duration time.Duration
 }
 
 // EventIdentity carries the "who" for a session event.

--- a/authbridge/authlib/pipeline/session.go
+++ b/authbridge/authlib/pipeline/session.go
@@ -30,6 +30,37 @@ type SessionEvent struct {
 	A2A       *A2AExtension
 	MCP       *MCPExtension
 	Inference *InferenceExtension
+
+	// Identity snapshot at record time. Lets downstream plugins attribute an
+	// event to the caller (Subject) and the handling sidecar (AgentID)
+	// without re-parsing the original request. Nil for events recorded
+	// before jwt-validation ran or when session tracking is disabled.
+	Identity *EventIdentity
+
+	// StatusCode is the HTTP status of the response. Zero on request events
+	// and on response events that were recorded before the status was known
+	// (e.g., connection reset). A non-zero value >= 400 also populates Error.
+	StatusCode int
+
+	// Error captures a terminal error condition for this event. Nil on
+	// successful requests and 2xx responses. Populated for non-2xx responses,
+	// guardrail blocks, and parse failures.
+	Error *EventError
+}
+
+// EventIdentity carries the "who" for a session event.
+type EventIdentity struct {
+	Subject  string   // end-user subject from JWT (Claims.Subject)
+	Scopes   []string // validated scopes
+	ClientID string   // JWT azp claim (the client that minted the token)
+	AgentID  string   // the sidecar's own workload identity (Agent.WorkloadID)
+}
+
+// EventError describes why a response event represents a failure.
+type EventError struct {
+	Kind    string // "backend_error" | "blocked" | "parser_error" | "timeout"
+	Code    string // protocol-specific error code (HTTP status, JSON-RPC code, etc.)
+	Message string // human-readable reason; safe to surface in logs/metrics
 }
 
 // SessionView is a read-only snapshot of a session, safe to pass to plugins.
@@ -96,3 +127,24 @@ func (v *SessionView) LastIntent() *SessionEvent {
 
 // Len returns total event count.
 func (v *SessionView) Len() int { return len(v.Events) }
+
+// FailedEvents returns response-phase events that carry an Error.
+func (v *SessionView) FailedEvents() []SessionEvent {
+	var out []SessionEvent
+	for _, e := range v.Events {
+		if e.Phase == SessionResponse && e.Error != nil {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// LastError returns the most recent response event with an Error, or nil.
+func (v *SessionView) LastError() *SessionEvent {
+	for i := len(v.Events) - 1; i >= 0; i-- {
+		if v.Events[i].Phase == SessionResponse && v.Events[i].Error != nil {
+			return &v.Events[i]
+		}
+	}
+	return nil
+}

--- a/authbridge/authlib/plugins/a2aparser.go
+++ b/authbridge/authlib/plugins/a2aparser.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"log/slog"
@@ -43,7 +44,11 @@ func (p *A2AParser) OnRequest(_ context.Context, pctx *pipeline.Context) pipelin
 
 	// Extract message fields generically — any method with params.message
 	// gets full extraction (forward-compatible with future A2A methods).
-	ext.SessionID = rpc.stringParam("sessionId")
+	// A2A spec uses "contextId" (current) or "sessionId" (older drafts).
+	ext.SessionID = rpc.stringParam("contextId")
+	if ext.SessionID == "" {
+		ext.SessionID = rpc.stringParam("sessionId")
+	}
 	if msg := rpc.mapParam("message"); msg != nil {
 		if role, ok := msg["role"].(string); ok {
 			ext.Role = role
@@ -69,8 +74,62 @@ func (p *A2AParser) OnRequest(_ context.Context, pctx *pipeline.Context) pipelin
 	return pipeline.Action{Type: pipeline.Continue}
 }
 
-func (p *A2AParser) OnResponse(_ context.Context, _ *pipeline.Context) pipeline.Action {
+// OnResponse extracts the server-assigned session/context ID from the response body
+// and stores it on the A2A extension. This lets downstream plugins correlate the
+// freshly-assigned session for the next turn of the conversation, since clients
+// typically don't include a contextId on the first message.
+//
+// Handles both JSON-RPC responses (message/send) and SSE event streams (message/stream).
+func (p *A2AParser) OnResponse(_ context.Context, pctx *pipeline.Context) pipeline.Action {
+	if len(pctx.ResponseBody) == 0 || pctx.Extensions.A2A == nil {
+		return pipeline.Action{Type: pipeline.Continue}
+	}
+
+	sid := extractSessionID(pctx.ResponseBody)
+	if sid == "" {
+		slog.Debug("a2a-parser: no sessionId or contextId found in response")
+		return pipeline.Action{Type: pipeline.Continue}
+	}
+
+	pctx.Extensions.A2A.SessionID = sid
+	slog.Debug("a2a-parser: response sessionId", "sessionId", sid)
 	return pipeline.Action{Type: pipeline.Continue}
+}
+
+// extractSessionID finds a contextId (preferred) or sessionId in the response.
+// Supports plain JSON-RPC responses and SSE event streams (message/stream).
+func extractSessionID(body []byte) string {
+	if sid := sessionIDFromJSON(body); sid != "" {
+		return sid
+	}
+	// SSE format: scan "data:" lines for the first event that carries a session ID.
+	for _, line := range bytes.Split(body, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if !bytes.HasPrefix(line, []byte("data:")) {
+			continue
+		}
+		data := bytes.TrimSpace(bytes.TrimPrefix(line, []byte("data:")))
+		if sid := sessionIDFromJSON(data); sid != "" {
+			return sid
+		}
+	}
+	return ""
+}
+
+func sessionIDFromJSON(data []byte) string {
+	var resp struct {
+		Result struct {
+			ContextID string `json:"contextId"`
+			SessionID string `json:"sessionId"`
+		} `json:"result"`
+	}
+	if json.Unmarshal(data, &resp) != nil {
+		return ""
+	}
+	if resp.Result.ContextID != "" {
+		return resp.Result.ContextID
+	}
+	return resp.Result.SessionID
 }
 
 func parseA2AParts(rawParts []any) []pipeline.A2APart {

--- a/authbridge/authlib/plugins/a2aparser.go
+++ b/authbridge/authlib/plugins/a2aparser.go
@@ -71,6 +71,9 @@ func (p *A2AParser) OnRequest(_ context.Context, pctx *pipeline.Context) pipelin
 		"messageId", ext.MessageID,
 		"parts", len(ext.Parts),
 	)
+	for i, part := range ext.Parts {
+		slog.Debug("a2a-parser: part", "index", i, "kind", part.Kind, "content", truncate(part.Content, debugBodyMax))
+	}
 	return pipeline.Action{Type: pipeline.Continue}
 }
 
@@ -93,6 +96,7 @@ func (p *A2AParser) OnResponse(_ context.Context, pctx *pipeline.Context) pipeli
 
 	pctx.Extensions.A2A.SessionID = sid
 	slog.Debug("a2a-parser: response sessionId", "sessionId", sid)
+	slog.Debug("a2a-parser: response body", "body", truncate(string(pctx.ResponseBody), debugBodyMax))
 	return pipeline.Action{Type: pipeline.Continue}
 }
 

--- a/authbridge/authlib/plugins/a2aparser_test.go
+++ b/authbridge/authlib/plugins/a2aparser_test.go
@@ -364,10 +364,124 @@ func TestA2AParser_MalformedContentValues(t *testing.T) {
 	}
 }
 
-func TestA2AParser_OnResponse(t *testing.T) {
+func TestA2AParser_OnResponse_NoRequestContext(t *testing.T) {
+	// If OnRequest never ran (no A2A extension on pctx), OnResponse is a no-op.
 	p := NewA2AParser()
-	action := p.OnResponse(context.Background(), &pipeline.Context{})
+	pctx := &pipeline.Context{
+		ResponseBody: []byte(`{"jsonrpc":"2.0","result":{"contextId":"abc-123"}}`),
+	}
+	action := p.OnResponse(context.Background(), pctx)
 	if action.Type != pipeline.Continue {
-		t.Errorf("OnResponse should return Continue, got %v", action.Type)
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	if pctx.Extensions.A2A != nil {
+		t.Error("A2A extension should remain nil when request was not parsed")
+	}
+}
+
+func TestA2AParser_OnResponse_EmptyBody(t *testing.T) {
+	p := NewA2AParser()
+	pctx := &pipeline.Context{
+		Extensions: pipeline.Extensions{A2A: &pipeline.A2AExtension{Method: "message/send"}},
+	}
+	action := p.OnResponse(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	if pctx.Extensions.A2A.SessionID != "" {
+		t.Errorf("SessionID should remain empty, got %q", pctx.Extensions.A2A.SessionID)
+	}
+}
+
+func TestA2AParser_OnResponse_JSONRPC_ContextID(t *testing.T) {
+	p := NewA2AParser()
+	pctx := &pipeline.Context{
+		Extensions:   pipeline.Extensions{A2A: &pipeline.A2AExtension{Method: "message/send"}},
+		ResponseBody: []byte(`{"jsonrpc":"2.0","id":1,"result":{"contextId":"ctx-abc","messageId":"m1"}}`),
+	}
+	action := p.OnResponse(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	if pctx.Extensions.A2A.SessionID != "ctx-abc" {
+		t.Errorf("SessionID = %q, want %q", pctx.Extensions.A2A.SessionID, "ctx-abc")
+	}
+}
+
+func TestA2AParser_OnResponse_JSONRPC_SessionIDFallback(t *testing.T) {
+	// Older A2A drafts use sessionId — still extract it when contextId is absent.
+	p := NewA2AParser()
+	pctx := &pipeline.Context{
+		Extensions:   pipeline.Extensions{A2A: &pipeline.A2AExtension{Method: "message/send"}},
+		ResponseBody: []byte(`{"jsonrpc":"2.0","id":1,"result":{"sessionId":"sess-legacy"}}`),
+	}
+	action := p.OnResponse(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	if pctx.Extensions.A2A.SessionID != "sess-legacy" {
+		t.Errorf("SessionID = %q, want %q", pctx.Extensions.A2A.SessionID, "sess-legacy")
+	}
+}
+
+func TestA2AParser_OnResponse_SSE(t *testing.T) {
+	// message/stream returns SSE events; each "data:" line carries a JSON-RPC event.
+	p := NewA2AParser()
+	body := "data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"contextId\":\"ctx-sse\",\"kind\":\"message\"}}\r\n\r\n" +
+		"data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"contextId\":\"ctx-sse\",\"kind\":\"status-update\"}}\r\n\r\n"
+	pctx := &pipeline.Context{
+		Extensions:   pipeline.Extensions{A2A: &pipeline.A2AExtension{Method: "message/stream"}},
+		ResponseBody: []byte(body),
+	}
+	action := p.OnResponse(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	if pctx.Extensions.A2A.SessionID != "ctx-sse" {
+		t.Errorf("SessionID = %q, want %q", pctx.Extensions.A2A.SessionID, "ctx-sse")
+	}
+}
+
+func TestA2AParser_OnResponse_SSE_SkipsEventsWithoutSession(t *testing.T) {
+	// The first "data:" line carries no contextId; the parser should keep scanning
+	// rather than give up on the first event.
+	p := NewA2AParser()
+	body := "data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"kind\":\"status-update\"}}\r\n\r\n" +
+		"data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"contextId\":\"ctx-late\"}}\r\n\r\n"
+	pctx := &pipeline.Context{
+		Extensions:   pipeline.Extensions{A2A: &pipeline.A2AExtension{Method: "message/stream"}},
+		ResponseBody: []byte(body),
+	}
+	_ = p.OnResponse(context.Background(), pctx)
+	if pctx.Extensions.A2A.SessionID != "ctx-late" {
+		t.Errorf("SessionID = %q, want %q", pctx.Extensions.A2A.SessionID, "ctx-late")
+	}
+}
+
+func TestA2AParser_OnResponse_NoSessionFound(t *testing.T) {
+	p := NewA2AParser()
+	pctx := &pipeline.Context{
+		Extensions:   pipeline.Extensions{A2A: &pipeline.A2AExtension{Method: "message/send", SessionID: "preexisting"}},
+		ResponseBody: []byte(`{"jsonrpc":"2.0","id":1,"result":{"kind":"message"}}`),
+	}
+	_ = p.OnResponse(context.Background(), pctx)
+	// Should NOT overwrite the existing value when the response has no session.
+	if pctx.Extensions.A2A.SessionID != "preexisting" {
+		t.Errorf("SessionID = %q, should not be cleared", pctx.Extensions.A2A.SessionID)
+	}
+}
+
+func TestA2AParser_OnRequest_ContextIDPreferred(t *testing.T) {
+	// A client resuming a conversation sends contextId; we should pick it up on the request side too.
+	p := NewA2AParser()
+	pctx := &pipeline.Context{
+		Body: []byte(`{"jsonrpc":"2.0","method":"message/send","id":1,"params":{"contextId":"ctx-resume","message":{"role":"user","messageId":"m2","parts":[{"kind":"text","text":"hi again"}]}}}`),
+	}
+	action := p.OnRequest(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	if pctx.Extensions.A2A == nil || pctx.Extensions.A2A.SessionID != "ctx-resume" {
+		t.Errorf("SessionID from contextId: got %+v, want ctx-resume", pctx.Extensions.A2A)
 	}
 }

--- a/authbridge/authlib/plugins/inferenceparser.go
+++ b/authbridge/authlib/plugins/inferenceparser.go
@@ -65,6 +65,9 @@ func (p *InferenceParser) OnRequest(_ context.Context, pctx *pipeline.Context) p
 
 	slog.Info("inference-parser", "model", ext.Model)
 	slog.Debug("inference-parser: extracted", "model", ext.Model, "messages", len(ext.Messages), "stream", ext.Stream, "tools", len(ext.Tools))
+	for i, m := range ext.Messages {
+		slog.Debug("inference-parser: message", "index", i, "role", m.Role, "content", truncate(m.Content, debugBodyMax))
+	}
 
 	return pipeline.Action{Type: pipeline.Continue}
 }
@@ -90,6 +93,7 @@ func (p *InferenceParser) OnResponse(_ context.Context, pctx *pipeline.Context) 
 		"promptTokens", ext.PromptTokens,
 		"completionTokens", ext.CompletionTokens,
 	)
+	slog.Debug("inference-parser: completion", "text", truncate(ext.Completion, debugBodyMax))
 	return pipeline.Action{Type: pipeline.Continue}
 }
 

--- a/authbridge/authlib/plugins/inferenceparser.go
+++ b/authbridge/authlib/plugins/inferenceparser.go
@@ -183,9 +183,58 @@ type inferenceRequest struct {
 	Tools       []inferenceTool    `json:"tools"`
 }
 
+// inferenceMessage accepts both OpenAI content shapes:
+//   - "content": "plain string"
+//   - "content": [{"type":"text","text":"..."}, {"type":"image_url",...}, ...]
+//
+// The array form is used for multi-modal input and tool-result messages.
+// Non-text parts (image_url, tool_use objects, etc.) are dropped since the
+// parser only exposes text for downstream policy plugins.
 type inferenceMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role    string
+	Content string
+}
+
+func (m *inferenceMessage) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	m.Role = raw.Role
+	m.Content = flattenContent(raw.Content)
+	return nil
+}
+
+// flattenContent returns the text representation of an OpenAI content value.
+// Returns "" when content is absent, null, or contains no text parts.
+func flattenContent(raw json.RawMessage) string {
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var parts []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(raw, &parts); err == nil {
+		var b strings.Builder
+		for _, p := range parts {
+			if p.Type == "text" && p.Text != "" {
+				if b.Len() > 0 {
+					b.WriteByte('\n')
+				}
+				b.WriteString(p.Text)
+			}
+		}
+		return b.String()
+	}
+	return ""
 }
 
 type inferenceTool struct {

--- a/authbridge/authlib/plugins/inferenceparser.go
+++ b/authbridge/authlib/plugins/inferenceparser.go
@@ -1,9 +1,11 @@
 package plugins
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"log/slog"
+	"strings"
 
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/pipeline"
 )
@@ -67,8 +69,109 @@ func (p *InferenceParser) OnRequest(_ context.Context, pctx *pipeline.Context) p
 	return pipeline.Action{Type: pipeline.Continue}
 }
 
-func (p *InferenceParser) OnResponse(_ context.Context, _ *pipeline.Context) pipeline.Action {
+// OnResponse populates the response-side fields (Completion, FinishReason,
+// token counts) on pctx.Extensions.Inference. Handles both non-streaming
+// JSON responses and SSE streams from OpenAI-compatible servers.
+func (p *InferenceParser) OnResponse(_ context.Context, pctx *pipeline.Context) pipeline.Action {
+	if len(pctx.ResponseBody) == 0 || pctx.Extensions.Inference == nil {
+		return pipeline.Action{Type: pipeline.Continue}
+	}
+
+	if pctx.Extensions.Inference.Stream {
+		parseInferenceSSE(pctx.ResponseBody, pctx.Extensions.Inference)
+	} else {
+		parseInferenceJSON(pctx.ResponseBody, pctx.Extensions.Inference)
+	}
+
+	ext := pctx.Extensions.Inference
+	slog.Info("inference-parser: response",
+		"model", ext.Model,
+		"finishReason", ext.FinishReason,
+		"promptTokens", ext.PromptTokens,
+		"completionTokens", ext.CompletionTokens,
+	)
 	return pipeline.Action{Type: pipeline.Continue}
+}
+
+// parseInferenceJSON parses a non-streaming OpenAI chat/completions response.
+func parseInferenceJSON(body []byte, ext *pipeline.InferenceExtension) {
+	var resp inferenceResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		slog.Debug("inference-parser: invalid response JSON", "error", err)
+		return
+	}
+	if len(resp.Choices) > 0 {
+		ext.Completion = resp.Choices[0].Message.Content
+		ext.FinishReason = resp.Choices[0].FinishReason
+	}
+	ext.PromptTokens = resp.Usage.PromptTokens
+	ext.CompletionTokens = resp.Usage.CompletionTokens
+	ext.TotalTokens = resp.Usage.TotalTokens
+}
+
+// parseInferenceSSE concatenates content deltas across SSE events and captures
+// the last finish_reason and usage block (sent when stream_options.include_usage
+// is set). The stream terminates with a "data: [DONE]" marker which is skipped.
+func parseInferenceSSE(body []byte, ext *pipeline.InferenceExtension) {
+	var completion strings.Builder
+	for _, line := range bytes.Split(body, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if !bytes.HasPrefix(line, []byte("data:")) {
+			continue
+		}
+		data := bytes.TrimSpace(bytes.TrimPrefix(line, []byte("data:")))
+		if len(data) == 0 || bytes.Equal(data, []byte("[DONE]")) {
+			continue
+		}
+		var chunk inferenceStreamChunk
+		if json.Unmarshal(data, &chunk) != nil {
+			continue
+		}
+		for _, c := range chunk.Choices {
+			if c.Delta.Content != "" {
+				completion.WriteString(c.Delta.Content)
+			}
+			if c.FinishReason != "" {
+				ext.FinishReason = c.FinishReason
+			}
+		}
+		if chunk.Usage.TotalTokens > 0 {
+			ext.PromptTokens = chunk.Usage.PromptTokens
+			ext.CompletionTokens = chunk.Usage.CompletionTokens
+			ext.TotalTokens = chunk.Usage.TotalTokens
+		}
+	}
+	ext.Completion = completion.String()
+}
+
+type inferenceResponse struct {
+	Choices []inferenceChoice `json:"choices"`
+	Usage   inferenceUsage    `json:"usage"`
+}
+
+type inferenceChoice struct {
+	Message      inferenceMessage `json:"message"`
+	FinishReason string           `json:"finish_reason"`
+}
+
+type inferenceStreamChunk struct {
+	Choices []inferenceStreamChoice `json:"choices"`
+	Usage   inferenceUsage          `json:"usage"`
+}
+
+type inferenceStreamChoice struct {
+	Delta        inferenceDelta `json:"delta"`
+	FinishReason string         `json:"finish_reason"`
+}
+
+type inferenceDelta struct {
+	Content string `json:"content"`
+}
+
+type inferenceUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
 }
 
 type inferenceRequest struct {

--- a/authbridge/authlib/plugins/inferenceparser.go
+++ b/authbridge/authlib/plugins/inferenceparser.go
@@ -128,7 +128,8 @@ func parseInferenceSSE(body []byte, ext *pipeline.InferenceExtension) {
 			continue
 		}
 		var chunk inferenceStreamChunk
-		if json.Unmarshal(data, &chunk) != nil {
+		if err := json.Unmarshal(data, &chunk); err != nil {
+			slog.Debug("inference-parser: skipping malformed SSE data frame", "error", err, "data", truncate(string(data), 128))
 			continue
 		}
 		for _, c := range chunk.Choices {

--- a/authbridge/authlib/plugins/inferenceparser_test.go
+++ b/authbridge/authlib/plugins/inferenceparser_test.go
@@ -250,10 +250,99 @@ func TestInferenceParser_LegacyCompletions(t *testing.T) {
 	}
 }
 
-func TestInferenceParser_OnResponse(t *testing.T) {
+func TestInferenceParser_OnResponse_NoRequestContext(t *testing.T) {
+	// Without an Inference extension (e.g., path didn't match on the request),
+	// OnResponse should be a no-op.
 	p := NewInferenceParser()
-	action := p.OnResponse(context.Background(), &pipeline.Context{})
+	pctx := &pipeline.Context{
+		ResponseBody: []byte(`{"choices":[{"message":{"content":"hi"}}]}`),
+	}
+	action := p.OnResponse(context.Background(), pctx)
 	if action.Type != pipeline.Continue {
-		t.Errorf("OnResponse should return Continue, got %v", action.Type)
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	if pctx.Extensions.Inference != nil {
+		t.Error("Inference extension should remain nil when request was not parsed")
+	}
+}
+
+func TestInferenceParser_OnResponse_EmptyBody(t *testing.T) {
+	p := NewInferenceParser()
+	pctx := &pipeline.Context{
+		Extensions: pipeline.Extensions{Inference: &pipeline.InferenceExtension{Model: "gpt-4"}},
+	}
+	action := p.OnResponse(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	if pctx.Extensions.Inference.Completion != "" {
+		t.Errorf("Completion = %q, want empty", pctx.Extensions.Inference.Completion)
+	}
+}
+
+func TestInferenceParser_OnResponse_NonStreaming(t *testing.T) {
+	p := NewInferenceParser()
+	pctx := &pipeline.Context{
+		Extensions: pipeline.Extensions{Inference: &pipeline.InferenceExtension{Model: "gpt-4"}},
+		ResponseBody: []byte(`{
+			"choices":[{"message":{"role":"assistant","content":"Hello, world!"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":12,"completion_tokens":5,"total_tokens":17}
+		}`),
+	}
+	action := p.OnResponse(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	ext := pctx.Extensions.Inference
+	if ext.Completion != "Hello, world!" {
+		t.Errorf("Completion = %q, want %q", ext.Completion, "Hello, world!")
+	}
+	if ext.FinishReason != "stop" {
+		t.Errorf("FinishReason = %q, want %q", ext.FinishReason, "stop")
+	}
+	if ext.PromptTokens != 12 || ext.CompletionTokens != 5 || ext.TotalTokens != 17 {
+		t.Errorf("Tokens = (%d, %d, %d), want (12, 5, 17)", ext.PromptTokens, ext.CompletionTokens, ext.TotalTokens)
+	}
+}
+
+func TestInferenceParser_OnResponse_SSE(t *testing.T) {
+	p := NewInferenceParser()
+	body := "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{\"content\":\", \"}}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{\"content\":\"world!\"},\"finish_reason\":\"stop\"}]}\n\n" +
+		"data: {\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":3,\"total_tokens\":13}}\n\n" +
+		"data: [DONE]\n\n"
+	pctx := &pipeline.Context{
+		Extensions: pipeline.Extensions{Inference: &pipeline.InferenceExtension{Model: "gpt-4", Stream: true}},
+		ResponseBody: []byte(body),
+	}
+	action := p.OnResponse(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	ext := pctx.Extensions.Inference
+	if ext.Completion != "Hello, world!" {
+		t.Errorf("Completion = %q, want %q", ext.Completion, "Hello, world!")
+	}
+	if ext.FinishReason != "stop" {
+		t.Errorf("FinishReason = %q, want %q", ext.FinishReason, "stop")
+	}
+	if ext.TotalTokens != 13 {
+		t.Errorf("TotalTokens = %d, want 13", ext.TotalTokens)
+	}
+}
+
+func TestInferenceParser_OnResponse_InvalidJSON(t *testing.T) {
+	p := NewInferenceParser()
+	pctx := &pipeline.Context{
+		Extensions:   pipeline.Extensions{Inference: &pipeline.InferenceExtension{Model: "gpt-4"}},
+		ResponseBody: []byte("not json"),
+	}
+	action := p.OnResponse(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	if pctx.Extensions.Inference.Completion != "" {
+		t.Error("Completion should remain empty on parse failure")
 	}
 }

--- a/authbridge/authlib/plugins/inferenceparser_test.go
+++ b/authbridge/authlib/plugins/inferenceparser_test.go
@@ -346,3 +346,75 @@ func TestInferenceParser_OnResponse_InvalidJSON(t *testing.T) {
 		t.Error("Completion should remain empty on parse failure")
 	}
 }
+
+func TestInferenceParser_MultipartContent(t *testing.T) {
+	// Follow-up requests after tool calls often carry `content` as an array
+	// of parts. The parser must accept this shape without failing the whole
+	// unmarshal — previously the entire request was silently dropped because
+	// Content was typed as string.
+	p := NewInferenceParser()
+	body := `{
+		"model": "gpt-4",
+		"messages": [
+			{"role": "user", "content": "what's the weather?"},
+			{"role": "tool", "content": [{"type":"text","text":"sunny, 72F"}]},
+			{"role": "user", "content": [
+				{"type":"text","text":"hello"},
+				{"type":"image_url","image_url":{"url":"http://x"}},
+				{"type":"text","text":"there"}
+			]}
+		]
+	}`
+	pctx := &pipeline.Context{
+		Path: "/v1/chat/completions",
+		Body: []byte(body),
+	}
+
+	action := p.OnRequest(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	if pctx.Extensions.Inference == nil {
+		t.Fatal("Inference extension should be populated despite array content")
+	}
+	msgs := pctx.Extensions.Inference.Messages
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(msgs))
+	}
+	if msgs[0].Content != "what's the weather?" {
+		t.Errorf("msg[0].Content = %q, want plain string", msgs[0].Content)
+	}
+	if msgs[1].Content != "sunny, 72F" {
+		t.Errorf("msg[1].Content = %q, want flattened text part", msgs[1].Content)
+	}
+	// Non-text parts dropped, multiple text parts joined with newline.
+	if msgs[2].Content != "hello\nthere" {
+		t.Errorf("msg[2].Content = %q, want %q", msgs[2].Content, "hello\nthere")
+	}
+}
+
+func TestInferenceParser_NullContent(t *testing.T) {
+	// Assistant messages that only carry tool_calls have content: null.
+	p := NewInferenceParser()
+	body := `{
+		"model": "gpt-4",
+		"messages": [
+			{"role": "assistant", "content": null, "tool_calls": []}
+		]
+	}`
+	pctx := &pipeline.Context{
+		Path: "/v1/chat/completions",
+		Body: []byte(body),
+	}
+
+	action := p.OnRequest(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	if pctx.Extensions.Inference == nil {
+		t.Fatal("Inference extension should be populated despite null content")
+	}
+	if pctx.Extensions.Inference.Messages[0].Content != "" {
+		t.Errorf("Content = %q, want empty for null", pctx.Extensions.Inference.Messages[0].Content)
+	}
+}

--- a/authbridge/authlib/plugins/mcpparser.go
+++ b/authbridge/authlib/plugins/mcpparser.go
@@ -61,8 +61,12 @@ func (p *MCPParser) OnResponse(_ context.Context, pctx *pipeline.Context) pipeli
 	}
 
 	if rpc.Error != nil {
-		slog.Info("mcp-parser: response error", "method", pctx.Extensions.MCP.Method, "error", rpc.Error)
-		pctx.Extensions.MCP.Result = rpc.Error
+		pctx.Extensions.MCP.Err = &pipeline.MCPError{
+			Code:    rpc.Error.Code,
+			Message: rpc.Error.Message,
+			Data:    rpc.Error.Data,
+		}
+		slog.Info("mcp-parser: response error", "method", pctx.Extensions.MCP.Method, "code", rpc.Error.Code, "message", rpc.Error.Message)
 		return pipeline.Action{Type: pipeline.Continue}
 	}
 
@@ -77,7 +81,8 @@ func (p *MCPParser) OnResponse(_ context.Context, pctx *pipeline.Context) pipeli
 
 // parseMCPResponse handles both plain JSON-RPC responses and SSE event streams
 // (used by MCP's Streamable HTTP transport). For SSE, the first data: line
-// carrying a result or error wins.
+// carrying a result or error wins. Malformed SSE data frames are logged at
+// DEBUG so a broken upstream is observable rather than silently skipped.
 func parseMCPResponse(body []byte) (jsonRPCResponse, bool) {
 	var rpc jsonRPCResponse
 	if json.Unmarshal(body, &rpc) == nil && (rpc.Result != nil || rpc.Error != nil) {
@@ -93,17 +98,27 @@ func parseMCPResponse(body []byte) (jsonRPCResponse, bool) {
 			continue
 		}
 		var r jsonRPCResponse
-		if json.Unmarshal(data, &r) == nil && (r.Result != nil || r.Error != nil) {
+		if err := json.Unmarshal(data, &r); err != nil {
+			slog.Debug("mcp-parser: skipping malformed SSE data frame", "error", err, "data", truncate(string(data), 128))
+			continue
+		}
+		if r.Result != nil || r.Error != nil {
 			return r, true
 		}
 	}
 	return jsonRPCResponse{}, false
 }
 
+type jsonRPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data"`
+}
+
 type jsonRPCResponse struct {
 	ID     any            `json:"id"`
 	Result map[string]any `json:"result"`
-	Error  map[string]any `json:"error"`
+	Error  *jsonRPCError  `json:"error"`
 }
 
 func resultKeys(m map[string]any) []string {

--- a/authbridge/authlib/plugins/mcpparser.go
+++ b/authbridge/authlib/plugins/mcpparser.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"log/slog"
@@ -53,9 +54,9 @@ func (p *MCPParser) OnResponse(_ context.Context, pctx *pipeline.Context) pipeli
 		return pipeline.Action{Type: pipeline.Continue}
 	}
 
-	var rpc jsonRPCResponse
-	if err := json.Unmarshal(pctx.ResponseBody, &rpc); err != nil {
-		slog.Debug("mcp-parser: response is not valid JSON-RPC", "error", err, "bodyLen", len(pctx.ResponseBody))
+	rpc, ok := parseMCPResponse(pctx.ResponseBody)
+	if !ok {
+		slog.Debug("mcp-parser: response is not valid JSON-RPC or SSE", "bodyLen", len(pctx.ResponseBody))
 		return pipeline.Action{Type: pipeline.Continue}
 	}
 
@@ -72,6 +73,31 @@ func (p *MCPParser) OnResponse(_ context.Context, pctx *pipeline.Context) pipeli
 	}
 
 	return pipeline.Action{Type: pipeline.Continue}
+}
+
+// parseMCPResponse handles both plain JSON-RPC responses and SSE event streams
+// (used by MCP's Streamable HTTP transport). For SSE, the first data: line
+// carrying a result or error wins.
+func parseMCPResponse(body []byte) (jsonRPCResponse, bool) {
+	var rpc jsonRPCResponse
+	if json.Unmarshal(body, &rpc) == nil && (rpc.Result != nil || rpc.Error != nil) {
+		return rpc, true
+	}
+	for _, line := range bytes.Split(body, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if !bytes.HasPrefix(line, []byte("data:")) {
+			continue
+		}
+		data := bytes.TrimSpace(bytes.TrimPrefix(line, []byte("data:")))
+		if len(data) == 0 {
+			continue
+		}
+		var r jsonRPCResponse
+		if json.Unmarshal(data, &r) == nil && (r.Result != nil || r.Error != nil) {
+			return r, true
+		}
+	}
+	return jsonRPCResponse{}, false
 }
 
 type jsonRPCResponse struct {

--- a/authbridge/authlib/plugins/mcpparser.go
+++ b/authbridge/authlib/plugins/mcpparser.go
@@ -44,7 +44,7 @@ func (p *MCPParser) OnRequest(_ context.Context, pctx *pipeline.Context) pipelin
 	}
 
 	slog.Info("mcp-parser: request", "method", rpc.Method)
-	slog.Debug("mcp-parser: payload", "method", rpc.Method, "body", truncate(string(pctx.Body), 128))
+	slog.Debug("mcp-parser: payload", "method", rpc.Method, "body", truncate(string(pctx.Body), debugBodyMax))
 
 	return pipeline.Action{Type: pipeline.Continue}
 }
@@ -69,7 +69,7 @@ func (p *MCPParser) OnResponse(_ context.Context, pctx *pipeline.Context) pipeli
 	if rpc.Result != nil {
 		pctx.Extensions.MCP.Result = rpc.Result
 		slog.Info("mcp-parser: response", "method", pctx.Extensions.MCP.Method, "resultKeys", resultKeys(rpc.Result))
-		slog.Debug("mcp-parser: response detail", "method", pctx.Extensions.MCP.Method, "body", truncate(string(pctx.ResponseBody), 256))
+		slog.Debug("mcp-parser: response detail", "method", pctx.Extensions.MCP.Method, "body", truncate(string(pctx.ResponseBody), debugBodyMax))
 	}
 
 	return pipeline.Action{Type: pipeline.Continue}
@@ -131,6 +131,13 @@ func (r *jsonRPCRequest) mapParam(key string) map[string]any {
 	return v
 }
 
+// debugBodyMax caps how many characters of a body/content string a parser
+// writes into debug logs. Large enough to capture a short user message or
+// a tool_call response verbatim, small enough to keep log lines tractable.
+const debugBodyMax = 512
+
+// truncate clips s to max characters, appending "..." when truncated.
+// Shared across parsers for consistent debug-log body formatting.
 func truncate(s string, max int) string {
 	if len(s) <= max {
 		return s

--- a/authbridge/authlib/plugins/mcpparser.go
+++ b/authbridge/authlib/plugins/mcpparser.go
@@ -48,8 +48,44 @@ func (p *MCPParser) OnRequest(_ context.Context, pctx *pipeline.Context) pipelin
 	return pipeline.Action{Type: pipeline.Continue}
 }
 
-func (p *MCPParser) OnResponse(_ context.Context, _ *pipeline.Context) pipeline.Action {
+func (p *MCPParser) OnResponse(_ context.Context, pctx *pipeline.Context) pipeline.Action {
+	if len(pctx.ResponseBody) == 0 || pctx.Extensions.MCP == nil {
+		return pipeline.Action{Type: pipeline.Continue}
+	}
+
+	var rpc jsonRPCResponse
+	if err := json.Unmarshal(pctx.ResponseBody, &rpc); err != nil {
+		slog.Debug("mcp-parser: response is not valid JSON-RPC", "error", err, "bodyLen", len(pctx.ResponseBody))
+		return pipeline.Action{Type: pipeline.Continue}
+	}
+
+	if rpc.Error != nil {
+		slog.Info("mcp-parser: response error", "method", pctx.Extensions.MCP.Method, "error", rpc.Error)
+		pctx.Extensions.MCP.Result = rpc.Error
+		return pipeline.Action{Type: pipeline.Continue}
+	}
+
+	if rpc.Result != nil {
+		pctx.Extensions.MCP.Result = rpc.Result
+		slog.Info("mcp-parser: response", "method", pctx.Extensions.MCP.Method, "resultKeys", resultKeys(rpc.Result))
+		slog.Debug("mcp-parser: response detail", "method", pctx.Extensions.MCP.Method, "body", truncate(string(pctx.ResponseBody), 256))
+	}
+
 	return pipeline.Action{Type: pipeline.Continue}
+}
+
+type jsonRPCResponse struct {
+	ID     any            `json:"id"`
+	Result map[string]any `json:"result"`
+	Error  map[string]any `json:"error"`
+}
+
+func resultKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }
 
 type jsonRPCRequest struct {

--- a/authbridge/authlib/plugins/mcpparser_test.go
+++ b/authbridge/authlib/plugins/mcpparser_test.go
@@ -181,10 +181,110 @@ func TestMCPParser_MissingParams(t *testing.T) {
 	}
 }
 
-func TestMCPParser_OnResponse(t *testing.T) {
+func TestMCPParser_OnResponse_NoRequestContext(t *testing.T) {
+	// If the request phase never ran (no MCP extension populated), OnResponse
+	// should skip — there's nothing to correlate the response to.
 	p := NewMCPParser()
-	action := p.OnResponse(context.Background(), &pipeline.Context{})
+	pctx := &pipeline.Context{
+		ResponseBody: []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}`),
+	}
+	action := p.OnResponse(context.Background(), pctx)
 	if action.Type != pipeline.Continue {
-		t.Errorf("OnResponse should return Continue, got %v", action.Type)
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	if pctx.Extensions.MCP != nil {
+		t.Error("MCP extension should remain nil when request was not parsed")
+	}
+}
+
+func TestMCPParser_OnResponse_EmptyBody(t *testing.T) {
+	p := NewMCPParser()
+	pctx := &pipeline.Context{
+		Extensions: pipeline.Extensions{MCP: &pipeline.MCPExtension{Method: "tools/list"}},
+	}
+	action := p.OnResponse(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	if pctx.Extensions.MCP.Result != nil {
+		t.Error("Result should remain nil when response body is empty")
+	}
+}
+
+func TestMCPParser_OnResponse_ToolsList(t *testing.T) {
+	p := NewMCPParser()
+	pctx := &pipeline.Context{
+		Extensions:   pipeline.Extensions{MCP: &pipeline.MCPExtension{Method: "tools/list"}},
+		ResponseBody: []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"get_weather"},{"name":"get_news"}]}}`),
+	}
+
+	action := p.OnResponse(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	if pctx.Extensions.MCP.Result == nil {
+		t.Fatal("Result should be populated")
+	}
+	tools, ok := pctx.Extensions.MCP.Result["tools"].([]any)
+	if !ok {
+		t.Fatalf("Result[tools] should be []any, got %T", pctx.Extensions.MCP.Result["tools"])
+	}
+	if len(tools) != 2 {
+		t.Errorf("expected 2 tools, got %d", len(tools))
+	}
+}
+
+func TestMCPParser_OnResponse_ToolsCall(t *testing.T) {
+	p := NewMCPParser()
+	pctx := &pipeline.Context{
+		Extensions:   pipeline.Extensions{MCP: &pipeline.MCPExtension{Method: "tools/call"}},
+		ResponseBody: []byte(`{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"sunny, 72F"}]}}`),
+	}
+
+	action := p.OnResponse(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	if pctx.Extensions.MCP.Result == nil {
+		t.Fatal("Result should be populated")
+	}
+	if _, ok := pctx.Extensions.MCP.Result["content"]; !ok {
+		t.Error("Result should contain content key")
+	}
+}
+
+func TestMCPParser_OnResponse_Error(t *testing.T) {
+	p := NewMCPParser()
+	pctx := &pipeline.Context{
+		Extensions:   pipeline.Extensions{MCP: &pipeline.MCPExtension{Method: "tools/call"}},
+		ResponseBody: []byte(`{"jsonrpc":"2.0","id":3,"error":{"code":-32601,"message":"Method not found"}}`),
+	}
+
+	action := p.OnResponse(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	// Error payload is stored in Result for downstream inspection.
+	if pctx.Extensions.MCP.Result == nil {
+		t.Fatal("Result should be populated with error payload")
+	}
+	if pctx.Extensions.MCP.Result["message"] != "Method not found" {
+		t.Errorf("Result[message] = %v, want %q", pctx.Extensions.MCP.Result["message"], "Method not found")
+	}
+}
+
+func TestMCPParser_OnResponse_InvalidJSON(t *testing.T) {
+	p := NewMCPParser()
+	pctx := &pipeline.Context{
+		Extensions:   pipeline.Extensions{MCP: &pipeline.MCPExtension{Method: "tools/list"}},
+		ResponseBody: []byte("not json"),
+	}
+
+	action := p.OnResponse(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	if pctx.Extensions.MCP.Result != nil {
+		t.Error("Result should remain nil for invalid JSON")
 	}
 }

--- a/authbridge/authlib/plugins/mcpparser_test.go
+++ b/authbridge/authlib/plugins/mcpparser_test.go
@@ -288,3 +288,40 @@ func TestMCPParser_OnResponse_InvalidJSON(t *testing.T) {
 		t.Error("Result should remain nil for invalid JSON")
 	}
 }
+
+func TestMCPParser_OnResponse_SSE(t *testing.T) {
+	// MCP's Streamable HTTP transport returns SSE (event: / data: lines)
+	// instead of plain JSON-RPC when the client sends Accept: text/event-stream.
+	p := NewMCPParser()
+	body := "event: message\r\n" +
+		"data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[{\"name\":\"get_weather\"}]}}\r\n\r\n"
+	pctx := &pipeline.Context{
+		Extensions:   pipeline.Extensions{MCP: &pipeline.MCPExtension{Method: "tools/list"}},
+		ResponseBody: []byte(body),
+	}
+
+	action := p.OnResponse(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	if pctx.Extensions.MCP.Result == nil {
+		t.Fatal("Result should be populated from SSE data frame")
+	}
+	if _, ok := pctx.Extensions.MCP.Result["tools"]; !ok {
+		t.Error("Result should contain tools from SSE data")
+	}
+}
+
+func TestMCPParser_OnResponse_SSE_Error(t *testing.T) {
+	p := NewMCPParser()
+	body := "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32601,\"message\":\"not found\"}}\n\n"
+	pctx := &pipeline.Context{
+		Extensions:   pipeline.Extensions{MCP: &pipeline.MCPExtension{Method: "tools/call"}},
+		ResponseBody: []byte(body),
+	}
+
+	_ = p.OnResponse(context.Background(), pctx)
+	if pctx.Extensions.MCP.Result == nil || pctx.Extensions.MCP.Result["message"] != "not found" {
+		t.Errorf("expected error payload in Result, got %v", pctx.Extensions.MCP.Result)
+	}
+}

--- a/authbridge/authlib/plugins/mcpparser_test.go
+++ b/authbridge/authlib/plugins/mcpparser_test.go
@@ -264,12 +264,17 @@ func TestMCPParser_OnResponse_Error(t *testing.T) {
 	if action.Type != pipeline.Continue {
 		t.Fatalf("expected Continue, got %v", action.Type)
 	}
-	// Error payload is stored in Result for downstream inspection.
-	if pctx.Extensions.MCP.Result == nil {
-		t.Fatal("Result should be populated with error payload")
+	if pctx.Extensions.MCP.Result != nil {
+		t.Errorf("Result should be nil on error response, got %v", pctx.Extensions.MCP.Result)
 	}
-	if pctx.Extensions.MCP.Result["message"] != "Method not found" {
-		t.Errorf("Result[message] = %v, want %q", pctx.Extensions.MCP.Result["message"], "Method not found")
+	if pctx.Extensions.MCP.Err == nil {
+		t.Fatal("Err should be populated")
+	}
+	if pctx.Extensions.MCP.Err.Code != -32601 {
+		t.Errorf("Err.Code = %d, want -32601", pctx.Extensions.MCP.Err.Code)
+	}
+	if pctx.Extensions.MCP.Err.Message != "Method not found" {
+		t.Errorf("Err.Message = %q, want %q", pctx.Extensions.MCP.Err.Message, "Method not found")
 	}
 }
 
@@ -321,7 +326,26 @@ func TestMCPParser_OnResponse_SSE_Error(t *testing.T) {
 	}
 
 	_ = p.OnResponse(context.Background(), pctx)
-	if pctx.Extensions.MCP.Result == nil || pctx.Extensions.MCP.Result["message"] != "not found" {
-		t.Errorf("expected error payload in Result, got %v", pctx.Extensions.MCP.Result)
+	if pctx.Extensions.MCP.Err == nil {
+		t.Fatal("expected Err populated from SSE error frame")
+	}
+	if pctx.Extensions.MCP.Err.Message != "not found" {
+		t.Errorf("Err.Message = %q, want %q", pctx.Extensions.MCP.Err.Message, "not found")
+	}
+}
+
+func TestMCPParser_OnResponse_SSE_SkipsMalformedFramesUntilGoodOne(t *testing.T) {
+	// A broken upstream emits a garbage data: line before the valid one.
+	// Malformed frames should be logged at DEBUG, not abort parsing.
+	p := NewMCPParser()
+	body := "data: not-json\n\n" +
+		"data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"ok\":true}}\n\n"
+	pctx := &pipeline.Context{
+		Extensions:   pipeline.Extensions{MCP: &pipeline.MCPExtension{Method: "tools/list"}},
+		ResponseBody: []byte(body),
+	}
+	_ = p.OnResponse(context.Background(), pctx)
+	if pctx.Extensions.MCP.Result == nil || pctx.Extensions.MCP.Result["ok"] != true {
+		t.Errorf("expected result from second SSE frame, got %v", pctx.Extensions.MCP.Result)
 	}
 }

--- a/authbridge/authlib/session/store.go
+++ b/authbridge/authlib/session/store.go
@@ -171,6 +171,9 @@ func (s *Store) Rekey(oldID, newID string) {
 		return
 	}
 	if len(newID) > maxSessionIDLen {
+		// Two long IDs sharing a prefix would collide on the same truncated key,
+		// silently turning the second Rekey into a no-op. Log so that's diagnosable.
+		slog.Warn("session: newID truncated for rekey", "origLen", len(newID), "maxLen", maxSessionIDLen)
 		newID = newID[:maxSessionIDLen]
 	}
 

--- a/authbridge/authlib/session/store.go
+++ b/authbridge/authlib/session/store.go
@@ -263,8 +263,14 @@ func logAppended(sessionID string, e *pipeline.SessionEvent) {
 		if e.Identity.Subject != "" {
 			attrs = append(attrs, "subject", e.Identity.Subject)
 		}
+		if e.Identity.ClientID != "" {
+			attrs = append(attrs, "clientID", e.Identity.ClientID)
+		}
 		if e.Identity.AgentID != "" {
 			attrs = append(attrs, "agent", e.Identity.AgentID)
+		}
+		if n := len(e.Identity.Scopes); n > 0 {
+			attrs = append(attrs, "scopes", n)
 		}
 	}
 	switch {

--- a/authbridge/authlib/session/store.go
+++ b/authbridge/authlib/session/store.go
@@ -4,6 +4,7 @@
 package session
 
 import (
+	"log/slog"
 	"sync"
 	"time"
 
@@ -100,6 +101,8 @@ func (s *Store) Append(sessionID string, event pipeline.SessionEvent) {
 	sess.Events = append(sess.Events, event)
 	sess.UpdatedAt = now
 	s.activeID = sessionID
+
+	logAppended(sessionID, &event)
 
 	if s.maxEvents > 0 && len(sess.Events) > s.maxEvents {
 		excess := len(sess.Events) - s.maxEvents
@@ -232,4 +235,55 @@ func (s *Store) evictOldestLocked() {
 
 func (s *Store) isExpired(sess *entry, now time.Time) bool {
 	return now.Sub(sess.UpdatedAt) > s.ttl
+}
+
+// logAppended emits a structured DEBUG line so operators can observe session
+// state evolution. Fields are chosen to cover the data captured by all four
+// record helpers — extension payloads themselves are intentionally omitted
+// since the parsers already log them.
+func logAppended(sessionID string, e *pipeline.SessionEvent) {
+	attrs := []any{
+		"sessionId", sessionID,
+		"direction", directionName(e.Direction),
+		"phase", e.Phase.String(),
+	}
+	if e.Host != "" {
+		attrs = append(attrs, "host", e.Host)
+	}
+	if e.TargetAudience != "" {
+		attrs = append(attrs, "aud", e.TargetAudience)
+	}
+	if e.StatusCode != 0 {
+		attrs = append(attrs, "status", e.StatusCode)
+	}
+	if e.Duration != 0 {
+		attrs = append(attrs, "durationMs", e.Duration.Milliseconds())
+	}
+	if e.Identity != nil {
+		if e.Identity.Subject != "" {
+			attrs = append(attrs, "subject", e.Identity.Subject)
+		}
+		if e.Identity.AgentID != "" {
+			attrs = append(attrs, "agent", e.Identity.AgentID)
+		}
+	}
+	switch {
+	case e.A2A != nil:
+		attrs = append(attrs, "proto", "a2a", "method", e.A2A.Method)
+	case e.MCP != nil:
+		attrs = append(attrs, "proto", "mcp", "method", e.MCP.Method)
+	case e.Inference != nil:
+		attrs = append(attrs, "proto", "inference", "model", e.Inference.Model)
+	}
+	if e.Error != nil {
+		attrs = append(attrs, "errorKind", e.Error.Kind)
+	}
+	slog.Debug("session: event appended", attrs...)
+}
+
+func directionName(d pipeline.Direction) string {
+	if d == pipeline.Inbound {
+		return "inbound"
+	}
+	return "outbound"
 }

--- a/authbridge/authlib/session/store.go
+++ b/authbridge/authlib/session/store.go
@@ -149,6 +149,47 @@ func (s *Store) ActiveSession() string {
 	return s.activeID
 }
 
+// Rekey renames a session from oldID to newID, preserving all events.
+// Used to merge the bootstrap "default" session into the server-assigned
+// contextId after the backend response reveals it, so events recorded
+// during the request phase (under "default") and subsequent turns (under
+// the real contextId) land in the same bucket.
+//
+// Safe to call when oldID does not exist (no-op) or newID already exists
+// (no-op — preserves the existing newID entry). If oldID was the active
+// session, activeID is updated to newID.
+//
+// Assumes single-tenant, no concurrent conversations per pod. In a
+// multi-tenant deployment two in-flight first-turn requests could both
+// land under "default"; rekeying the first to arrive would strand the
+// second's events. Call sites are expected to guard against that.
+func (s *Store) Rekey(oldID, newID string) {
+	if oldID == newID || oldID == "" || newID == "" {
+		return
+	}
+	if len(newID) > maxSessionIDLen {
+		newID = newID[:maxSessionIDLen]
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	sess, ok := s.sessions[oldID]
+	if !ok {
+		return
+	}
+	if _, exists := s.sessions[newID]; exists {
+		return
+	}
+
+	sess.ID = newID
+	s.sessions[newID] = sess
+	delete(s.sessions, oldID)
+	if s.activeID == oldID {
+		s.activeID = newID
+	}
+}
+
 // Cleanup removes expired sessions. Safe for concurrent use.
 func (s *Store) Cleanup() {
 	s.mu.Lock()

--- a/authbridge/authlib/session/store_test.go
+++ b/authbridge/authlib/session/store_test.go
@@ -393,3 +393,51 @@ func TestStore_Rekey_ActiveIDUntouchedWhenNotOldID(t *testing.T) {
 		t.Error("sess-a-renamed should exist")
 	}
 }
+
+func TestView_FailedEvents(t *testing.T) {
+	s := New(5*time.Minute, 100, 0)
+	defer s.Close()
+
+	s.Append("sess", pipeline.SessionEvent{Phase: pipeline.SessionRequest, A2A: &pipeline.A2AExtension{}})
+	s.Append("sess", pipeline.SessionEvent{Phase: pipeline.SessionResponse, StatusCode: 200})
+	s.Append("sess", pipeline.SessionEvent{
+		Phase:      pipeline.SessionResponse,
+		StatusCode: 503,
+		Error:      &pipeline.EventError{Kind: "backend_error", Code: "503"},
+	})
+	s.Append("sess", pipeline.SessionEvent{
+		Phase: pipeline.SessionResponse,
+		Error: &pipeline.EventError{Kind: "blocked", Message: "pii"},
+	})
+
+	v := s.View("sess")
+	if v == nil {
+		t.Fatal("View returned nil")
+	}
+
+	failed := v.FailedEvents()
+	if len(failed) != 2 {
+		t.Fatalf("FailedEvents len = %d, want 2", len(failed))
+	}
+	if failed[0].Error.Kind != "backend_error" {
+		t.Errorf("first failed Kind = %q", failed[0].Error.Kind)
+	}
+
+	last := v.LastError()
+	if last == nil || last.Error.Kind != "blocked" {
+		t.Errorf("LastError = %+v, want blocked", last)
+	}
+}
+
+func TestView_LastError_NoErrors(t *testing.T) {
+	s := New(5*time.Minute, 100, 0)
+	defer s.Close()
+	s.Append("sess", pipeline.SessionEvent{Phase: pipeline.SessionResponse, StatusCode: 200})
+	v := s.View("sess")
+	if v.LastError() != nil {
+		t.Error("LastError should be nil when no errors present")
+	}
+	if v.FailedEvents() != nil {
+		t.Error("FailedEvents should be nil when no errors present")
+	}
+}

--- a/authbridge/authlib/session/store_test.go
+++ b/authbridge/authlib/session/store_test.go
@@ -320,3 +320,76 @@ func TestView_InferenceRequests(t *testing.T) {
 		t.Errorf("InferenceRequests()[0].Model = %q, want %q", reqs[0].Inference.Model, "llama3.1")
 	}
 }
+
+func TestStore_Rekey(t *testing.T) {
+	s := New(5*time.Minute, 100, 0)
+
+	ev1 := pipeline.SessionEvent{Direction: pipeline.Inbound, A2A: &pipeline.A2AExtension{Method: "message/send"}}
+	ev2 := pipeline.SessionEvent{Direction: pipeline.Outbound, MCP: &pipeline.MCPExtension{Method: "tools/call"}}
+	s.Append(DefaultSessionID, ev1)
+	s.Append(DefaultSessionID, ev2)
+
+	s.Rekey(DefaultSessionID, "ctx-abc")
+
+	if v := s.View(DefaultSessionID); v != nil {
+		t.Error("old session should be gone after rekey")
+	}
+	v := s.View("ctx-abc")
+	if v == nil {
+		t.Fatal("new session should hold the rekeyed events")
+	}
+	if len(v.Events) != 2 {
+		t.Errorf("events len = %d, want 2", len(v.Events))
+	}
+	if id := s.ActiveSession(); id != "ctx-abc" {
+		t.Errorf("ActiveSession = %q, want %q — activeID should follow rekey", id, "ctx-abc")
+	}
+
+	// Next turn appends to the real contextId and still sees the earlier events.
+	s.Append("ctx-abc", pipeline.SessionEvent{Direction: pipeline.Inbound})
+	if v := s.View("ctx-abc"); v == nil || len(v.Events) != 3 {
+		t.Errorf("expected 3 events after second turn, got %v", v)
+	}
+}
+
+func TestStore_Rekey_NoOpCases(t *testing.T) {
+	s := New(5*time.Minute, 100, 0)
+	s.Append("sess-a", pipeline.SessionEvent{Direction: pipeline.Inbound})
+
+	// oldID absent: no-op.
+	s.Rekey("missing", "sess-b")
+	if v := s.View("sess-b"); v != nil {
+		t.Error("rekey of missing oldID should not create newID")
+	}
+
+	// newID already exists: preserve it, do not clobber.
+	s.Append("sess-b", pipeline.SessionEvent{Direction: pipeline.Outbound})
+	s.Rekey("sess-a", "sess-b")
+	if v := s.View("sess-a"); v == nil {
+		t.Error("sess-a should still exist because sess-b was already taken")
+	}
+	vb := s.View("sess-b")
+	if vb == nil || len(vb.Events) != 1 {
+		t.Errorf("sess-b should be preserved with its own event, got %v", vb)
+	}
+
+	// Empty IDs: no-op, no panic.
+	s.Rekey("", "x")
+	s.Rekey("x", "")
+	s.Rekey("sess-a", "sess-a")
+}
+
+func TestStore_Rekey_ActiveIDUntouchedWhenNotOldID(t *testing.T) {
+	s := New(5*time.Minute, 100, 0)
+	s.Append("sess-a", pipeline.SessionEvent{})
+	s.Append("sess-b", pipeline.SessionEvent{}) // activeID is now sess-b
+
+	s.Rekey("sess-a", "sess-a-renamed")
+
+	if id := s.ActiveSession(); id != "sess-b" {
+		t.Errorf("ActiveSession = %q, want sess-b (unchanged — rekey did not touch active)", id)
+	}
+	if v := s.View("sess-a-renamed"); v == nil {
+		t.Error("sess-a-renamed should exist")
+	}
+}

--- a/authbridge/cmd/authbridge/listener/extproc/server.go
+++ b/authbridge/cmd/authbridge/listener/extproc/server.go
@@ -125,6 +125,7 @@ func (s *Server) handleInbound(stream extprocv3.ExternalProcessor_ProcessServer,
 		Path:      getHeader(headers, ":path"),
 		Headers:   headerMapToHTTP(headers),
 		Body:      body,
+		StartedAt: time.Now(),
 	}
 
 	action := s.InboundPipeline.Run(ctx, pctx)
@@ -144,6 +145,7 @@ func (s *Server) handleInboundBody(stream extprocv3.ExternalProcessor_ProcessSer
 		Path:      getHeader(headers, ":path"),
 		Headers:   headerMapToHTTP(headers),
 		Body:      body,
+		StartedAt: time.Now(),
 	}
 
 	action := s.InboundPipeline.Run(ctx, pctx)
@@ -173,6 +175,7 @@ func (s *Server) recordInboundSession(pctx *pipeline.Context) {
 		Phase:     pipeline.SessionRequest,
 		A2A:       pctx.Extensions.A2A,
 		Identity:  snapshotIdentity(pctx),
+		Host:      pctx.Host,
 	}
 	s.Sessions.Append(sid, ev)
 }
@@ -199,6 +202,8 @@ func (s *Server) recordInboundResponseSession(pctx *pipeline.Context) {
 		Identity:   snapshotIdentity(pctx),
 		StatusCode: pctx.StatusCode,
 		Error:      deriveError(pctx),
+		Host:       pctx.Host,
+		Duration:   durationSince(pctx.StartedAt),
 	}
 	s.Sessions.Append(sid, ev)
 }
@@ -215,14 +220,17 @@ func (s *Server) recordOutboundResponseSession(pctx *pipeline.Context) {
 		sid = session.DefaultSessionID
 	}
 	ev := pipeline.SessionEvent{
-		At:         time.Now(),
-		Direction:  pipeline.Outbound,
-		Phase:      pipeline.SessionResponse,
-		MCP:        pctx.Extensions.MCP,
-		Inference:  pctx.Extensions.Inference,
-		Identity:   snapshotIdentity(pctx),
-		StatusCode: pctx.StatusCode,
-		Error:      deriveError(pctx),
+		At:             time.Now(),
+		Direction:      pipeline.Outbound,
+		Phase:          pipeline.SessionResponse,
+		MCP:            pctx.Extensions.MCP,
+		Inference:      pctx.Extensions.Inference,
+		Identity:       snapshotIdentity(pctx),
+		StatusCode:     pctx.StatusCode,
+		Error:          deriveError(pctx),
+		Host:           pctx.Host,
+		TargetAudience: routeAudience(pctx),
+		Duration:       durationSince(pctx.StartedAt),
 	}
 	if ev.MCP != nil || ev.Inference != nil {
 		s.Sessions.Append(sid, ev)
@@ -248,6 +256,24 @@ func snapshotIdentity(pctx *pipeline.Context) *pipeline.EventIdentity {
 		id.AgentID = pctx.Agent.WorkloadID
 	}
 	return id
+}
+
+// routeAudience returns the resolved OAuth audience for an outbound request,
+// or "" when no route matched (passthrough) or the event is inbound.
+func routeAudience(pctx *pipeline.Context) string {
+	if pctx.Route == nil || !pctx.Route.Matched {
+		return ""
+	}
+	return pctx.Route.Audience
+}
+
+// durationSince returns the elapsed time since StartedAt, or 0 when StartedAt
+// is zero (pctx constructed without wall-clock stamping, e.g. in unit tests).
+func durationSince(start time.Time) time.Duration {
+	if start.IsZero() {
+		return 0
+	}
+	return time.Since(start)
 }
 
 // deriveError constructs an EventError from response-side signals. Returns nil
@@ -292,12 +318,14 @@ func (s *Server) recordOutboundSession(pctx *pipeline.Context) {
 		sid = session.DefaultSessionID
 	}
 	ev := pipeline.SessionEvent{
-		At:        time.Now(),
-		Direction: pipeline.Outbound,
-		Phase:     pipeline.SessionRequest,
-		MCP:       pctx.Extensions.MCP,
-		Inference: pctx.Extensions.Inference,
-		Identity:  snapshotIdentity(pctx),
+		At:             time.Now(),
+		Direction:      pipeline.Outbound,
+		Phase:          pipeline.SessionRequest,
+		MCP:            pctx.Extensions.MCP,
+		Inference:      pctx.Extensions.Inference,
+		Identity:       snapshotIdentity(pctx),
+		Host:           pctx.Host,
+		TargetAudience: routeAudience(pctx),
 	}
 	if ev.MCP != nil || ev.Inference != nil {
 		s.Sessions.Append(sid, ev)
@@ -312,6 +340,7 @@ func (s *Server) handleOutbound(stream extprocv3.ExternalProcessor_ProcessServer
 		Path:      getHeader(headers, ":path"),
 		Headers:   headerMapToHTTP(headers),
 		Body:      body,
+		StartedAt: time.Now(),
 	}
 	if pctx.Host == "" {
 		pctx.Host = getHeader(headers, "host")
@@ -347,6 +376,7 @@ func (s *Server) handleOutboundBody(stream extprocv3.ExternalProcessor_ProcessSe
 		Path:      getHeader(headers, ":path"),
 		Headers:   headerMapToHTTP(headers),
 		Body:      body,
+		StartedAt: time.Now(),
 	}
 	if pctx.Host == "" {
 		pctx.Host = getHeader(headers, "host")

--- a/authbridge/cmd/authbridge/listener/extproc/server.go
+++ b/authbridge/cmd/authbridge/listener/extproc/server.go
@@ -175,6 +175,21 @@ func (s *Server) recordInboundSession(pctx *pipeline.Context) {
 	})
 }
 
+// rekeyInboundSession renames the DefaultSessionID bucket to the
+// server-assigned A2A contextId when the response reveals one, so events
+// from the first turn (recorded under "default" during the request phase)
+// merge with subsequent turns that carry the real contextId.
+func (s *Server) rekeyInboundSession(pctx *pipeline.Context, direction string) {
+	if direction != "inbound" || s.Sessions == nil || pctx.Extensions.A2A == nil {
+		return
+	}
+	sid := pctx.Extensions.A2A.SessionID
+	if sid == "" || sid == session.DefaultSessionID {
+		return
+	}
+	s.Sessions.Rekey(session.DefaultSessionID, sid)
+}
+
 func (s *Server) recordOutboundSession(pctx *pipeline.Context) {
 	if s.Sessions == nil {
 		return
@@ -325,6 +340,12 @@ func (s *Server) handleResponseBody(ctx context.Context, body []byte, pctx *pipe
 		return denyResponse(typev3.StatusCode(action.Status),
 			jsonError("response_blocked", action.Reason))
 	}
+
+	// The server's response may carry the server-assigned A2A contextId. If
+	// the request phase recorded events under DefaultSessionID (because the
+	// client had no contextId yet), migrate them to the real ID so subsequent
+	// turns — which will send that contextId — accumulate into one session.
+	s.rekeyInboundSession(pctx, direction)
 
 	if string(pctx.ResponseBody) != string(body) {
 		return &extprocv3.ProcessingResponse{

--- a/authbridge/cmd/authbridge/listener/extproc/server.go
+++ b/authbridge/cmd/authbridge/listener/extproc/server.go
@@ -215,6 +215,7 @@ func (s *Server) handleOutbound(stream extprocv3.ExternalProcessor_ProcessServer
 	pctx := &pipeline.Context{
 		Direction: pipeline.Outbound,
 		Host:      getHeader(headers, ":authority"),
+		Path:      getHeader(headers, ":path"),
 		Headers:   headerMapToHTTP(headers),
 		Body:      body,
 	}
@@ -249,6 +250,7 @@ func (s *Server) handleOutboundBody(stream extprocv3.ExternalProcessor_ProcessSe
 	pctx := &pipeline.Context{
 		Direction: pipeline.Outbound,
 		Host:      getHeader(headers, ":authority"),
+		Path:      getHeader(headers, ":path"),
 		Headers:   headerMapToHTTP(headers),
 		Body:      body,
 	}

--- a/authbridge/cmd/authbridge/listener/extproc/server.go
+++ b/authbridge/cmd/authbridge/listener/extproc/server.go
@@ -175,6 +175,51 @@ func (s *Server) recordInboundSession(pctx *pipeline.Context) {
 	})
 }
 
+// recordInboundResponseSession appends a Phase:SessionResponse event for the
+// inbound A2A direction. Called after RunResponse completes so the event
+// carries the updated SessionID (from the response body's contextId).
+func (s *Server) recordInboundResponseSession(pctx *pipeline.Context) {
+	if s.Sessions == nil || pctx.Extensions.A2A == nil {
+		return
+	}
+	sid := pctx.Extensions.A2A.SessionID
+	if sid == "" {
+		sid = s.Sessions.ActiveSession()
+	}
+	if sid == "" {
+		sid = session.DefaultSessionID
+	}
+	s.Sessions.Append(sid, pipeline.SessionEvent{
+		At:        time.Now(),
+		Direction: pipeline.Inbound,
+		Phase:     pipeline.SessionResponse,
+		A2A:       pctx.Extensions.A2A,
+	})
+}
+
+// recordOutboundResponseSession appends a Phase:SessionResponse event for the
+// outbound direction, carrying whichever protocol extension the response
+// populated (MCP tool result, inference completion + token counts).
+func (s *Server) recordOutboundResponseSession(pctx *pipeline.Context) {
+	if s.Sessions == nil {
+		return
+	}
+	sid := s.Sessions.ActiveSession()
+	if sid == "" {
+		sid = session.DefaultSessionID
+	}
+	ev := pipeline.SessionEvent{
+		At:        time.Now(),
+		Direction: pipeline.Outbound,
+		Phase:     pipeline.SessionResponse,
+		MCP:       pctx.Extensions.MCP,
+		Inference: pctx.Extensions.Inference,
+	}
+	if ev.MCP != nil || ev.Inference != nil {
+		s.Sessions.Append(sid, ev)
+	}
+}
+
 // rekeyInboundSession renames the DefaultSessionID bucket to the
 // server-assigned A2A contextId when the response reveals one, so events
 // from the first turn (recorded under "default" during the request phase)
@@ -314,6 +359,16 @@ func (s *Server) handleResponseHeaders(ctx context.Context, headers *corev3.Head
 		return denyResponse(typev3.StatusCode(action.Status),
 			jsonError("response_blocked", action.Reason))
 	}
+
+	// No body phase will run; record the response event here. A2A responses
+	// need the body to extract contextId, so the rekey path is body-only;
+	// skip it on this header-only path.
+	if direction == "inbound" {
+		s.recordInboundResponseSession(pctx)
+	} else {
+		s.recordOutboundResponseSession(pctx)
+	}
+
 	return &extprocv3.ProcessingResponse{
 		Response: &extprocv3.ProcessingResponse_ResponseHeaders{
 			ResponseHeaders: &extprocv3.HeadersResponse{},
@@ -347,7 +402,15 @@ func (s *Server) handleResponseBody(ctx context.Context, body []byte, pctx *pipe
 	// the request phase recorded events under DefaultSessionID (because the
 	// client had no contextId yet), migrate them to the real ID so subsequent
 	// turns — which will send that contextId — accumulate into one session.
+	// Rekey first so the response event we're about to append lands under
+	// the real contextId rather than being orphaned in "default".
 	s.rekeyInboundSession(pctx, direction)
+
+	if direction == "inbound" {
+		s.recordInboundResponseSession(pctx)
+	} else {
+		s.recordOutboundResponseSession(pctx)
+	}
 
 	if string(pctx.ResponseBody) != string(body) {
 		return &extprocv3.ProcessingResponse{

--- a/authbridge/cmd/authbridge/listener/extproc/server.go
+++ b/authbridge/cmd/authbridge/listener/extproc/server.go
@@ -167,12 +167,14 @@ func (s *Server) recordInboundSession(pctx *pipeline.Context) {
 	if sid == "" {
 		sid = session.DefaultSessionID
 	}
-	s.Sessions.Append(sid, pipeline.SessionEvent{
+	ev := pipeline.SessionEvent{
 		At:        time.Now(),
 		Direction: pipeline.Inbound,
 		Phase:     pipeline.SessionRequest,
 		A2A:       pctx.Extensions.A2A,
-	})
+		Identity:  snapshotIdentity(pctx),
+	}
+	s.Sessions.Append(sid, ev)
 }
 
 // recordInboundResponseSession appends a Phase:SessionResponse event for the
@@ -189,12 +191,16 @@ func (s *Server) recordInboundResponseSession(pctx *pipeline.Context) {
 	if sid == "" {
 		sid = session.DefaultSessionID
 	}
-	s.Sessions.Append(sid, pipeline.SessionEvent{
-		At:        time.Now(),
-		Direction: pipeline.Inbound,
-		Phase:     pipeline.SessionResponse,
-		A2A:       pctx.Extensions.A2A,
-	})
+	ev := pipeline.SessionEvent{
+		At:         time.Now(),
+		Direction:  pipeline.Inbound,
+		Phase:      pipeline.SessionResponse,
+		A2A:        pctx.Extensions.A2A,
+		Identity:   snapshotIdentity(pctx),
+		StatusCode: pctx.StatusCode,
+		Error:      deriveError(pctx),
+	}
+	s.Sessions.Append(sid, ev)
 }
 
 // recordOutboundResponseSession appends a Phase:SessionResponse event for the
@@ -209,15 +215,57 @@ func (s *Server) recordOutboundResponseSession(pctx *pipeline.Context) {
 		sid = session.DefaultSessionID
 	}
 	ev := pipeline.SessionEvent{
-		At:        time.Now(),
-		Direction: pipeline.Outbound,
-		Phase:     pipeline.SessionResponse,
-		MCP:       pctx.Extensions.MCP,
-		Inference: pctx.Extensions.Inference,
+		At:         time.Now(),
+		Direction:  pipeline.Outbound,
+		Phase:      pipeline.SessionResponse,
+		MCP:        pctx.Extensions.MCP,
+		Inference:  pctx.Extensions.Inference,
+		Identity:   snapshotIdentity(pctx),
+		StatusCode: pctx.StatusCode,
+		Error:      deriveError(pctx),
 	}
 	if ev.MCP != nil || ev.Inference != nil {
 		s.Sessions.Append(sid, ev)
 	}
+}
+
+// snapshotIdentity copies Claims + Agent identity off pctx so the session event
+// stays valid after pctx is discarded. Returns nil when no identity information
+// is available (e.g., jwt-validation didn't run on this path).
+func snapshotIdentity(pctx *pipeline.Context) *pipeline.EventIdentity {
+	if pctx.Claims == nil && pctx.Agent == nil {
+		return nil
+	}
+	id := &pipeline.EventIdentity{}
+	if pctx.Claims != nil {
+		id.Subject = pctx.Claims.Subject
+		id.ClientID = pctx.Claims.ClientID
+		if len(pctx.Claims.Scopes) > 0 {
+			id.Scopes = append([]string(nil), pctx.Claims.Scopes...)
+		}
+	}
+	if pctx.Agent != nil {
+		id.AgentID = pctx.Agent.WorkloadID
+	}
+	return id
+}
+
+// deriveError constructs an EventError from response-side signals. Returns nil
+// for 2xx / no guardrail block / no parser error.
+func deriveError(pctx *pipeline.Context) *pipeline.EventError {
+	if pctx.Extensions.Security != nil && pctx.Extensions.Security.Blocked {
+		return &pipeline.EventError{
+			Kind:    "blocked",
+			Message: pctx.Extensions.Security.BlockReason,
+		}
+	}
+	if pctx.StatusCode >= 400 {
+		return &pipeline.EventError{
+			Kind: "backend_error",
+			Code: strconv.Itoa(pctx.StatusCode),
+		}
+	}
+	return nil
 }
 
 // rekeyInboundSession renames the DefaultSessionID bucket to the
@@ -249,6 +297,7 @@ func (s *Server) recordOutboundSession(pctx *pipeline.Context) {
 		Phase:     pipeline.SessionRequest,
 		MCP:       pctx.Extensions.MCP,
 		Inference: pctx.Extensions.Inference,
+		Identity:  snapshotIdentity(pctx),
 	}
 	if ev.MCP != nil || ev.Inference != nil {
 		s.Sessions.Append(sid, ev)

--- a/authbridge/cmd/authbridge/listener/extproc/server_test.go
+++ b/authbridge/cmd/authbridge/listener/extproc/server_test.go
@@ -647,3 +647,128 @@ func TestRekeyInboundSession_NilStore(t *testing.T) {
 		Extensions: pipeline.Extensions{A2A: &pipeline.A2AExtension{SessionID: "ctx-abc"}},
 	}, "inbound")
 }
+
+func TestRecordInboundResponseSession(t *testing.T) {
+	store := session.New(5*time.Minute, 100, 0)
+	defer store.Close()
+	s := &Server{Sessions: store}
+
+	pctx := &pipeline.Context{
+		Extensions: pipeline.Extensions{
+			A2A: &pipeline.A2AExtension{
+				Method:    "message/stream",
+				SessionID: "ctx-abc",
+			},
+		},
+	}
+	s.recordInboundResponseSession(pctx)
+
+	v := store.View("ctx-abc")
+	if v == nil || len(v.Events) != 1 {
+		t.Fatalf("expected 1 event under ctx-abc, got %v", v)
+	}
+	e := v.Events[0]
+	if e.Direction != pipeline.Inbound || e.Phase != pipeline.SessionResponse {
+		t.Errorf("event fields = (%v, %v), want (Inbound, SessionResponse)", e.Direction, e.Phase)
+	}
+	if e.A2A == nil || e.A2A.SessionID != "ctx-abc" {
+		t.Errorf("A2A extension not attached: %+v", e.A2A)
+	}
+}
+
+func TestRecordInboundResponseSession_NoA2A(t *testing.T) {
+	// No A2A extension — nothing to record.
+	store := session.New(5*time.Minute, 100, 0)
+	defer store.Close()
+	s := &Server{Sessions: store}
+
+	s.recordInboundResponseSession(&pipeline.Context{})
+	if store.View(session.DefaultSessionID) != nil {
+		t.Error("no session should have been created without A2A extension")
+	}
+}
+
+func TestRecordOutboundResponseSession_MCP(t *testing.T) {
+	store := session.New(5*time.Minute, 100, 0)
+	defer store.Close()
+	store.Append(session.DefaultSessionID, pipeline.SessionEvent{Direction: pipeline.Inbound}) // seed active
+	s := &Server{Sessions: store}
+
+	pctx := &pipeline.Context{
+		Extensions: pipeline.Extensions{
+			MCP: &pipeline.MCPExtension{
+				Method: "tools/call",
+				Result: map[string]any{"content": []any{map[string]any{"text": "result"}}},
+			},
+		},
+	}
+	s.recordOutboundResponseSession(pctx)
+
+	v := store.View(session.DefaultSessionID)
+	if v == nil || len(v.Events) != 2 { // 1 seed + 1 response
+		t.Fatalf("expected 2 events, got %v", v)
+	}
+	resp := v.Events[1]
+	if resp.Direction != pipeline.Outbound || resp.Phase != pipeline.SessionResponse {
+		t.Errorf("event fields = (%v, %v), want (Outbound, SessionResponse)", resp.Direction, resp.Phase)
+	}
+	if resp.MCP == nil || resp.MCP.Result["content"] == nil {
+		t.Errorf("MCP Result not attached: %+v", resp.MCP)
+	}
+}
+
+func TestRecordOutboundResponseSession_Inference(t *testing.T) {
+	store := session.New(5*time.Minute, 100, 0)
+	defer store.Close()
+	store.Append(session.DefaultSessionID, pipeline.SessionEvent{})
+	s := &Server{Sessions: store}
+
+	pctx := &pipeline.Context{
+		Extensions: pipeline.Extensions{
+			Inference: &pipeline.InferenceExtension{
+				Model:            "llama3",
+				Completion:       "Hello",
+				FinishReason:     "stop",
+				PromptTokens:     10,
+				CompletionTokens: 5,
+				TotalTokens:      15,
+			},
+		},
+	}
+	s.recordOutboundResponseSession(pctx)
+
+	v := store.View(session.DefaultSessionID)
+	if v == nil || len(v.Events) != 2 {
+		t.Fatalf("expected 2 events, got %v", v)
+	}
+	resp := v.Events[1]
+	if resp.Inference == nil || resp.Inference.Completion != "Hello" {
+		t.Errorf("Inference not attached with response data: %+v", resp.Inference)
+	}
+	if resp.Inference.TotalTokens != 15 {
+		t.Errorf("TotalTokens = %d, want 15", resp.Inference.TotalTokens)
+	}
+}
+
+func TestRecordOutboundResponseSession_NothingToRecord(t *testing.T) {
+	// Neither MCP nor Inference populated — nothing to write.
+	store := session.New(5*time.Minute, 100, 0)
+	defer store.Close()
+	s := &Server{Sessions: store}
+
+	s.recordOutboundResponseSession(&pipeline.Context{})
+	if store.View(session.DefaultSessionID) != nil {
+		t.Error("no session should have been created without MCP/Inference")
+	}
+}
+
+func TestRecordResponseSessions_NilStore(t *testing.T) {
+	// Session tracking disabled — both helpers must be safe to call.
+	s := &Server{Sessions: nil}
+	s.recordInboundResponseSession(&pipeline.Context{
+		Extensions: pipeline.Extensions{A2A: &pipeline.A2AExtension{}},
+	})
+	s.recordOutboundResponseSession(&pipeline.Context{
+		Extensions: pipeline.Extensions{MCP: &pipeline.MCPExtension{}},
+	})
+}

--- a/authbridge/cmd/authbridge/listener/extproc/server_test.go
+++ b/authbridge/cmd/authbridge/listener/extproc/server_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extprocfilterv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
@@ -20,6 +21,7 @@ import (
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/pipeline"
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/plugins"
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/routing"
+	"github.com/kagenti/kagenti-extensions/authbridge/authlib/session"
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/validation"
 )
 
@@ -561,4 +563,87 @@ func TestExtProc_NoBodyBuffering_WhenNotNeeded(t *testing.T) {
 	if stream.responses[0].ModeOverride != nil {
 		t.Error("should not request body when pipeline doesn't need it")
 	}
+}
+
+func TestRekeyInboundSession(t *testing.T) {
+	cases := []struct {
+		name         string
+		direction    string
+		a2a          *pipeline.A2AExtension
+		seedDefault  bool
+		wantDefault  bool
+		wantNewID    string
+		wantActiveID string
+	}{
+		{
+			name:         "inbound rekey migrates default to contextId",
+			direction:    "inbound",
+			a2a:          &pipeline.A2AExtension{SessionID: "ctx-abc"},
+			seedDefault:  true,
+			wantDefault:  false,
+			wantNewID:    "ctx-abc",
+			wantActiveID: "ctx-abc",
+		},
+		{
+			name:        "outbound direction is a no-op",
+			direction:   "outbound",
+			a2a:         &pipeline.A2AExtension{SessionID: "ctx-abc"},
+			seedDefault: true,
+			wantDefault: true,
+		},
+		{
+			name:        "nil A2A extension is a no-op",
+			direction:   "inbound",
+			a2a:         nil,
+			seedDefault: true,
+			wantDefault: true,
+		},
+		{
+			name:        "empty SessionID is a no-op",
+			direction:   "inbound",
+			a2a:         &pipeline.A2AExtension{SessionID: ""},
+			seedDefault: true,
+			wantDefault: true,
+		},
+		{
+			name:        "SessionID equal to DefaultSessionID is a no-op",
+			direction:   "inbound",
+			a2a:         &pipeline.A2AExtension{SessionID: session.DefaultSessionID},
+			seedDefault: true,
+			wantDefault: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := session.New(5*time.Minute, 100, 0)
+			defer store.Close()
+			if tc.seedDefault {
+				store.Append(session.DefaultSessionID, pipeline.SessionEvent{Direction: pipeline.Inbound})
+			}
+			s := &Server{Sessions: store}
+			pctx := &pipeline.Context{Extensions: pipeline.Extensions{A2A: tc.a2a}}
+
+			s.rekeyInboundSession(pctx, tc.direction)
+
+			hasDefault := store.View(session.DefaultSessionID) != nil
+			if hasDefault != tc.wantDefault {
+				t.Errorf("default session present = %v, want %v", hasDefault, tc.wantDefault)
+			}
+			if tc.wantNewID != "" && store.View(tc.wantNewID) == nil {
+				t.Errorf("expected session under %q after rekey", tc.wantNewID)
+			}
+			if tc.wantActiveID != "" && store.ActiveSession() != tc.wantActiveID {
+				t.Errorf("ActiveSession = %q, want %q", store.ActiveSession(), tc.wantActiveID)
+			}
+		})
+	}
+}
+
+func TestRekeyInboundSession_NilStore(t *testing.T) {
+	// Session tracking disabled — must not panic.
+	s := &Server{Sessions: nil}
+	s.rekeyInboundSession(&pipeline.Context{
+		Extensions: pipeline.Extensions{A2A: &pipeline.A2AExtension{SessionID: "ctx-abc"}},
+	}, "inbound")
 }

--- a/authbridge/cmd/authbridge/listener/extproc/server_test.go
+++ b/authbridge/cmd/authbridge/listener/extproc/server_test.go
@@ -917,3 +917,68 @@ func TestRecordOutboundResponseSession_CapturesStatusAndError(t *testing.T) {
 		t.Errorf("Identity not snapshotted: %+v", resp.Identity)
 	}
 }
+
+func TestRouteAudience(t *testing.T) {
+	cases := []struct {
+		name string
+		pctx *pipeline.Context
+		want string
+	}{
+		{"nil route", &pipeline.Context{}, ""},
+		{"unmatched route falls through to passthrough",
+			&pipeline.Context{Route: &routing.ResolvedRoute{Matched: false, Audience: "ignored"}}, ""},
+		{"matched route surfaces audience",
+			&pipeline.Context{Route: &routing.ResolvedRoute{Matched: true, Audience: "github-tool"}}, "github-tool"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := routeAudience(tc.pctx); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDurationSince(t *testing.T) {
+	if d := durationSince(time.Time{}); d != 0 {
+		t.Errorf("zero StartedAt should yield 0, got %v", d)
+	}
+	start := time.Now().Add(-50 * time.Millisecond)
+	if d := durationSince(start); d < 50*time.Millisecond {
+		t.Errorf("elapsed = %v, want >= 50ms", d)
+	}
+}
+
+func TestRecordOutboundResponseSession_CapturesHostAndRoute(t *testing.T) {
+	store := session.New(5*time.Minute, 100, 0)
+	defer store.Close()
+	store.Append(session.DefaultSessionID, pipeline.SessionEvent{})
+	s := &Server{Sessions: store}
+
+	start := time.Now().Add(-25 * time.Millisecond)
+	pctx := &pipeline.Context{
+		StartedAt:  start,
+		Host:       "github-tool-mcp",
+		StatusCode: 200,
+		Route: &routing.ResolvedRoute{
+			Matched:  true,
+			Audience: "github-tool",
+		},
+		Extensions: pipeline.Extensions{
+			MCP: &pipeline.MCPExtension{Method: "tools/call"},
+		},
+	}
+	s.recordOutboundResponseSession(pctx)
+
+	v := store.View(session.DefaultSessionID)
+	resp := v.Events[len(v.Events)-1]
+	if resp.Host != "github-tool-mcp" {
+		t.Errorf("Host = %q, want github-tool-mcp", resp.Host)
+	}
+	if resp.TargetAudience != "github-tool" {
+		t.Errorf("TargetAudience = %q, want github-tool", resp.TargetAudience)
+	}
+	if resp.Duration < 25*time.Millisecond {
+		t.Errorf("Duration = %v, want >= 25ms", resp.Duration)
+	}
+}

--- a/authbridge/cmd/authbridge/listener/extproc/server_test.go
+++ b/authbridge/cmd/authbridge/listener/extproc/server_test.go
@@ -772,3 +772,148 @@ func TestRecordResponseSessions_NilStore(t *testing.T) {
 		Extensions: pipeline.Extensions{MCP: &pipeline.MCPExtension{}},
 	})
 }
+
+func TestSnapshotIdentity(t *testing.T) {
+	cases := []struct {
+		name   string
+		claims *validation.Claims
+		agent  *pipeline.AgentIdentity
+		want   *pipeline.EventIdentity
+	}{
+		{
+			name: "claims and agent both set",
+			claims: &validation.Claims{
+				Subject:  "alice",
+				ClientID: "kagenti-ui",
+				Scopes:   []string{"openid", "weather-read"},
+			},
+			agent: &pipeline.AgentIdentity{WorkloadID: "spiffe://localtest.me/ns/team1/sa/weather-agent"},
+			want: &pipeline.EventIdentity{
+				Subject:  "alice",
+				ClientID: "kagenti-ui",
+				Scopes:   []string{"openid", "weather-read"},
+				AgentID:  "spiffe://localtest.me/ns/team1/sa/weather-agent",
+			},
+		},
+		{
+			name:   "only agent (outbound, no JWT validation)",
+			claims: nil,
+			agent:  &pipeline.AgentIdentity{WorkloadID: "spiffe://localtest.me/ns/team1/sa/weather-agent"},
+			want:   &pipeline.EventIdentity{AgentID: "spiffe://localtest.me/ns/team1/sa/weather-agent"},
+		},
+		{
+			name:   "neither set",
+			claims: nil,
+			agent:  nil,
+			want:   nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := snapshotIdentity(&pipeline.Context{Claims: tc.claims, Agent: tc.agent})
+			if tc.want == nil {
+				if got != nil {
+					t.Errorf("got %+v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("got nil, want populated")
+			}
+			if got.Subject != tc.want.Subject || got.ClientID != tc.want.ClientID || got.AgentID != tc.want.AgentID {
+				t.Errorf("identity mismatch: got %+v, want %+v", got, tc.want)
+			}
+			if len(got.Scopes) != len(tc.want.Scopes) {
+				t.Errorf("scopes len: got %d, want %d", len(got.Scopes), len(tc.want.Scopes))
+			}
+		})
+	}
+}
+
+func TestSnapshotIdentity_ScopesDeepCopy(t *testing.T) {
+	// Mutating the claims slice after snapshot must not mutate the event.
+	claims := &validation.Claims{Subject: "alice", Scopes: []string{"a", "b"}}
+	id := snapshotIdentity(&pipeline.Context{Claims: claims})
+	claims.Scopes[0] = "x"
+	if id.Scopes[0] != "a" {
+		t.Errorf("snapshot scopes aliased original: got %v", id.Scopes)
+	}
+}
+
+func TestDeriveError(t *testing.T) {
+	cases := []struct {
+		name     string
+		pctx     *pipeline.Context
+		wantNil  bool
+		wantKind string
+		wantCode string
+	}{
+		{name: "2xx no block", pctx: &pipeline.Context{StatusCode: 200}, wantNil: true},
+		{name: "no status (request phase)", pctx: &pipeline.Context{}, wantNil: true},
+		{name: "404 backend_error", pctx: &pipeline.Context{StatusCode: 404}, wantKind: "backend_error", wantCode: "404"},
+		{name: "500 backend_error", pctx: &pipeline.Context{StatusCode: 500}, wantKind: "backend_error", wantCode: "500"},
+		{
+			name: "guardrail block wins over status",
+			pctx: &pipeline.Context{
+				StatusCode: 200,
+				Extensions: pipeline.Extensions{
+					Security: &pipeline.SecurityExtension{Blocked: true, BlockReason: "pii_detected"},
+				},
+			},
+			wantKind: "blocked",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := deriveError(tc.pctx)
+			if tc.wantNil {
+				if got != nil {
+					t.Errorf("got %+v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("got nil, want error")
+			}
+			if got.Kind != tc.wantKind {
+				t.Errorf("Kind = %q, want %q", got.Kind, tc.wantKind)
+			}
+			if tc.wantCode != "" && got.Code != tc.wantCode {
+				t.Errorf("Code = %q, want %q", got.Code, tc.wantCode)
+			}
+		})
+	}
+}
+
+func TestRecordOutboundResponseSession_CapturesStatusAndError(t *testing.T) {
+	store := session.New(5*time.Minute, 100, 0)
+	defer store.Close()
+	store.Append(session.DefaultSessionID, pipeline.SessionEvent{})
+	s := &Server{Sessions: store}
+
+	pctx := &pipeline.Context{
+		StatusCode: 503,
+		Claims:     &validation.Claims{Subject: "alice"},
+		Extensions: pipeline.Extensions{
+			MCP: &pipeline.MCPExtension{Method: "tools/call"},
+		},
+	}
+	s.recordOutboundResponseSession(pctx)
+
+	v := store.View(session.DefaultSessionID)
+	if v == nil || len(v.Events) < 2 {
+		t.Fatalf("expected event appended, got %v", v)
+	}
+	resp := v.Events[len(v.Events)-1]
+	if resp.StatusCode != 503 {
+		t.Errorf("StatusCode = %d, want 503", resp.StatusCode)
+	}
+	if resp.Error == nil || resp.Error.Kind != "backend_error" || resp.Error.Code != "503" {
+		t.Errorf("Error = %+v, want backend_error/503", resp.Error)
+	}
+	if resp.Identity == nil || resp.Identity.Subject != "alice" {
+		t.Errorf("Identity not snapshotted: %+v", resp.Identity)
+	}
+}

--- a/authbridge/cmd/authbridge/main.go
+++ b/authbridge/cmd/authbridge/main.go
@@ -122,10 +122,11 @@ func main() {
 		}
 	}
 
-	// Build session store if enabled (nil when disabled — zero overhead)
+	// Build session store if enabled (nil when disabled — zero overhead).
+	// Defaults to on; set session.enabled: false in runtime config to opt out.
 	var sessions *session.Store
-	if cfg.Session.Enabled {
-		ttl := 5 * time.Minute
+	if cfg.Session.SessionEnabled() {
+		ttl := 30 * time.Minute
 		if cfg.Session.TTL != "" {
 			if d, err := time.ParseDuration(cfg.Session.TTL); err == nil {
 				ttl = d
@@ -137,12 +138,14 @@ func main() {
 		if cfg.Session.MaxEvents > 0 {
 			maxEvents = cfg.Session.MaxEvents
 		}
-		maxSessions := 1000
+		maxSessions := 100
 		if cfg.Session.MaxSessions > 0 {
 			maxSessions = cfg.Session.MaxSessions
 		}
 		sessions = session.New(ttl, maxEvents, maxSessions)
 		slog.Info("session tracking enabled", "ttl", ttl, "maxEvents", maxEvents, "maxSessions", maxSessions)
+	} else {
+		slog.Info("session tracking disabled")
 	}
 
 	// Track servers for graceful shutdown

--- a/authbridge/demos/webhook/k8s/configmaps-webhook.yaml
+++ b/authbridge/demos/webhook/k8s/configmaps-webhook.yaml
@@ -161,7 +161,7 @@ data:
                   allow_mode_override: true
                   processing_mode:
                     request_header_mode: SEND
-                    response_header_mode: SKIP
+                    response_header_mode: SEND
                     request_body_mode: NONE
                     response_body_mode: NONE
               - name: envoy.filters.http.router
@@ -213,7 +213,7 @@ data:
                   allow_mode_override: true
                   processing_mode:
                     request_header_mode: SEND
-                    response_header_mode: SKIP
+                    response_header_mode: SEND
                     request_body_mode: NONE
                     response_body_mode: NONE
               - name: envoy.filters.http.router


### PR DESCRIPTION
## Summary

- Adds `OnResponse` to all three parsers (a2a, mcp, inference) so downstream plugins can inspect server replies, tool results, and LLM completions — not just inbound requests.
- Enriches the session store with per-event identity, HTTP status, error state, target host, OAuth audience, and latency, and starts recording response-phase events (previously only request-phase events were written).
- Flips session tracking to on-by-default with tightened caps (ttl 30m, 100 sessions × 100 events) so the parser work is actually usable out of the box.

## What was broken before this PR

1. **Response-phase parsing didn't exist.** Every parser's `OnResponse` was a no-op. Tool results, LLM completions, assigned A2A contextIds — all observed by Envoy, all thrown away before anything could act on them.
2. **ext_proc didn't set `pctx.Path` on outbound**, so `inference-parser`'s gate (`/v1/chat/completions`) never matched and the request path was dead for the entire outbound direction.
3. **MCP Streamable HTTP responses come back as SSE** (`event: message\ndata: {...}`). The parser only understood plain JSON-RPC and silently dropped every real response with `"invalid character 'e'"`.
4. **Inference-parser crashed** on follow-up requests after a tool call because the tool-result message uses array-shaped `content`, which broke `json.Unmarshal` into `Content string` and zeroed out the entire `Inference` extension.
5. **Session events never carried response data** even though `SessionPhase.SessionResponse` and helpers like `ToolResponses()` existed in the schema. All recording sites used `Phase: SessionRequest`.
6. **First-turn A2A events landed under `"default"`** because the client has no `contextId` yet, and subsequent turns that carried the real contextId wrote to a different bucket — fragmenting one conversation across two sessions.
7. **Session events had no `Identity`, `StatusCode`, `Error`, `Host`, `TargetAudience`, or `Duration`**, so a `SessionView` couldn't answer "who made this call?", "did it succeed?", "to which tool?", or "how long did it take?"
8. **Session tracking was off by default**, so all of the above improvements were inert unless the operator explicitly opted in.

## What this PR changes

### Parsers (`authlib/plugins/`)

- **`a2a-parser`**: `OnResponse` extracts `contextId` (spec-current) or `sessionId` (legacy) from both JSON-RPC responses and SSE event streams, stamps it on `Extensions.A2A.SessionID`. `OnRequest` fix: prefer `contextId` over `sessionId` in params so resume-turn correlation works.
- **`mcp-parser`**: `OnResponse` stores the parsed `result` map (or `error` map) on `Extensions.MCP.Result`. Handles both JSON-RPC and SSE response shapes.
- **`inference-parser`**: `OnResponse` populates `Completion`, `FinishReason`, `PromptTokens`, `CompletionTokens`, `TotalTokens` for both non-streaming JSON and SSE streams (concatenates deltas). `OnRequest` fix: custom `UnmarshalJSON` on `inferenceMessage` accepts both `content: "string"` and `content: [{"type":"text",...}]`; non-text parts (images, tool_use) dropped.
- **DEBUG logs**: every parser now emits truncated content at DEBUG (part text, message content, completion, bodies — capped at 512 chars via a shared `debugBodyMax`).

### Pipeline / extensions (`authlib/pipeline/`)

- `MCPExtension.Result map[string]any` — parsed response payload.
- `InferenceExtension.Completion / FinishReason / PromptTokens / CompletionTokens / TotalTokens`.
- `Context.StartedAt time.Time` — stamped on every pctx construction so response-time `Duration` is trivial to compute.
- `SessionEvent` extended with `Identity`, `StatusCode`, `Error`, `Host`, `TargetAudience`, `Duration`.
- `SessionView.FailedEvents() / LastError()` — convenience queries over `Error`.

### Session store (`authlib/session/`)

- `Store.Rekey(oldID, newID)` — renames a session in place, preserving events and updating `activeID`. No-op when `oldID` is absent, `newID` is taken, or either is empty. Called on inbound response to migrate `"default"` → server-assigned contextId.
- Every `Append` emits a structured DEBUG line summarizing the event (sessionId, direction, phase, host, OAuth aud, status, durationMs, identity, protocol, error kind) so operators can verify the store is populated correctly.

### ext_proc listener (`cmd/authbridge/listener/extproc/`)

- `Path: getHeader(headers, ":path")` added to both outbound pctx constructions. Unblocks `inference-parser` in production.
- New helpers `recordInboundResponseSession`, `recordOutboundResponseSession`, `snapshotIdentity`, `deriveError`, `routeAudience`, `durationSince`, `rekeyInboundSession`. All four record paths (in/out × req/resp) now snapshot identity; response paths also carry status/error/duration.
- `handleResponseBody` calls `rekeyInboundSession` *before* recording the inbound response event so the event lands under the real contextId rather than being orphaned in `"default"`.
- `handleResponseHeaders` records response events for the headers-only path (plugins without `BodyAccess`).

### Config / defaults (`authlib/config/`, `cmd/authbridge/main.go`)

- `SessionConfig.Enabled` is now `*bool`. Unset → enabled; explicit `false` → disabled. New helper `SessionEnabled()`.
- Defaults tightened: `ttl: 5m → 30m`, `maxSessions: 1000 → 100`, `maxEvents: 100` (unchanged). Upper bound with defaults: ~10k events in memory — well under a typical sidecar limit. Operators wanting more raise the caps explicitly; operators wanting zero overhead set `session.enabled: false`.

### Envoy config (`demos/webhook/k8s/configmaps-webhook.yaml`)

- `response_header_mode: SKIP → SEND` on both the inbound and outbound listeners so Envoy actually forwards response headers to ext_proc.

## Test plan

- [x] Unit tests for every new helper + field: `Rekey` (including edge cases), `snapshotIdentity`, `deriveError`, `routeAudience`, `durationSince`, `recordInboundResponseSession`, `recordOutboundResponseSession`, `SessionEnabled`, parser `OnResponse` (JSON + SSE + error + multipart), inference request multipart content, `SessionView.FailedEvents / LastError`.
- [x] Live end-to-end on the weather-agent demo with all three parsers firing, session tracking enabled by default, rekey observed on the inbound response, full response content logged at DEBUG including the LLM's final answer.
- [x] Verified token accounting (e.g., 167+18 prompt/completion tokens on the tool-calling LLM turn, 169+49 on the formulation turn).
- [x] Verified per-call latencies (MCP handshake ~1-2 ms, LLM ~500-1600 ms, end-to-end inbound ~3-5 s for a weather query with one tool hop).

## Follow-ups (not in this PR)

- `pctx.Agent` is never populated anywhere in the codebase — pre-existing dangling field; plumbing it from the SPIFFE ID at startup is a separate PR.
- Multi-tenant session correctness: the rekey assumes single-conversation-per-pod; two concurrent first-turn requests would both land in `"default"` and one rekey would strand the other. Acceptable for the current sidecar model; revisit when sharing an agent pod across callers becomes a real deployment target.
- Non-text A2A parts (`file`, `data`) are captured but could use a typed accessor for guardrail plugins.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>