### PR TITLE
feat: Capture A2A response summary in session events

### DIFF
--- a/authbridge/authlib/pipeline/extensions.go
+++ b/authbridge/authlib/pipeline/extensions.go
@@ -30,14 +30,22 @@ type MCPError struct {
 	Data    any    `json:"data,omitempty"`
 }
 
-// A2AExtension carries parsed A2A protocol metadata from inbound requests.
+// A2AExtension carries parsed A2A protocol metadata from inbound requests
+// and response summaries for debugging.
 type A2AExtension struct {
+	// Request fields
 	Method    string    `json:"method,omitempty"`
 	RPCID     any       `json:"rpcId,omitempty"`
 	SessionID string    `json:"sessionId,omitempty"`
 	MessageID string    `json:"messageId,omitempty"`
+	TaskID    string    `json:"taskId,omitempty"`
 	Role      string    `json:"role,omitempty"`
 	Parts     []A2APart `json:"parts,omitempty"`
+
+	// Response fields (populated by a2a-parser OnResponse)
+	FinalStatus  string `json:"finalStatus,omitempty"`  // "completed", "failed", "canceled"
+	Artifact     string `json:"artifact,omitempty"`     // final artifact text
+	ErrorMessage string `json:"errorMessage,omitempty"` // failure reason if status is "failed"
 }
 
 // A2APart represents a message part in an A2A request.

--- a/authbridge/authlib/plugins/a2aparser.go
+++ b/authbridge/authlib/plugins/a2aparser.go
@@ -49,6 +49,7 @@ func (p *A2AParser) OnRequest(_ context.Context, pctx *pipeline.Context) pipelin
 	if ext.SessionID == "" {
 		ext.SessionID = rpc.stringParam("sessionId")
 	}
