### PR TITLE
feat: HTTP session events API (snapshots + SSE stream)

### DIFF
--- a/authbridge/CLAUDE.md
+++ b/authbridge/CLAUDE.md
@@ -290,10 +290,53 @@ kubectl apply -f k8s/auth-target-deployment-webhook.yaml     # Target service
 | 15123 | Envoy | TCP | Outbound listener (iptables redirects app traffic here) |
 | 15124 | Envoy | TCP | Inbound listener (iptables redirects incoming traffic here) |
 | 9090 | authbridge | gRPC | Ext-proc server (called by Envoy) |
+| 9093 | authbridge | HTTP | Stats + config inspection (`/stats`, `/config`) |
+| 9094 | authbridge | HTTP | Session events API (JSON snapshots + SSE stream) |
 | 9901 | Envoy | HTTP | Admin interface (bound to 127.0.0.1) |
 | 8080 | auth-proxy | HTTP | Example app (NOT part of sidecar) |
 | 8081 | demo-app | HTTP | Demo target (JWT validation) |
 | 8443 | demo-app | HTTPS | Demo target (TLS echo, no JWT) |
+
+## Session Events API (`:9094`)
+
+When `session.enabled` is true (default) and `listener.session_api_addr` is non-empty (default `:9094`), the authbridge binary exposes the captured session store over HTTP. Intended for operators debugging the plugin pipeline via `kubectl port-forward` and for the `abctl` TUI.
+
+**Trust model:** no authentication. Bind only on in-cluster addresses, never behind ingress. Payloads may contain raw user messages, LLM completions, and tool results.
+
+### Endpoints
+
+| Method & Path | Format | Purpose |
+|---|---|---|
+| `GET /v1/sessions` | `application/json` | List active sessions: `{sessions: [{id, createdAt, updatedAt, eventCount, active}]}`. |
+| `GET /v1/sessions/{id}` | `application/json` | Full snapshot of one session's events. 404 if unknown/expired. |
+| `GET /v1/events` | `text/event-stream` | SSE stream of new events. Optional `?session=<id>` filters to one session. Heartbeat every 30s. |
+| `GET /healthz` | text | Liveness probe. |
+
+### Quick examples
+
+```sh
+# Port-forward to an agent pod
+POD=$(kubectl get pod -n team1 -l app.kubernetes.io/name=weather-agent \
+  -o jsonpath='{.items[0].metadata.name}')
+kubectl port-forward -n team1 $POD 9094:9094 &
+
+# List sessions
+curl -s http://localhost:9094/v1/sessions | jq
+
+# Snapshot the most recently updated session
+SID=$(curl -s http://localhost:9094/v1/sessions | jq -r '.sessions[0].id')
+curl -s "http://localhost:9094/v1/sessions/$SID" | jq
+
+# Live tail every event
+curl -N http://localhost:9094/v1/events
+
+# Live tail a single session
+curl -N "http://localhost:9094/v1/events?session=$SID"
+```
+
+### Disabling
+
+Set `session.enabled: false` in the runtime config to turn off the store (and implicitly the API). Setting `listener.session_api_addr: ""` alone is not currently supported as a selective disable — the preset refills it; if you need store-on-API-off, raise an issue.
 
 ## Code Conventions
 

--- a/authbridge/authlib/config/config.go
+++ b/authbridge/authlib/config/config.go
@@ -94,6 +94,11 @@ type ListenerConfig struct {
 	ForwardProxyAddr    string `yaml:"forward_proxy_addr" json:"forward_proxy_addr"`
 	ReverseProxyAddr    string `yaml:"reverse_proxy_addr" json:"reverse_proxy_addr"`
 	ReverseProxyBackend string `yaml:"reverse_proxy_backend" json:"reverse_proxy_backend"`
+
+	// SessionAPIAddr is the bind address for the session events HTTP server
+	// (JSON snapshots + SSE stream consumed by abctl or curl). Default per
+	// mode preset is ":9094". Set to empty string to disable the endpoint.
+	SessionAPIAddr string `yaml:"session_api_addr" json:"session_api_addr"`
 }
 
 // BypassConfig holds path patterns that skip inbound JWT validation.

--- a/authbridge/authlib/config/presets.go
+++ b/authbridge/authlib/config/presets.go
@@ -28,6 +28,12 @@ func ApplyPreset(cfg *Config) {
 		setDefault(&cfg.Listener.ForwardProxyAddr, ":8081")
 	}
 