+	ext.TaskID = rpc.stringParam("taskId")
 	if msg := rpc.mapParam("message"); msg != nil {
 		if role, ok := msg["role"].(string); ok {
 			ext.Role = role
@@ -77,10 +78,9 @@ func (p *A2AParser) OnRequest(_ context.Context, pctx *pipeline.Context) pipelin
 	return pipeline.Action{Type: pipeline.Continue}
 }
 
-// OnResponse extracts the server-assigned session/context ID from the response body
-// and stores it on the A2A extension. This lets downstream plugins correlate the
-// freshly-assigned session for the next turn of the conversation, since clients
-// typically don't include a contextId on the first message.
+// OnResponse extracts the server-assigned session/context ID and response summary
+// from the response body. The summary includes final status, artifact text, and
+// error message — enabling debugging of agent behavior without reading raw SSE.
 //
 // Handles both JSON-RPC responses (message/send) and SSE event streams (message/stream).
 func (p *A2AParser) OnResponse(_ context.Context, pctx *pipeline.Context) pipeline.Action {
@@ -88,16 +88,153 @@ func (p *A2AParser) OnResponse(_ context.Context, pctx *pipeline.Context) pipeli
 		return pipeline.Action{Type: pipeline.Continue}
 	}
 
-	sid := extractSessionID(pctx.ResponseBody)
-	if sid == "" {
-		slog.Debug("a2a-parser: no sessionId or contextId found in response")
-		return pipeline.Action{Type: pipeline.Continue}
+	// Extract session ID (existing behavior)
+	if sid := extractSessionID(pctx.ResponseBody); sid != "" {
+		pctx.Extensions.A2A.SessionID = sid
 	}
 
-	pctx.Extensions.A2A.SessionID = sid
-	slog.Debug("a2a-parser: response sessionId", "sessionId", sid)
-	slog.Debug("a2a-parser: response body", "body", truncate(string(pctx.ResponseBody), debugBodyMax))
+	// Extract response summary (final status + artifact + error)
+	extractResponseSummary(pctx.ResponseBody, pctx.Extensions.A2A)
+
+	slog.Debug("a2a-parser: response parsed",
+		"sessionId", pctx.Extensions.A2A.SessionID,
+		"finalStatus", pctx.Extensions.A2A.FinalStatus,
+		"artifactLen", len(pctx.Extensions.A2A.Artifact),
+		"error", pctx.Extensions.A2A.ErrorMessage,
+	)
 	return pipeline.Action{Type: pipeline.Continue}
+}
+
+// extractResponseSummary parses the response body for final status, artifact text,
+// and error message. Supports both SSE streams (message/stream) and plain JSON-RPC
+// responses (message/send).
+func extractResponseSummary(body []byte, ext *pipeline.A2AExtension) {
+	// Try plain JSON-RPC first (message/send response)
+	if extractSendResponse(body, ext) {
+		return
+	}
+	// SSE stream (message/stream): scan data: lines for status and artifact events
+	extractStreamResponse(body, ext)
+}
+
+// extractSendResponse handles message/send responses (single JSON-RPC result).
+func extractSendResponse(body []byte, ext *pipeline.A2AExtension) bool {
+	var resp struct {
+		Result struct {
+			Status struct {
+				State   string `json:"state"`
+				Message struct {
+					Parts []struct {
+						Type string `json:"type"`
+						Text string `json:"text"`
+					} `json:"parts"`
+				} `json:"message"`
+			} `json:"status"`
+			Artifacts []struct {
+				Parts []struct {
+					Type string `json:"type"`
+					Text string `json:"text"`
+				} `json:"parts"`
+			} `json:"artifacts"`
+			TaskID string `json:"taskId"`
+		} `json:"result"`
+	}
+	if json.Unmarshal(body, &resp) != nil || resp.Result.Status.State == "" {
+		return false
+	}
+
+	ext.FinalStatus = resp.Result.Status.State
+	if ext.TaskID == "" && resp.Result.TaskID != "" {
+		ext.TaskID = resp.Result.TaskID
+	}
+
+	// Extract artifact text
+	for _, artifact := range resp.Result.Artifacts {
+		for _, part := range artifact.Parts {
+			if part.Type == "text" && part.Text != "" {
+				ext.Artifact = part.Text
+			}
+		}
+	}
+
+	// Extract error message from status message on failure
+	if resp.Result.Status.State == "failed" {
+		for _, part := range resp.Result.Status.Message.Parts {
+			if part.Type == "text" && part.Text != "" {
+				ext.ErrorMessage = part.Text
+				break
+			}
+		}
+	}
+	return true
+}
+
+// extractStreamResponse handles message/stream SSE responses.
+func extractStreamResponse(body []byte, ext *pipeline.A2AExtension) {
+	for _, line := range bytes.Split(body, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if !bytes.HasPrefix(line, []byte("data:")) {
+			continue
+		}
+		data := bytes.TrimSpace(bytes.TrimPrefix(line, []byte("data:")))
+		if len(data) == 0 {
+			continue
+		}
+
+		var event struct {
+			Result struct {
+				Kind   string `json:"kind"`
+				Final  bool   `json:"final"`
+				TaskID string `json:"taskId"`
+				Status struct {
+					State   string `json:"state"`
+					Message struct {
+						Parts []struct {
+							Type string `json:"type"`
+							Text string `json:"text"`
+						} `json:"parts"`
+					} `json:"message"`
+				} `json:"status"`
+				Artifact struct {
+					Parts []struct {
+						Type string `json:"type"`
+						Text string `json:"text"`
+					} `json:"parts"`
+				} `json:"artifact"`
+			} `json:"result"`
+		}
+		if json.Unmarshal(data, &event) != nil {
+			continue
+		}
+
+		// Capture taskId from any event
+		if ext.TaskID == "" && event.Result.TaskID != "" {
+			ext.TaskID = event.Result.TaskID
+		}
+
+		switch event.Result.Kind {
+		case "status-update":
+			if event.Result.Final {
+				ext.FinalStatus = event.Result.Status.State
+				// Extract error message on failure
+				if event.Result.Status.State == "failed" {
+					for _, part := range event.Result.Status.Message.Parts {
+						if part.Type == "text" && part.Text != "" {
+							ext.ErrorMessage = part.Text
+							break
+						}
+					}
+				}
+			}
+		case "artifact":
+			// Keep the last artifact (final answer)
+			for _, part := range event.Result.Artifact.Parts {
+				if part.Type == "text" && part.Text != "" {
+					ext.Artifact = part.Text
+				}
+			}
+		}
+	}
 }
 
 // extractSessionID finds a contextId (preferred) or sessionId in the response.


### PR DESCRIPTION
## Summary

Session events for A2A responses now include the agent's actual answer, final status, and error message — enabling debugging of agent behavior without reading raw SSE streams.

## Changes

- `A2AExtension` gains 4 new fields: `TaskID`, `FinalStatus`, `Artifact`, `ErrorMessage`
- `a2a-parser.OnRequest` extracts `taskId` from request params
- `a2a-parser.OnResponse` parses both SSE streams (`message/stream`) and plain JSON-RPC (`message/send`) to extract final status, artifact text, and error message

## Before / After

Before:
```json
{"a2a":{"method":"message/stream","rpcId":"...","sessionId":"..."}, "statusCode":200, "durationMs":4001}
```

After:
```json
{"a2a":{"method":"message/stream","rpcId":"...","sessionId":"...","taskId":"task-1","finalStatus":"completed","artifact":"The weather in New York is sunny, 72 F"}, "statusCode":200, "durationMs":4001}
```

## Test plan

- [x] All existing A2A parser tests pass
- [x] Full binary builds
- [ ] E2E: deploy weather agent, send query, verify session event shows artifact

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>