+	// Session events API is default-on for every mode. Operators who want
+	// to turn it off can disable session tracking entirely via
+	// session.enabled: false — main.go skips the API server when the store
+	// itself is nil.
+	setDefault(&cfg.Listener.SessionAPIAddr, ":9094")
+
 	// All modes share the same default bypass paths
 	if len(cfg.Bypass.InboundPaths) == 0 {
 		cfg.Bypass.InboundPaths = bypass.DefaultPatterns

--- a/authbridge/authlib/pipeline/context.go
+++ b/authbridge/authlib/pipeline/context.go
@@ -17,6 +17,19 @@ const (
 	Outbound
 )
 
+// String returns "inbound" / "outbound". Used for structured logs and the
+// wire format of SessionEvent.
+func (d Direction) String() string {
+	switch d {
+	case Inbound:
+		return "inbound"
+	case Outbound:
+		return "outbound"
+	default:
+		return "unknown"
+	}
+}
+
 // Context is the shared state passed through the plugin pipeline.
 // Plugins read and mutate fields directly — there is no separate mutation API.
 type Context struct {

--- a/authbridge/authlib/pipeline/extensions.go
+++ b/authbridge/authlib/pipeline/extensions.go
@@ -16,67 +16,67 @@ type Extensions struct {
 // MCPExtension carries parsed MCP JSON-RPC metadata.
 // Result and Err are mutually exclusive: a response sets exactly one.
 type MCPExtension struct {
-	Method string         // JSON-RPC method (e.g. "tools/call", "resources/read", "initialize")
-	RPCID  any            // JSON-RPC id for request-response correlation
-	Params map[string]any // raw params from the JSON-RPC request
-	Result map[string]any // parsed successful result; nil on error or before OnResponse runs
-	Err    *MCPError      // non-nil when the server returned a JSON-RPC error
+	Method string         `json:"method,omitempty"`
+	RPCID  any            `json:"rpcId,omitempty"`
+	Params map[string]any `json:"params,omitempty"`
+	Result map[string]any `json:"result,omitempty"`
+	Err    *MCPError      `json:"error,omitempty"`
 }
 
 // MCPError mirrors a JSON-RPC 2.0 error object.
 type MCPError struct {
-	Code    int    // JSON-RPC error code (e.g. -32601 method not found)
-	Message string // human-readable error message
-	Data    any    // optional structured error data (implementation-defined)
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
 }
 
 // A2AExtension carries parsed A2A protocol metadata from inbound requests.
 type A2AExtension struct {
-	Method    string // JSON-RPC method: "message/send", "message/stream"
-	RPCID     any    // JSON-RPC id for request-response correlation
-	SessionID string // conversation session (from params.sessionId)
-	MessageID string // unique message ID (from params.message.messageId)
-	Role      string // "user" or "assistant"
-	Parts     []A2APart
+	Method    string    `json:"method,omitempty"`
+	RPCID     any       `json:"rpcId,omitempty"`
+	SessionID string    `json:"sessionId,omitempty"`
+	MessageID string    `json:"messageId,omitempty"`
+	Role      string    `json:"role,omitempty"`
+	Parts     []A2APart `json:"parts,omitempty"`
 }
 
 // A2APart represents a message part in an A2A request.
 type A2APart struct {
-	Kind    string // "text", "file", "data"
-	Content string // text content, file URI, or serialized data
+	Kind    string `json:"kind"`
+	Content string `json:"content,omitempty"`
 }
 
 // InferenceExtension carries parsed LLM inference request and response metadata.
 // Request fields are populated by OnRequest; response fields by OnResponse.
 type InferenceExtension struct {
-	Model       string             // model name (e.g., "llama3.1", "gpt-4")
-	Messages    []InferenceMessage // conversation messages
-	Temperature *float64           // sampling temperature (nil if not set)
-	MaxTokens   *int               // max tokens to generate (nil if not set)
-	Stream      bool               // whether streaming is requested
-	Tools       []string           // tool/function names declared
+	Model       string             `json:"model,omitempty"`
+	Messages    []InferenceMessage `json:"messages,omitempty"`
+	Temperature *float64           `json:"temperature,omitempty"`
+	MaxTokens   *int               `json:"maxTokens,omitempty"`
+	Stream      bool               `json:"stream,omitempty"`
+	Tools       []string           `json:"tools,omitempty"`
 
 	// Response fields (populated after OnResponse runs).
-	Completion       string // assistant's response text (concatenated across SSE deltas)
-	FinishReason     string // "stop", "length", "tool_calls", "content_filter", etc.
-	PromptTokens     int    // tokens consumed by the prompt
-	CompletionTokens int    // tokens generated in the response
-	TotalTokens      int    // PromptTokens + CompletionTokens (as reported by the server)
+	Completion       string `json:"completion,omitempty"`
+	FinishReason     string `json:"finishReason,omitempty"`
+	PromptTokens     int    `json:"promptTokens,omitempty"`
+	CompletionTokens int    `json:"completionTokens,omitempty"`
+	TotalTokens      int    `json:"totalTokens,omitempty"`
 }
 
 // InferenceMessage represents a single message in the conversation.
 type InferenceMessage struct {
-	Role    string // "system", "user", "assistant", "tool"
-	Content string
+	Role    string `json:"role"`
+	Content string `json:"content,omitempty"`
 }
 
 // SecurityExtension carries guardrail output.
 // Caller identity is already in ctx.Agent and ctx.Claims — this slot is only
 // for downstream signals from content-inspection plugins.
 type SecurityExtension struct {
-	Labels      []string
-	Blocked     bool
-	BlockReason string
+	Labels      []string `json:"labels,omitempty"`
+	Blocked     bool     `json:"blocked,omitempty"`
+	BlockReason string   `json:"blockReason,omitempty"`
 }
 
 // DelegationExtension tracks the token delegation chain across hops.

--- a/authbridge/authlib/pipeline/session.go
+++ b/authbridge/authlib/pipeline/session.go
@@ -1,6 +1,9 @@
 package pipeline
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 // SessionPhase distinguishes request from response events.
 type SessionPhase int
@@ -66,26 +69,61 @@ type SessionEvent struct {
 	Duration time.Duration
 }
 
+// MarshalJSON emits SessionEvent in a form consumable by off-process clients:
+// Direction and Phase become strings instead of opaque int enums, and Duration
+// is emitted as milliseconds (the field name reflects the unit). The default
+// json marshaler would stringify enums as numbers and duration as nanoseconds
+// — both awkward for CLI / dashboard consumption.
+func (e SessionEvent) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		At             time.Time           `json:"at"`
+		Direction      string              `json:"direction"`
+		Phase          string              `json:"phase"`
+		A2A            *A2AExtension       `json:"a2a,omitempty"`
+		MCP            *MCPExtension       `json:"mcp,omitempty"`
+		Inference      *InferenceExtension `json:"inference,omitempty"`
+		Identity       *EventIdentity      `json:"identity,omitempty"`
+		StatusCode     int                 `json:"statusCode,omitempty"`
+		Error          *EventError         `json:"error,omitempty"`
+		Host           string              `json:"host,omitempty"`
+		TargetAudience string              `json:"targetAudience,omitempty"`
+		DurationMs     int64               `json:"durationMs,omitempty"`
+	}{
+		At:             e.At,
+		Direction:      e.Direction.String(),
+		Phase:          e.Phase.String(),
+		A2A:            e.A2A,
+		MCP:            e.MCP,
+		Inference:      e.Inference,
+		Identity:       e.Identity,
+		StatusCode:     e.StatusCode,
+		Error:          e.Error,
+		Host:           e.Host,
+		TargetAudience: e.TargetAudience,
+		DurationMs:     e.Duration.Milliseconds(),
+	})
+}
+
 // EventIdentity carries the "who" for a session event.
 type EventIdentity struct {
-	Subject  string   // end-user subject from JWT (Claims.Subject)
-	Scopes   []string // validated scopes
-	ClientID string   // JWT azp claim (the client that minted the token)
-	AgentID  string   // the sidecar's own workload identity (Agent.WorkloadID)
+	Subject  string   `json:"subject,omitempty"`
+	Scopes   []string `json:"scopes,omitempty"`
+	ClientID string   `json:"clientId,omitempty"`
+	AgentID  string   `json:"agentId,omitempty"`
 }
 
 // EventError describes why a response event represents a failure.
 type EventError struct {
-	Kind    string // "backend_error" | "blocked" | "parser_error" | "timeout"
-	Code    string // protocol-specific error code (HTTP status, JSON-RPC code, etc.)
+	Kind    string `json:"kind"`
+	Code    string `json:"code,omitempty"`
 	Message string // human-readable reason; safe to surface in logs/metrics
 }
 
 // SessionView is a read-only snapshot of a session, safe to pass to plugins.
 // It contains a copy of events — plugins cannot mutate the store.
 type SessionView struct {
-	ID     string
-	Events []SessionEvent
+	ID     string         `json:"id"`
+	Events []SessionEvent `json:"events"`
 }
 
 // Intents returns only inbound A2A request events (user messages).

--- a/authbridge/authlib/pipeline/session.go
+++ b/authbridge/authlib/pipeline/session.go
@@ -27,6 +27,13 @@ func (p SessionPhase) String() string {
 // SessionEvent represents a single pipeline event captured by the session store.
 // Exactly one of A2A, MCP, or Inference is non-nil.
 type SessionEvent struct {
+	// SessionID is the session bucket the event was appended to. Populated by
+	// Store.Append so downstream consumers (particularly the SSE stream
+	// filter) can attribute any event — including outbound MCP/Inference
+	// events that have no protocol-native session concept — to a session
+	// without needing a side-channel lookup.
+	SessionID string
+
 	At        time.Time
 	Direction Direction
 	Phase     SessionPhase
@@ -76,6 +83,7 @@ type SessionEvent struct {
 // — both awkward for CLI / dashboard consumption.
 func (e SessionEvent) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
+		SessionID      string              `json:"sessionId,omitempty"`
 		At             time.Time           `json:"at"`
 		Direction      string              `json:"direction"`
 		Phase          string              `json:"phase"`
@@ -89,6 +97,7 @@ func (e SessionEvent) MarshalJSON() ([]byte, error) {
 		TargetAudience string              `json:"targetAudience,omitempty"`
 		DurationMs     int64               `json:"durationMs,omitempty"`
 	}{
+		SessionID:      e.SessionID,
 		At:             e.At,
 		Direction:      e.Direction.String(),
 		Phase:          e.Phase.String(),
@@ -116,7 +125,7 @@ type EventIdentity struct {
 type EventError struct {
 	Kind    string `json:"kind"`
 	Code    string `json:"code,omitempty"`
-	Message string // human-readable reason; safe to surface in logs/metrics
+	Message string `json:"message,omitempty"` // human-readable reason; safe to surface in logs/metrics
 }
 
 // SessionView is a read-only snapshot of a session, safe to pass to plugins.

--- a/authbridge/authlib/pipeline/session_test.go
+++ b/authbridge/authlib/pipeline/session_test.go
@@ -1,0 +1,64 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDirectionString(t *testing.T) {
+	if Inbound.String() != "inbound" {
+		t.Errorf("Inbound.String() = %q, want %q", Inbound.String(), "inbound")
+	}
+	if Outbound.String() != "outbound" {
+		t.Errorf("Outbound.String() = %q, want %q", Outbound.String(), "outbound")
+	}
+	if got := Direction(42).String(); got != "unknown" {
+		t.Errorf("unknown direction = %q, want %q", got, "unknown")
+	}
+}
+
+func TestSessionEvent_MarshalJSON_ReadableEnums(t *testing.T) {
+	e := SessionEvent{
+		At:        time.Unix(1700000000, 0).UTC(),
+		Direction: Inbound,
+		Phase:     SessionResponse,
+		Duration:  250 * time.Millisecond,
+		Host:      "weather-tool-mcp:9090",
+		A2A:       &A2AExtension{Method: "message/stream"},
+	}
+
+	data, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	s := string(data)
+
+	// Enums must be strings, not numbers.
+	if !strings.Contains(s, `"direction":"inbound"`) {
+		t.Errorf("direction not serialized as string: %s", s)
+	}
+	if !strings.Contains(s, `"phase":"response"`) {
+		t.Errorf("phase not serialized as string: %s", s)
+	}
+	// Duration must be emitted in ms, not the default nanosecond form.
+	if !strings.Contains(s, `"durationMs":250`) {
+		t.Errorf("durationMs missing or wrong: %s", s)
+	}
+}
+
+func TestSessionEvent_MarshalJSON_OmitsEmpty(t *testing.T) {
+	e := SessionEvent{Direction: Outbound, Phase: SessionRequest}
+	data, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	s := string(data)
+
+	for _, field := range []string{"a2a", "mcp", "inference", "identity", "statusCode", "error", "host", "targetAudience", "durationMs"} {
+		if strings.Contains(s, `"`+field+`":`) {
+			t.Errorf("expected %q omitted when zero: %s", field, s)
+		}
+	}
+}

--- a/authbridge/authlib/session/store.go
+++ b/authbridge/authlib/session/store.go
@@ -5,7 +5,9 @@ package session
 
 import (
 	"log/slog"
+	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/pipeline"
@@ -37,6 +39,74 @@ type Store struct {
 	activeID    string
 	stop        chan struct{}
 	closeOnce   sync.Once
+
+	// subscribers is the fan-out list for Subscribe(). Protected by mu.
+	subscribers []*subscriber
+}
+
+// subscriberChanBuf caps each subscriber's channel depth. 64 absorbs short
+// bursts without unbounded memory; slow consumers drop rather than blocking
+// Append.
+const subscriberChanBuf = 64
+
+// subscriber wires one live consumer of session events. Writes on ch are
+// non-blocking — a full channel increments drops and discards the event.
+type subscriber struct {
+	ch        chan pipeline.SessionEvent
+	drops     uint64 // atomic; reads via LoadDrops
+	closeOnce sync.Once
+}
+
+// closeCh closes ch at most once. Called by the cancel func returned from
+// Subscribe and by Store.Close during shutdown; whichever runs first wins.
+func (s *subscriber) closeCh() {
+	s.closeOnce.Do(func() { close(s.ch) })
+}
+
+// LoadDrops returns the total events dropped for this subscriber since Subscribe.
+func (s *subscriber) LoadDrops() uint64 {
+	return atomic.LoadUint64(&s.drops)
+}
+
+// Subscribe registers a listener for session events written after the call.
+// The returned channel is buffered (64). Events are sent non-blockingly; if
+// the consumer falls behind, events are dropped — the caller can observe the
+// drop count via the returned Subscription's Drops method. Always call the
+// cancel func to remove the subscriber and close the channel.
+func (s *Store) Subscribe() (*Subscription, func()) {
+	sub := &subscriber{ch: make(chan pipeline.SessionEvent, subscriberChanBuf)}
+
+	s.mu.Lock()
+	s.subscribers = append(s.subscribers, sub)
+	s.mu.Unlock()
+
+	cancel := func() {
+		s.mu.Lock()
+		for i, existing := range s.subscribers {
+			if existing == sub {
+				s.subscribers = append(s.subscribers[:i], s.subscribers[i+1:]...)
+				break
+			}
+		}
+		s.mu.Unlock()
+		sub.closeCh()
+	}
+	return &Subscription{sub: sub}, cancel
+}
+
+// Subscription is the consumer-facing handle returned by Store.Subscribe.
+type Subscription struct {
+	sub *subscriber
+}
+
+// Events returns the receive-only channel of session events.
+func (s *Subscription) Events() <-chan pipeline.SessionEvent {
+	return s.sub.ch
+}
+
+// Drops returns the cumulative event drops due to a full channel.
+func (s *Subscription) Drops() uint64 {
+	return s.sub.LoadDrops()
 }
 
 // New creates a Store with the given TTL, per-session event limit, and max
@@ -54,9 +124,21 @@ func New(ttl time.Duration, maxEvents int, maxSessions int) *Store {
 	return s
 }
 
-// Close stops the background cleanup goroutine. Safe to call multiple times.
+// Close stops the background cleanup goroutine and closes every subscriber's
+// channel so consumers unblock cleanly on shutdown. Safe to call multiple times.
 func (s *Store) Close() {
-	s.closeOnce.Do(func() { close(s.stop) })
+	s.closeOnce.Do(func() {
+		close(s.stop)
+
+		s.mu.Lock()
+		subs := s.subscribers
+		s.subscribers = nil
+		s.mu.Unlock()
+
+		for _, sub := range subs {
+			sub.closeCh()
+		}
+	})
 }
 
 func (s *Store) backgroundCleanup() {
@@ -103,6 +185,7 @@ func (s *Store) Append(sessionID string, event pipeline.SessionEvent) {
 	s.activeID = sessionID
 
 	logAppended(sessionID, &event)
+	s.publishLocked(event)
 
 	if s.maxEvents > 0 && len(sess.Events) > s.maxEvents {
 		excess := len(sess.Events) - s.maxEvents
@@ -134,6 +217,43 @@ func (s *Store) View(sessionID string) *pipeline.SessionView {
 	events := make([]pipeline.SessionEvent, len(sess.Events))
 	copy(events, sess.Events)
 	return &pipeline.SessionView{ID: sessionID, Events: events}
+}
+
+// SessionSummary is a metadata-only view of a session, suitable for list
+// endpoints that shouldn't copy the full event backlog.
+type SessionSummary struct {
+	ID         string    `json:"id"`
+	CreatedAt  time.Time `json:"createdAt"`
+	UpdatedAt  time.Time `json:"updatedAt"`
+	EventCount int       `json:"eventCount"`
+	Active     bool      `json:"active"` // true if this is the most recently updated session
+}
+
+// ListSessions returns summaries for every non-expired session. Order is
+// UpdatedAt descending (most recent first). Safe for concurrent use.
+func (s *Store) ListSessions() []SessionSummary {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	now := time.Now()
+	out := make([]SessionSummary, 0, len(s.sessions))
+	for id, sess := range s.sessions {
+		if s.isExpired(sess, now) {
+			continue
+		}
+		out = append(out, SessionSummary{
+			ID:         id,
+			CreatedAt:  sess.CreatedAt,
+			UpdatedAt:  sess.UpdatedAt,
+			EventCount: len(sess.Events),
+			Active:     id == s.activeID,
+		})
+	}
+	// Most recently updated first.
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].UpdatedAt.After(out[j].UpdatedAt)
+	})
+	return out
 }
 
 // ActiveSession returns the most recently updated session ID.
@@ -240,6 +360,19 @@ func (s *Store) isExpired(sess *entry, now time.Time) bool {
 	return now.Sub(sess.UpdatedAt) > s.ttl
 }
 
+// publishLocked fans out event to every current subscriber. Must be called
+// with s.mu held. Sends are non-blocking — a full channel increments the
+// subscriber's drop counter and discards the event.
+func (s *Store) publishLocked(event pipeline.SessionEvent) {
+	for _, sub := range s.subscribers {
+		select {
+		case sub.ch <- event:
+		default:
+			atomic.AddUint64(&sub.drops, 1)
+		}
+	}
+}
+
 // logAppended emits a structured DEBUG line so operators can observe session
 // state evolution. Fields are chosen to cover the data captured by all four
 // record helpers — extension payloads themselves are intentionally omitted
@@ -247,7 +380,7 @@ func (s *Store) isExpired(sess *entry, now time.Time) bool {
 func logAppended(sessionID string, e *pipeline.SessionEvent) {
 	attrs := []any{
 		"sessionId", sessionID,
-		"direction", directionName(e.Direction),
+		"direction", e.Direction.String(),
 		"phase", e.Phase.String(),
 	}
 	if e.Host != "" {
@@ -290,9 +423,3 @@ func logAppended(sessionID string, e *pipeline.SessionEvent) {
 	slog.Debug("session: event appended", attrs...)
 }
 
-func directionName(d pipeline.Direction) string {
-	if d == pipeline.Inbound {
-		return "inbound"
-	}
-	return "outbound"
-}

--- a/authbridge/authlib/session/store.go
+++ b/authbridge/authlib/session/store.go
@@ -180,6 +180,11 @@ func (s *Store) Append(sessionID string, event pipeline.SessionEvent) {
 		s.sessions[sessionID] = sess
 	}
 
+	// Stamp the bucket ID so downstream consumers can attribute the event
+	// without needing to know which session it was appended to — critical for
+	// outbound events that have no protocol-native session field.
+	event.SessionID = sessionID
+
 	sess.Events = append(sess.Events, event)
 	sess.UpdatedAt = now
 	s.activeID = sessionID
@@ -314,6 +319,11 @@ func (s *Store) Rekey(oldID, newID string) {
 	if s.activeID == oldID {
 		s.activeID = newID
 	}
+	// Retrofit already-recorded events with the new session ID so snapshot
+	// reads stay consistent with live-streamed events after a rekey.
+	for i := range sess.Events {
+		sess.Events[i].SessionID = newID
+	}
 }
 
 // Cleanup removes expired sessions. Safe for concurrent use.
@@ -363,6 +373,12 @@ func (s *Store) isExpired(sess *entry, now time.Time) bool {
 // publishLocked fans out event to every current subscriber. Must be called
 // with s.mu held. Sends are non-blocking — a full channel increments the
 // subscriber's drop counter and discards the event.
+//
+// Performance note: fan-out runs under s.mu, which serializes Append on the
+// subscriber list length. This is fine for the debug API's expected load
+// (O(1) live consumers: one abctl instance + maybe a curl tail). If the
+// store ever needs to support many concurrent subscribers, refactor this
+// to an unlocked broadcast (snapshot the slice under the lock, send outside).
 func (s *Store) publishLocked(event pipeline.SessionEvent) {
 	for _, sub := range s.subscribers {
 		select {

--- a/authbridge/authlib/session/store_test.go
+++ b/authbridge/authlib/session/store_test.go
@@ -441,3 +441,122 @@ func TestView_LastError_NoErrors(t *testing.T) {
 		t.Error("FailedEvents should be nil when no errors present")
 	}
 }
+
+func TestStore_Subscribe_ReceivesAppendedEvents(t *testing.T) {
+	s := New(5*time.Minute, 100, 0)
+	defer s.Close()
+
+	sub, cancel := s.Subscribe()
+	defer cancel()
+
+	s.Append("sess", pipeline.SessionEvent{
+		A2A: &pipeline.A2AExtension{Method: "message/send"},
+	})
+
+	select {
+	case e := <-sub.Events():
+		if e.A2A == nil || e.A2A.Method != "message/send" {
+			t.Errorf("received wrong event: %+v", e)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no event received within 1s")
+	}
+}
+
+func TestStore_Subscribe_CancelStopsDelivery(t *testing.T) {
+	s := New(5*time.Minute, 100, 0)
+	defer s.Close()
+
+	sub, cancel := s.Subscribe()
+	cancel()
+
+	s.Append("sess", pipeline.SessionEvent{A2A: &pipeline.A2AExtension{}})
+
+	// Channel should be closed; receive returns zero value with ok=false.
+	select {
+	case _, ok := <-sub.Events():
+		if ok {
+			t.Error("received event after cancel")
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("channel never closed after cancel")
+	}
+}
+
+func TestStore_Subscribe_SlowConsumerDropsWithoutBlocking(t *testing.T) {
+	s := New(5*time.Minute, 10000, 0)
+	defer s.Close()
+
+	sub, cancel := s.Subscribe()
+	defer cancel()
+
+	// Flood well beyond buffer capacity without consuming — must not block Append.
+	total := subscriberChanBuf + 50
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < total; i++ {
+			s.Append("sess", pipeline.SessionEvent{})
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Good — Append did not block.
+	case <-time.After(time.Second):
+		t.Fatal("Append blocked on slow consumer")
+	}
+
+	if drops := sub.Drops(); drops == 0 {
+		t.Errorf("expected some drops, got 0")
+	}
+}
+
+func TestStore_Subscribe_FanOutToMultipleSubscribers(t *testing.T) {
+	s := New(5*time.Minute, 100, 0)
+	defer s.Close()
+
+	a, cancelA := s.Subscribe()
+	defer cancelA()
+	b, cancelB := s.Subscribe()
+	defer cancelB()
+
+	s.Append("sess", pipeline.SessionEvent{A2A: &pipeline.A2AExtension{Method: "ping"}})
+
+	gotA := waitEvent(t, a.Events(), time.Second)
+	gotB := waitEvent(t, b.Events(), time.Second)
+	if gotA.A2A == nil || gotA.A2A.Method != "ping" {
+		t.Errorf("A received wrong event: %+v", gotA)
+	}
+	if gotB.A2A == nil || gotB.A2A.Method != "ping" {
+		t.Errorf("B received wrong event: %+v", gotB)
+	}
+}
+
+func TestStore_Subscribe_CloseStoreUnblocksSubscribers(t *testing.T) {
+	s := New(5*time.Minute, 100, 0)
+	sub, cancel := s.Subscribe()
+	defer cancel()
+
+	s.Close() // must close subscriber channels, not just the cleanup goroutine
+
+	select {
+	case _, ok := <-sub.Events():
+		if ok {
+			t.Error("expected closed channel after Store.Close")
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Store.Close did not close subscriber channel")
+	}
+}
+
+func waitEvent(t *testing.T, ch <-chan pipeline.SessionEvent, d time.Duration) pipeline.SessionEvent {
+	t.Helper()
+	select {
+	case e := <-ch:
+		return e
+	case <-time.After(d):
+		t.Fatalf("timeout waiting for event after %v", d)
+		return pipeline.SessionEvent{}
+	}
+}

--- a/authbridge/authlib/session/store_test.go
+++ b/authbridge/authlib/session/store_test.go
@@ -550,6 +550,46 @@ func TestStore_Subscribe_CloseStoreUnblocksSubscribers(t *testing.T) {
 	}
 }
 
+func TestStore_Append_StampsSessionID(t *testing.T) {
+	// Consumers (snapshot or stream) need to attribute events — especially
+	// outbound ones with no protocol-native session field — to a bucket.
+	s := New(5*time.Minute, 100, 0)
+	defer s.Close()
+
+	s.Append("bucket-42", pipeline.SessionEvent{MCP: &pipeline.MCPExtension{Method: "tools/call"}})
+
+	v := s.View("bucket-42")
+	if v == nil || len(v.Events) != 1 {
+		t.Fatalf("expected 1 event, got %+v", v)
+	}
+	if v.Events[0].SessionID != "bucket-42" {
+		t.Errorf("SessionID = %q, want %q", v.Events[0].SessionID, "bucket-42")
+	}
+}
+
+func TestStore_Rekey_RewritesExistingEventSessionIDs(t *testing.T) {
+	// After Rekey, snapshot reads of the new key must show the original
+	// events with SessionID updated to the new bucket ID — otherwise
+	// downstream consumers see a mismatch between the session's outer ID
+	// and each event's inner SessionID.
+	s := New(5*time.Minute, 100, 0)
+	defer s.Close()
+
+	s.Append(DefaultSessionID, pipeline.SessionEvent{A2A: &pipeline.A2AExtension{}})
+	s.Append(DefaultSessionID, pipeline.SessionEvent{MCP: &pipeline.MCPExtension{}})
+	s.Rekey(DefaultSessionID, "ctx-abc")
+
+	v := s.View("ctx-abc")
+	if v == nil || len(v.Events) != 2 {
+		t.Fatalf("expected 2 events under new key, got %+v", v)
+	}
+	for i, e := range v.Events {
+		if e.SessionID != "ctx-abc" {
+			t.Errorf("events[%d].SessionID = %q, want %q", i, e.SessionID, "ctx-abc")
+		}
+	}
+}
+
 func waitEvent(t *testing.T, ch <-chan pipeline.SessionEvent, d time.Duration) pipeline.SessionEvent {
 	t.Helper()
 	select {

--- a/authbridge/authlib/sessionapi/server.go
+++ b/authbridge/authlib/sessionapi/server.go
@@ -1,0 +1,182 @@
+// Package sessionapi exposes AuthBridge's in-memory session store over HTTP:
+// JSON snapshots plus an SSE stream of live events. Intended for local
+// operators debugging the plugin pipeline via kubectl port-forward and for
+// the abctl TUI.
+//
+// Trust model: no authentication. Bind only on in-cluster addresses, never
+// behind an ingress. The payload may contain user messages, LLM completions,
+// and tool results verbatim.
+package sessionapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/kagenti/kagenti-extensions/authbridge/authlib/session"
+)
+
+// defaultHeartbeatInterval is how often the SSE stream sends a keep-alive
+// comment so clients can detect a dead connection. Tuneable for tests via
+// WithHeartbeatInterval.
+const defaultHeartbeatInterval = 30 * time.Second
+
+// Server wraps an http.Server bound to a session store.
+type Server struct {
+	server    *http.Server
+	store     *session.Store
+	heartbeat time.Duration
+}
+
+// Option configures a Server at construction time.
+type Option func(*Server)
+
+// WithHeartbeatInterval overrides the SSE heartbeat cadence. Primarily for
+// tests — production deployments should use the default.
+func WithHeartbeatInterval(d time.Duration) Option {
+	return func(s *Server) { s.heartbeat = d }
+}
+
+// New constructs an HTTP server serving the session API at addr. store must
+// be non-nil; callers should only instantiate when session tracking is on.
+func New(addr string, store *session.Store, opts ...Option) *Server {
+	s := &Server{
+		store:     store,
+		heartbeat: defaultHeartbeatInterval,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /v1/sessions", s.handleList)
+	mux.HandleFunc("GET /v1/sessions/{id}", s.handleGet)
+	mux.HandleFunc("GET /v1/events", s.handleStream)
+	mux.HandleFunc("GET /healthz", s.handleHealthz)
+
+	s.server = &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	return s
+}
+
+// Server returns the underlying *http.Server so callers can register it for
+// graceful shutdown alongside the binary's other HTTP listeners.
+func (s *Server) Server() *http.Server { return s.server }
+
+// ListenAndServe blocks until the server returns. Returns http.ErrServerClosed
+// on graceful shutdown.
+func (s *Server) ListenAndServe() error { return s.server.ListenAndServe() }
+
+// Shutdown gracefully stops the server.
+func (s *Server) Shutdown(ctx context.Context) error { return s.server.Shutdown(ctx) }
+
+// --- handlers -------------------------------------------------------------
+
+func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok\n"))
+}
+
+func (s *Server) handleList(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(struct {
+		Sessions []session.SessionSummary `json:"sessions"`
+	}{Sessions: s.store.ListSessions()}); err != nil {
+		slog.Debug("sessionapi: list encode failed", "error", err)
+	}
+}
+
+func (s *Server) handleGet(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	view := s.store.View(id)
+	if view == nil {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(view); err != nil {
+		slog.Debug("sessionapi: get encode failed", "error", err, "sessionID", id)
+	}
+}
+
+// handleStream delivers new session events as an SSE stream. Supports
+// ?session=<id> to filter to one session. A heartbeat comment is emitted
+// at the configured interval so clients can detect dead connections.
+//
+// Lifecycle: subscribes to the store, flushes each event to the client, and
+// exits when the client disconnects (via r.Context().Done()). The subscriber
+// is always cancelled on exit to free the buffered channel.
+func (s *Server) handleStream(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	filter := strings.TrimSpace(r.URL.Query().Get("session"))
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no") // disable proxy buffering if any
+
+	// Initial comment lets the client know the stream is live before any events.
+	fmt.Fprint(w, ": ok\n\n")
+	flusher.Flush()
+
+	sub, cancel := s.store.Subscribe()
+	defer cancel()
+
+	heartbeat := time.NewTicker(s.heartbeat)
+	defer heartbeat.Stop()
+
+	var id uint64
+	var lastDrops uint64
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+
+		case event, ok := <-sub.Events():
+			if !ok {
+				// Store closed or subscription cancelled externally.
+				return
+			}
+			if filter != "" && event.A2A != nil && event.A2A.SessionID != filter {
+				continue
+			}
+			// For outbound events there's no direct sessionID; best-effort
+			// filtering happens only when the event carries an A2A extension.
+			// A policy plugin wanting fine-grained per-session outbound filtering
+			// should consume the full stream and filter client-side.
+
+			payload, err := json.Marshal(event)
+			if err != nil {
+				slog.Debug("sessionapi: marshal event failed", "error", err)
+				continue
+			}
+			atomic.AddUint64(&id, 1)
+			fmt.Fprintf(w, "event: session-event\nid: %d\ndata: %s\n\n", id, payload)
+			flusher.Flush()
+
+		case <-heartbeat.C:
+			// Surface accumulated drops so the operator can notice a slow client.
+			if drops := sub.Drops(); drops > lastDrops {
+				slog.Warn("sessionapi: sse consumer lagged",
+					"drops", drops, "newDrops", drops-lastDrops)
+				lastDrops = drops
+			}
+			fmt.Fprint(w, ": heartbeat\n\n")
+			flusher.Flush()
+		}
+	}
+}

--- a/authbridge/authlib/sessionapi/server.go
+++ b/authbridge/authlib/sessionapi/server.go
@@ -15,7 +15,6 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/session"
@@ -151,20 +150,16 @@ func (s *Server) handleStream(w http.ResponseWriter, r *http.Request) {
 				// Store closed or subscription cancelled externally.
 				return
 			}
-			if filter != "" && event.A2A != nil && event.A2A.SessionID != filter {
+			if filter != "" && event.SessionID != filter {
 				continue
 			}
-			// For outbound events there's no direct sessionID; best-effort
-			// filtering happens only when the event carries an A2A extension.
-			// A policy plugin wanting fine-grained per-session outbound filtering
-			// should consume the full stream and filter client-side.
 
 			payload, err := json.Marshal(event)
 			if err != nil {
 				slog.Debug("sessionapi: marshal event failed", "error", err)
 				continue
 			}
-			atomic.AddUint64(&id, 1)
+			id++
 			fmt.Fprintf(w, "event: session-event\nid: %d\ndata: %s\n\n", id, payload)
 			flusher.Flush()
 

--- a/authbridge/authlib/sessionapi/server_test.go
+++ b/authbridge/authlib/sessionapi/server_test.go
@@ -205,15 +205,16 @@ func TestHandleStream_SessionFilter(t *testing.T) {
 	}
 	defer resp.Body.Close()
 	sc := bufio.NewScanner(resp.Body)
+	sc.Buffer(make([]byte, 0, 8192), 4<<20)
 	waitForLine(t, sc, ":", "initial", time.Second)
 
 	// Event with a different SessionID — should be filtered out.
 	store.Append("drop", pipeline.SessionEvent{
-		A2A: &pipeline.A2AExtension{SessionID: "drop"},
+		A2A: &pipeline.A2AExtension{Method: "message/stream"},
 	})
 	// Event with matching SessionID — should come through.
 	store.Append("keep", pipeline.SessionEvent{
-		A2A: &pipeline.A2AExtension{SessionID: "keep", Method: "message/stream"},
+		A2A: &pipeline.A2AExtension{Method: "message/stream"},
 	})
 
 	data := scanUntilPrefix(t, sc, "data: ", time.Second)
@@ -221,10 +222,50 @@ func TestHandleStream_SessionFilter(t *testing.T) {
 		t.Fatal("no data frame received")
 	}
 	if !strings.Contains(data, `"sessionId":"keep"`) {
-		t.Errorf("got wrong session in stream: %s", data)
+		t.Errorf("expected keep session in stream, got: %s", data)
 	}
 	if strings.Contains(data, `"sessionId":"drop"`) {
 		t.Errorf("unfiltered drop event leaked: %s", data)
+	}
+}
+
+func TestHandleStream_SessionFilter_WorksOnOutboundMCP(t *testing.T) {
+	// Prior to SessionEvent.SessionID being populated at Append time, this
+	// test would have failed: the outbound MCP event has no A2A extension
+	// and the old filter check bailed when A2A was nil, letting foreign
+	// events through. Guards against regression.
+	ts, store := newTestServer(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, "GET", ts.URL+"/v1/events?session=keep", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	sc := bufio.NewScanner(resp.Body)
+	sc.Buffer(make([]byte, 0, 8192), 4<<20)
+	waitForLine(t, sc, ":", "initial", time.Second)
+
+	// Outbound MCP call appended to the wrong bucket — must be filtered.
+	store.Append("drop", pipeline.SessionEvent{
+		MCP: &pipeline.MCPExtension{Method: "tools/call"},
+	})
+	// Outbound MCP call in the target bucket — must pass.
+	store.Append("keep", pipeline.SessionEvent{
+		MCP: &pipeline.MCPExtension{Method: "tools/list"},
+	})
+
+	data := scanUntilPrefix(t, sc, "data: ", time.Second)
+	if data == "" {
+		t.Fatal("no data frame received within deadline")
+	}
+	if !strings.Contains(data, `"sessionId":"keep"`) {
+		t.Errorf("expected sessionId:keep, got: %s", data)
+	}
+	if !strings.Contains(data, `"method":"tools/list"`) {
+		t.Errorf("expected MCP tools/list event, got: %s", data)
 	}
 }
 

--- a/authbridge/authlib/sessionapi/server_test.go
+++ b/authbridge/authlib/sessionapi/server_test.go
@@ -1,0 +1,297 @@
+package sessionapi
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kagenti/kagenti-extensions/authbridge/authlib/pipeline"
+	"github.com/kagenti/kagenti-extensions/authbridge/authlib/session"
+)
+
+// newTestServer wires a Server backed by a fresh Store onto httptest so tests
+// hit the real mux and real handlers. Returns a teardown closer.
+func newTestServer(t *testing.T, opts ...Option) (*httptest.Server, *session.Store) {
+	t.Helper()
+	store := session.New(5*time.Minute, 100, 0)
+	// Use a tiny heartbeat by default so SSE tests don't hang.
+	opts = append([]Option{WithHeartbeatInterval(50 * time.Millisecond)}, opts...)
+	srv := New(":0", store, opts...)
+	ts := httptest.NewServer(srv.server.Handler)
+	t.Cleanup(func() {
+		ts.Close()
+		store.Close()
+	})
+	return ts, store
+}
+
+func TestHandleList_Empty(t *testing.T) {
+	ts, _ := newTestServer(t)
+	resp, err := http.Get(ts.URL + "/v1/sessions")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var body struct {
+		Sessions []session.SessionSummary `json:"sessions"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Sessions) != 0 {
+		t.Errorf("expected 0 sessions, got %d", len(body.Sessions))
+	}
+}
+
+func TestHandleList_ShowsAppendedSessions(t *testing.T) {
+	ts, store := newTestServer(t)
+	store.Append("s1", pipeline.SessionEvent{A2A: &pipeline.A2AExtension{}})
+	store.Append("s2", pipeline.SessionEvent{A2A: &pipeline.A2AExtension{}})
+	store.Append("s2", pipeline.SessionEvent{A2A: &pipeline.A2AExtension{}})
+
+	resp, err := http.Get(ts.URL + "/v1/sessions")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var body struct {
+		Sessions []session.SessionSummary `json:"sessions"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Sessions) != 2 {
+		t.Fatalf("expected 2 sessions, got %d (%+v)", len(body.Sessions), body.Sessions)
+	}
+	// Most recently updated first.
+	if body.Sessions[0].ID != "s2" {
+		t.Errorf("first = %q, want s2", body.Sessions[0].ID)
+	}
+	if body.Sessions[0].EventCount != 2 {
+		t.Errorf("s2 eventCount = %d, want 2", body.Sessions[0].EventCount)
+	}
+	if !body.Sessions[0].Active {
+		t.Errorf("s2 should be marked active")
+	}
+}
+
+func TestHandleGet_NotFound(t *testing.T) {
+	ts, _ := newTestServer(t)
+	resp, err := http.Get(ts.URL + "/v1/sessions/does-not-exist")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 404 {
+		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestHandleGet_ReturnsEventsAndReadableEnums(t *testing.T) {
+	ts, store := newTestServer(t)
+	store.Append("s1", pipeline.SessionEvent{
+		Direction: pipeline.Inbound,
+		Phase:     pipeline.SessionResponse,
+		A2A:       &pipeline.A2AExtension{Method: "message/stream"},
+	})
+
+	resp, err := http.Get(ts.URL + "/v1/sessions/s1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(raw), `"direction":"inbound"`) {
+		t.Errorf("expected string enums in payload: %s", raw)
+	}
+	if !strings.Contains(string(raw), `"phase":"response"`) {
+		t.Errorf("expected string phase in payload: %s", raw)
+	}
+}
+
+func TestHandleStream_DeliversAppendedEvent(t *testing.T) {
+	ts, store := newTestServer(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, "GET", ts.URL+"/v1/events", nil)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.Header.Get("Content-Type") != "text/event-stream" {
+		t.Errorf("content-type = %q, want text/event-stream", resp.Header.Get("Content-Type"))
+	}
+
+	// Scanner with a 4MB buffer; SSE frames can be large.
+	sc := bufio.NewScanner(resp.Body)
+	sc.Buffer(make([]byte, 0, 8192), 4<<20)
+
+	// Wait for the initial ": ok" comment to know the handler is ready.
+	waitForLine(t, sc, ":", "initial comment", 2*time.Second)
+
+	// Now append an event and expect it in the stream.
+	store.Append("s1", pipeline.SessionEvent{
+		Direction: pipeline.Inbound,
+		Phase:     pipeline.SessionRequest,
+		A2A:       &pipeline.A2AExtension{Method: "message/stream"},
+	})
+
+	// Expect event/id/data lines, in order, within 2s.
+	sawEvent := scanUntil(t, sc, "event: session-event", 2*time.Second)
+	if !sawEvent {
+		t.Fatal("event: session-event line never arrived")
+	}
+	sawID := scanUntil(t, sc, "id: 1", time.Second)
+	if !sawID {
+		t.Error("id: 1 line never arrived")
+	}
+	sawData := scanUntilPrefix(t, sc, "data: ", time.Second)
+	if sawData == "" {
+		t.Fatal("data: line never arrived")
+	}
+	if !strings.Contains(sawData, `"method":"message/stream"`) {
+		t.Errorf("data line missing expected field: %s", sawData)
+	}
+}
+
+func TestHandleStream_Heartbeat(t *testing.T) {
+	// With heartbeat=25ms, we should see at least one heartbeat comment
+	// within 200ms even with no events appended.
+	ts, _ := newTestServer(t, WithHeartbeatInterval(25*time.Millisecond))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, "GET", ts.URL+"/v1/events", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	sc := bufio.NewScanner(resp.Body)
+	// Consume the initial ": ok", then expect ": heartbeat" within the window.
+	waitForLine(t, sc, ":", "initial", time.Second)
+	got := scanUntilExact(t, sc, ": heartbeat", 500*time.Millisecond)
+	if !got {
+		t.Error("no heartbeat observed within 500ms")
+	}
+}
+
+func TestHandleStream_SessionFilter(t *testing.T) {
+	ts, store := newTestServer(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, "GET", ts.URL+"/v1/events?session=keep", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	sc := bufio.NewScanner(resp.Body)
+	waitForLine(t, sc, ":", "initial", time.Second)
+
+	// Event with a different SessionID — should be filtered out.
+	store.Append("drop", pipeline.SessionEvent{
+		A2A: &pipeline.A2AExtension{SessionID: "drop"},
+	})
+	// Event with matching SessionID — should come through.
+	store.Append("keep", pipeline.SessionEvent{
+		A2A: &pipeline.A2AExtension{SessionID: "keep", Method: "message/stream"},
+	})
+
+	data := scanUntilPrefix(t, sc, "data: ", time.Second)
+	if data == "" {
+		t.Fatal("no data frame received")
+	}
+	if !strings.Contains(data, `"sessionId":"keep"`) {
+		t.Errorf("got wrong session in stream: %s", data)
+	}
+	if strings.Contains(data, `"sessionId":"drop"`) {
+		t.Errorf("unfiltered drop event leaked: %s", data)
+	}
+}
+
+func TestHandleHealthz(t *testing.T) {
+	ts, _ := newTestServer(t)
+	resp, err := http.Get(ts.URL + "/healthz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !bytes.Contains(body, []byte("ok")) {
+		t.Errorf("body = %q, want to contain \"ok\"", body)
+	}
+}
+
+// --- helpers -------------------------------------------------------------
+
+// waitForLine scans until a line equal to want appears or the deadline fires.
+func waitForLine(t *testing.T, sc *bufio.Scanner, want, label string, d time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if !sc.Scan() {
+			t.Fatalf("scanner closed before %s line; err=%v", label, sc.Err())
+		}
+		if sc.Text() == want || strings.HasPrefix(sc.Text(), want) {
+			return
+		}
+	}
+	t.Fatalf("deadline waiting for %s line (%q)", label, want)
+}
+
+// scanUntil returns true if line == want appears before the deadline.
+func scanUntil(t *testing.T, sc *bufio.Scanner, want string, d time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if !sc.Scan() {
+			return false
+		}
+		if sc.Text() == want {
+			return true
+		}
+	}
+	return false
+}
+
+// scanUntilExact returns true if the exact line appears before the deadline.
+func scanUntilExact(t *testing.T, sc *bufio.Scanner, exact string, d time.Duration) bool {
+	return scanUntil(t, sc, exact, d)
+}
+
+// scanUntilPrefix returns the line (once) if it starts with prefix, else "".
+func scanUntilPrefix(t *testing.T, sc *bufio.Scanner, prefix string, d time.Duration) string {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if !sc.Scan() {
+			return ""
+		}
+		if strings.HasPrefix(sc.Text(), prefix) {
+			return sc.Text()
+		}
+	}
+	return ""
+}

--- a/authbridge/cmd/authbridge/listener/extproc/server.go
+++ b/authbridge/cmd/authbridge/listener/extproc/server.go
@@ -158,17 +158,26 @@ func (s *Server) handleInboundBody(stream extprocv3.ExternalProcessor_ProcessSer
 	return allowBodyResponse(), pctx
 }
 
+// inboundSessionID returns the bucket ID for an inbound event. Trusts the
+// client's stated contextId (pctx.Extensions.A2A.SessionID) as authoritative
+// and bootstraps to DefaultSessionID when empty. Does NOT fall back to
+// ActiveSession() — that fallback was a cross-conversation contamination
+// vector: a new conversation's first turn (empty SessionID) would inherit
+// the previous conversation's rekeyed bucket, stranding the current turn's
+// request events in the prior bucket and creating an orphan 1-event session
+// for the response.
+func inboundSessionID(pctx *pipeline.Context) string {
+	if sid := pctx.Extensions.A2A.SessionID; sid != "" {
+		return sid
+	}
+	return session.DefaultSessionID
+}
+
 func (s *Server) recordInboundSession(pctx *pipeline.Context) {
 	if s.Sessions == nil || pctx.Extensions.A2A == nil {
 		return
 	}
-	sid := pctx.Extensions.A2A.SessionID
-	if sid == "" {
-		sid = s.Sessions.ActiveSession()
-	}
-	if sid == "" {
-		sid = session.DefaultSessionID
-	}
+	sid := inboundSessionID(pctx)
 	ev := pipeline.SessionEvent{
 		At:        time.Now(),
 		Direction: pipeline.Inbound,
@@ -187,13 +196,7 @@ func (s *Server) recordInboundResponseSession(pctx *pipeline.Context) {
 	if s.Sessions == nil || pctx.Extensions.A2A == nil {
 		return
 	}
-	sid := pctx.Extensions.A2A.SessionID
-	if sid == "" {
-		sid = s.Sessions.ActiveSession()
-	}
-	if sid == "" {
-		sid = session.DefaultSessionID
-	}
+	sid := inboundSessionID(pctx)
 	ev := pipeline.SessionEvent{
 		At:         time.Now(),
 		Direction:  pipeline.Inbound,

--- a/authbridge/cmd/authbridge/listener/extproc/server_test.go
+++ b/authbridge/cmd/authbridge/listener/extproc/server_test.go
@@ -688,6 +688,40 @@ func TestRecordInboundResponseSession_NoA2A(t *testing.T) {
 	}
 }
 
+// Regression: a fresh inbound request with empty A2A.SessionID must bootstrap
+// to DefaultSessionID, NOT inherit ActiveSession() from a prior conversation.
+// Before the fix this produced cross-conversation contamination — the new
+// conversation's request events landed in the previous conversation's
+// rekeyed bucket, and the response-phase event (which used the new
+// contextId) ended up orphaned in its own 1-event bucket.
+func TestInboundSessionID_DoesNotLeakAcrossConversations(t *testing.T) {
+	store := session.New(5*time.Minute, 100, 0)
+	defer store.Close()
+	// Simulate a prior conversation that finished: rekey "default" to
+	// "prev-ctx". ActiveSession now points at "prev-ctx".
+	store.Append(session.DefaultSessionID, pipeline.SessionEvent{A2A: &pipeline.A2AExtension{}})
+	store.Rekey(session.DefaultSessionID, "prev-ctx")
+	if id := store.ActiveSession(); id != "prev-ctx" {
+		t.Fatalf("precondition: ActiveSession = %q, want prev-ctx", id)
+	}
+
+	s := &Server{Sessions: store}
+
+	// New conversation's first inbound request — empty A2A.SessionID.
+	pctx := &pipeline.Context{
+		Extensions: pipeline.Extensions{A2A: &pipeline.A2AExtension{Method: "message/send"}},
+	}
+	s.recordInboundSession(pctx)
+
+	// Must land in DefaultSessionID, NOT prev-ctx.
+	if v := store.View(session.DefaultSessionID); v == nil || len(v.Events) != 1 {
+		t.Errorf("expected new request under DefaultSessionID, got %v", v)
+	}
+	if v := store.View("prev-ctx"); v == nil || len(v.Events) != 1 {
+		t.Errorf("prev-ctx should be unchanged (1 seed event), got %v", v)
+	}
+}
+
 func TestRecordOutboundResponseSession_MCP(t *testing.T) {
 	store := session.New(5*time.Minute, 100, 0)
 	defer store.Close()

--- a/authbridge/cmd/authbridge/main.go
+++ b/authbridge/cmd/authbridge/main.go
@@ -177,11 +177,16 @@ func main() {
 	statSrv := startStatServer(cfg, handler)
 
 	// Session events API (optional; only when session tracking is on).
+	// The API has no authentication — bind only on in-cluster addresses and
+	// never expose via ingress. Payloads contain raw user messages, LLM
+	// completions, and tool results verbatim. Set session.enabled: false to
+	// disable.
 	var sessionAPISrv *sessionapi.Server
 	if cfg.Listener.SessionAPIAddr != "" && sessions != nil {
 		sessionAPISrv = sessionapi.New(cfg.Listener.SessionAPIAddr, sessions)
 		go func() {
-			slog.Info("session API listening", "addr", cfg.Listener.SessionAPIAddr)
+			slog.Warn("session API listening — UNAUTHENTICATED; contains raw user content; never expose via ingress",
+				"addr", cfg.Listener.SessionAPIAddr)
 			if err := sessionAPISrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 				log.Fatalf("session API: %v", err)
 			}

--- a/authbridge/cmd/authbridge/main.go
+++ b/authbridge/cmd/authbridge/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/pipeline"
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/plugins"
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/session"
+	"github.com/kagenti/kagenti-extensions/authbridge/authlib/sessionapi"
 	"github.com/kagenti/kagenti-extensions/authbridge/cmd/authbridge/listener/extauthz"
 	"github.com/kagenti/kagenti-extensions/authbridge/cmd/authbridge/listener/extproc"
 	"github.com/kagenti/kagenti-extensions/authbridge/cmd/authbridge/listener/forwardproxy"
@@ -175,6 +176,18 @@ func main() {
 
 	statSrv := startStatServer(cfg, handler)
 
+	// Session events API (optional; only when session tracking is on).
+	var sessionAPISrv *sessionapi.Server
+	if cfg.Listener.SessionAPIAddr != "" && sessions != nil {
+		sessionAPISrv = sessionapi.New(cfg.Listener.SessionAPIAddr, sessions)
+		go func() {
+			slog.Info("session API listening", "addr", cfg.Listener.SessionAPIAddr)
+			if err := sessionAPISrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				log.Fatalf("session API: %v", err)
+			}
+		}()
+	}
+
 	slog.Info("authbridge starting", "mode", cfg.Mode, "logLevel", logLevel.Level().String())
 
 	// Resolve credentials in background — doesn't block the listener.
@@ -219,6 +232,9 @@ func main() {
 		srv.Shutdown(shutdownCtx)
 	}
 	statSrv.Shutdown(shutdownCtx)
+	if sessionAPISrv != nil {
+		sessionAPISrv.Shutdown(shutdownCtx)
+	}
 	if sessions != nil {
 		sessions.Close()
 	}


### PR DESCRIPTION
## Summary

Adds an HTTP endpoint that externalizes AuthBridge's in-memory session store so operators can debug the plugin pipeline via `kubectl port-forward` and (in a follow-up PR) drive an interactive TUI.

Three endpoints on a new port (`:9094` by default):
- `GET /v1/sessions` - JSON list of active sessions with summaries
- `GET /v1/sessions/{id}` - JSON snapshot of a single session events
- `GET /v1/events` - SSE stream of new events, optional `?session=` filter, 30-second heartbeat

> **Note:** This PR is **stacked on #370** (response-side parsers + session enrichment). The SSE stream only has rich content to show because of the event schema introduced in that PR. Once #370 merges, I will rebase this onto `main`.

## What changes

**`session.Store`**
- `Subscribe() (*Subscription, func())` registers a consumer that receives every appended event via a buffered channel (cap 64). Non-blocking fan-out in `Append`; slow consumers drop events and increment a per-subscriber counter. `Close()` closes subscriber channels idempotently.
- `ListSessions() []SessionSummary` returns metadata-only summaries (id, createdAt, updatedAt, eventCount, active) for the list endpoint, sorted most-recent-first.

**Serialization (`pipeline/`)**
- `Direction.String()` replaces the local `directionName` helper.
- `SessionEvent.MarshalJSON` emits `direction`/`phase` as strings and `durationMs` instead of raw nanoseconds.
- Every extension struct (`MCPExtension`, `A2AExtension`, `InferenceExtension`, `EventIdentity`, `EventError`, `SessionView`, etc.) gets lower-camel `json` tags + `omitempty` for consistent wire format.

**`sessionapi/` (new package)**
- Mirrors `observe/statserver.go` shape: constructor `New(addr, store, opts...)`, `ListenAndServe`, `Shutdown`. Uses `http.ServeMux` with method-qualified routes.
- SSE handler subscribes on connect, flushes `event:/id:/data:` frames, sends heartbeat comments at the configured interval (`WithHeartbeatInterval` for tests), cancels subscription on client disconnect, logs WARN on accumulated drops.
- `httptest`-driven tests cover empty list, populated list, 404, JSON enum readability, SSE delivery + framing, heartbeat cadence, and `?session=` filtering.

**Wiring**
- `ListenerConfig.SessionAPIAddr string` - new field, defaults to `:9094` via `ApplyPreset` for all three modes.
- `main.go` starts the server when `SessionAPIAddr != ""` AND `sessions != nil`. To disable, set `session.enabled: false`.
- Docs: `authbridge/CLAUDE.md` updated with a Session Events API section; port table now lists `:9093` (stats) and `:9094` (session API); includes `kubectl port-forward` + `curl` examples.

## Trust model

No authentication. Bind only on in-cluster addresses, never behind ingress. Payloads may contain raw user messages, LLM completions, and tool results. Matches the existing stats endpoint trust model.

## Test plan

- [x] Unit tests: `Store.Subscribe` (5 cases), `SessionEvent.MarshalJSON` (2 cases), `Direction.String`, `sessionapi.Server` (8 cases covering each endpoint, SSE framing, heartbeat, filter).
- [x] Race detector clean across the whole module.
- [x] Live end-to-end on the weather-agent demo:
  - `curl http://localhost:9094/v1/sessions` is empty before any query, then lists the active session after.
  - `curl -N http://localhost:9094/v1/events` streamed 23 SSE frames during a "weather in new york" query, covering the full conversation: inbound request with user prompt, MCP handshake x2, tool call with city arg, two LLM calls with full completion text, inbound response with `durationMs=4697` and the rekeyed contextId.
  - `/v1/sessions/{id}` returned 200 with 23 events; `/v1/sessions/does-not-exist` returned 404.

## Out of scope

- Bearer-token auth on the endpoint (tracked for v1.5).
- `abctl` TUI - follow-up PR once this is merged.
- Cluster-wide aggregation across multiple sidecars.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
