### PR TITLE
feat(abctl): Identity banner + token columns + plugin state helpers

### DIFF
--- a/authbridge/authlib/pipeline/extensions.go
+++ b/authbridge/authlib/pipeline/extensions.go
@@ -4,6 +4,16 @@ import "time"
 
 // Extensions holds typed extension slots for plugin-to-plugin communication.
 // Each slot is populated by a specific plugin and consumed by downstream plugins.
+//
+// The named slots (MCP, A2A, Security, Delegation, Inference) are reserved
+// for telemetry-worthy extensions — data that flows into SessionEvent, is
+// serialized on the wire API, and has a published schema that unrelated
+// plugins can rely on. Adding a new named slot is a core-library change.
+//
+// For plugin-private, per-request state that doesn't need a published
+// schema, use the generic GetState / SetState helpers defined below; they
+// store values in Custom keyed by plugin name, letting a new plugin land
+// without any authlib modification.
 type Extensions struct {
 	MCP        *MCPExtension
 	A2A        *A2AExtension
@@ -11,6 +21,38 @@ type Extensions struct {
 	Delegation *DelegationExtension
 	Inference  *InferenceExtension
 	Custom     map[string]any
+}
+
+// SetState stashes a typed value on pctx under key. Intended for plugin-
+// private per-request state — e.g., a rate-limiter remembering how many
+// tokens were available when OnRequest saw the call, for OnResponse to
+// consult. The generic type parameter is documentary: it forces callers
+// to pass *T rather than an unrelated interface, which pairs with the
+// symmetric type-assert in GetState.
+//
+// Convention: `key` should be the plugin's Name() so keys from unrelated
+// plugins don't collide. SetState is not safe for concurrent use — pctx
+// is single-threaded per request in the pipeline.
+func SetState[T any](pctx *Context, key string, v *T) {
+	if pctx.Extensions.Custom == nil {
+		pctx.Extensions.Custom = map[string]any{}
+	}
+	pctx.Extensions.Custom[key] = v
+}
+
+// GetState retrieves a typed value previously stored via SetState. Returns
+// nil when the key is absent or when the stored value is not a *T —
+// safe-fails rather than panicking so a mid-pipeline type migration
+// (plugin version skew) degrades instead of crashing the handler.
+func GetState[T any](pctx *Context, key string) *T {
+	if pctx.Extensions.Custom == nil {
+		return nil
+	}
+	v, ok := pctx.Extensions.Custom[key].(*T)
+	if !ok {
+		return nil
+	}
+	return v
 }
 
 // MCPExtension carries parsed MCP JSON-RPC metadata.

--- a/authbridge/authlib/pipeline/extensions_test.go
+++ b/authbridge/authlib/pipeline/extensions_test.go
@@ -1,0 +1,92 @@
+package pipeline
+
+import (
+	"testing"
+)
+
+// Locking in the SetState / GetState contract so a future refactor of
+// Extensions.Custom doesn't break plugins that have been ported to the
+// generic helpers. These helpers are the canonical way to attach plugin-
+// private per-request state without extending the core Extensions struct.
+func TestSetGetState_RoundTrip(t *testing.T) {
+	type myState struct {
+		TokensAtStart int
+		Decision      string
+	}
+
+	pctx := &Context{}
+
+	// Get on a fresh pctx returns nil, no panic on nil map.
+	if got := GetState[myState](pctx, "rate-limiter"); got != nil {
+		t.Errorf("GetState on empty pctx = %+v, want nil", got)
+	}
+
+	// Set then get returns the same pointer.
+	orig := &myState{TokensAtStart: 100, Decision: "allow"}
+	SetState(pctx, "rate-limiter", orig)
+	got := GetState[myState](pctx, "rate-limiter")
+	if got == nil {
+		t.Fatal("GetState returned nil after SetState")
+	}
+	if got != orig {
+		t.Error("GetState returned a different pointer than stored")
+	}
+	if got.TokensAtStart != 100 || got.Decision != "allow" {
+		t.Errorf("GetState value = %+v, want {100 allow}", got)
+	}
+}
+
+// Mutations through the retrieved pointer must be visible on subsequent
+// GetState calls — plugins rely on this to update state between
+// OnRequest and OnResponse.
+func TestSetGetState_MutationVisible(t *testing.T) {
+	type cnt struct{ N int }
+	pctx := &Context{}
+	SetState(pctx, "k", &cnt{N: 1})
+	got := GetState[cnt](pctx, "k")
+	got.N = 42
+	again := GetState[cnt](pctx, "k")
+	if again.N != 42 {
+		t.Errorf("after mutation, got.N = %d, want 42", again.N)
+	}
+}
+
+// A GetState with the wrong type parameter must not panic; it should
+// return nil so a buggy consumer degrades rather than crashing the pipeline.
+func TestGetState_WrongType(t *testing.T) {
+	type a struct{ X int }
+	type b struct{ Y string }
+	pctx := &Context{}
+	SetState(pctx, "k", &a{X: 1})
+	if got := GetState[b](pctx, "k"); got != nil {
+		t.Errorf("wrong-type GetState = %+v, want nil", got)
+	}
+}
+
+// Absent keys return nil even when the map has other data.
+func TestGetState_MissingKey(t *testing.T) {
+	type a struct{ X int }
+	pctx := &Context{}
+	SetState(pctx, "k1", &a{X: 1})
+	if got := GetState[a](pctx, "k2"); got != nil {
+		t.Errorf("missing key returned %+v, want nil", got)
+	}
+}
+
+// Two plugins using distinct keys must see only their own state. This is
+// the key property that lets arbitrary plugins land without touching the
+// Extensions struct — the Custom map is partitioned by plugin name.
+func TestSetGetState_MultiplePlugins(t *testing.T) {
+	type rlState struct{ Tokens int }
+	type auditState struct{ Hits int }
+	pctx := &Context{}
+	SetState(pctx, "rate-limiter", &rlState{Tokens: 50})
+	SetState(pctx, "audit", &auditState{Hits: 3})
+
+	if rl := GetState[rlState](pctx, "rate-limiter"); rl == nil || rl.Tokens != 50 {
+		t.Errorf("rate-limiter state = %+v", rl)
+	}
+	if au := GetState[auditState](pctx, "audit"); au == nil || au.Hits != 3 {
+		t.Errorf("audit state = %+v", au)
+	}
+}

--- a/authbridge/authlib/session/store.go
+++ b/authbridge/authlib/session/store.go
@@ -227,11 +227,12 @@ func (s *Store) View(sessionID string) *pipeline.SessionView {
 // SessionSummary is a metadata-only view of a session, suitable for list
 // endpoints that shouldn't copy the full event backlog.
 type SessionSummary struct {
-	ID         string    `json:"id"`
-	CreatedAt  time.Time `json:"createdAt"`
-	UpdatedAt  time.Time `json:"updatedAt"`
-	EventCount int       `json:"eventCount"`
-	Active     bool      `json:"active"` // true if this is the most recently updated session
+	ID          string    `json:"id"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+	EventCount  int       `json:"eventCount"`
+	TotalTokens int       `json:"totalTokens,omitempty"` // sum of Inference.TotalTokens across response events
+	Active      bool      `json:"active"`                // true if this is the most recently updated session
 }
 
 // ListSessions returns summaries for every non-expired session. Order is
@@ -247,11 +248,12 @@ func (s *Store) ListSessions() []SessionSummary {
 			continue
 		}
 		out = append(out, SessionSummary{
-			ID:         id,
-			CreatedAt:  sess.CreatedAt,
-			UpdatedAt:  sess.UpdatedAt,
-			EventCount: len(sess.Events),
-			Active:     id == s.activeID,
+			ID:          id,
+			CreatedAt:   sess.CreatedAt,
+			UpdatedAt:   sess.UpdatedAt,
+			EventCount:  len(sess.Events),
+			TotalTokens: sumTokens(sess.Events),
+			Active:      id == s.activeID,
 		})
 	}
 	// Most recently updated first.
@@ -259,6 +261,23 @@ func (s *Store) ListSessions() []SessionSummary {
 		return out[i].UpdatedAt.After(out[j].UpdatedAt)
 	})
 	return out
+}
+
+// sumTokens aggregates Inference.TotalTokens across all response events
+// in a session. Used by ListSessions so the summary endpoint can report a
+// per-session cost without the caller loading every event first.
+func sumTokens(events []pipeline.SessionEvent) int {
+	var total int
+	for i := range events {
+		if events[i].Phase != pipeline.SessionResponse {
+			continue
+		}
+		if events[i].Inference == nil {
+			continue
+		}
+		total += events[i].Inference.TotalTokens
+	}
+	return total
 }
 
 // ActiveSession returns the most recently updated session ID.

--- a/authbridge/authlib/session/store_test.go
+++ b/authbridge/authlib/session/store_test.go
@@ -590,6 +590,81 @@ func TestStore_Rekey_RewritesExistingEventSessionIDs(t *testing.T) {
 	}
 }
 
+// TestSumTokens verifies that SessionSummary.TotalTokens aggregates only
+// over inference response events. Request events, non-inference responses,
+// and events without Inference populated must not contribute.
+func TestSumTokens(t *testing.T) {
+	evs := []pipeline.SessionEvent{
+		// Inference response — counted.
+		{
+			Phase:     pipeline.SessionResponse,
+			Inference: &pipeline.InferenceExtension{TotalTokens: 100},
+		},
+		// Inference request (has tokens field set, unusual, but must be skipped
+		// because request-phase token counts aren't usage).
+		{
+			Phase:     pipeline.SessionRequest,
+			Inference: &pipeline.InferenceExtension{TotalTokens: 99},
+		},
+		// MCP response — no inference, skipped.
+		{
+			Phase: pipeline.SessionResponse,
+			MCP:   &pipeline.MCPExtension{Method: "tools/call"},
+		},
+		// Inference response with zero tokens — contributes zero.
+		{
+			Phase:     pipeline.SessionResponse,
+			Inference: &pipeline.InferenceExtension{TotalTokens: 0},
+		},
+		// Second inference response — counted.
+		{
+			Phase:     pipeline.SessionResponse,
+			Inference: &pipeline.InferenceExtension{TotalTokens: 250},
+		},
+	}
+	got := sumTokens(evs)
+	if got != 350 {
+		t.Errorf("sumTokens = %d, want 350", got)
+	}
+	if sumTokens(nil) != 0 {
+		t.Error("sumTokens(nil) should be 0")
+	}
+	if sumTokens([]pipeline.SessionEvent{}) != 0 {
+		t.Error("sumTokens([]) should be 0")
+	}
+}
+
+// TestListSessions_TotalTokens verifies the aggregate lands on the summary.
+func TestListSessions_TotalTokens(t *testing.T) {
+	s := New(5*time.Minute, 100, 0)
+	s.Append("sess-a", pipeline.SessionEvent{
+		Phase:     pipeline.SessionResponse,
+		Inference: &pipeline.InferenceExtension{TotalTokens: 42},
+	})
+	s.Append("sess-a", pipeline.SessionEvent{
+		Phase: pipeline.SessionResponse,
+		MCP:   &pipeline.MCPExtension{Method: "tools/call"},
+	})
+	s.Append("sess-b", pipeline.SessionEvent{
+		Phase:     pipeline.SessionResponse,
+		Inference: &pipeline.InferenceExtension{TotalTokens: 17},
+	})
+	sums := s.ListSessions()
+	if len(sums) != 2 {
+		t.Fatalf("expected 2 summaries, got %d", len(sums))
+	}
+	byID := map[string]int{}
+	for _, sum := range sums {
+		byID[sum.ID] = sum.TotalTokens
+	}
+	if byID["sess-a"] != 42 {
+		t.Errorf("sess-a TotalTokens = %d, want 42", byID["sess-a"])
+	}
+	if byID["sess-b"] != 17 {
+		t.Errorf("sess-b TotalTokens = %d, want 17", byID["sess-b"])
+	}
+}
+
 func waitEvent(t *testing.T, ch <-chan pipeline.SessionEvent, d time.Duration) pipeline.SessionEvent {
 	t.Helper()
 	select {

--- a/authbridge/cmd/abctl/tui/app.go
+++ b/authbridge/cmd/abctl/tui/app.go
@@ -109,6 +109,10 @@ type model struct {
 	flash         string
 	flashUntil    time.Time
 	width, height int
+	// bodyHeight is the inner height available to panes (terminal height
+	// minus title + footer). Cached by layout() so rebuildEventsTable can
+	// size the events table after accounting for the IDENTITY banner.
+	bodyHeight int
 
 	// Panel components.
 	sessionsTbl  table.Model
@@ -402,6 +406,9 @@ func (m *model) View() string {
 	case paneEvents:
 		title = fmt.Sprintf("abctl · %s", trunc(m.selectedSess, 36))
 		body = m.eventsTbl.View()
+		if banner := identityBanner(m.events[m.selectedSess]); banner != "" {
+			body = banner + "\n" + body
+		}
 	case paneDetail:
 		title = fmt.Sprintf("abctl · %s · event", trunc(m.selectedSess, 24))
 		body = m.detailVp.View()

--- a/authbridge/cmd/abctl/tui/detail_pane.go
+++ b/authbridge/cmd/abctl/tui/detail_pane.go
@@ -62,6 +62,10 @@ func filterForDetail(data []byte, phase pipeline.SessionPhase) []byte {
 	if a2a, ok := m["a2a"].(map[string]any); ok {
 		m["a2a"] = filterFields(a2a, a2aKeep)
 	}
+	// Identity is summarized at the session level (events pane banner).
+	// Drop it from per-event detail rows to reduce repetition — the full
+	// value is still in the wire JSON that yank writes out.
+	delete(m, "identity")
 	out, err := json.Marshal(m)
 	if err != nil {
 		return data

--- a/authbridge/cmd/abctl/tui/events_pane.go
+++ b/authbridge/cmd/abctl/tui/events_pane.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/bubbles/table"
+	"github.com/charmbracelet/lipgloss"
 
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/pipeline"
 )
@@ -22,6 +23,7 @@ func newEventsTable() table.Model {
 			{Title: "METHOD", Width: 22},
 			{Title: "STATUS", Width: 7},
 			{Title: "DURATION", Width: 10},
+			{Title: "TOKENS", Width: 8},
 			{Title: "HOST", Width: 20},
 		}),
 		table.WithFocused(true),
@@ -31,9 +33,25 @@ func newEventsTable() table.Model {
 }
 
 // rebuildEventsTable populates the events table from the cache for the
-// currently selected session, applying filter + preserving cursor.
+// currently selected session, applying filter + preserving cursor. Also
+// resizes the table height to account for the IDENTITY banner — when
+// the session has inbound identity, subtract the banner's rendered
+// height so it doesn't push rows off-screen; otherwise claim the full
+// body height.
 func (m *model) rebuildEventsTable() {
 	events := m.events[m.selectedSess]
+
+	if m.bodyHeight > 0 {
+		h := m.bodyHeight
+		if len(distinctInboundIdentities(events)) > 0 {
+			h -= identityBannerHeight
+		}
+		if h < 3 {
+			h = 3
+		}
+		m.eventsTbl.SetHeight(h)
+	}
+
 	prevRow := m.eventsTbl.Cursor()
 	wasAtEnd := prevRow >= len(m.eventsTbl.Rows())-1
 
@@ -62,6 +80,7 @@ func (m *model) rebuildEventsTable() {
 			eventMethod(e),
 			statusCell(e),
 			durationCell(e),
+			tokensCell(e),
 			truncStr(e.Host, 20),
 		})
 	}
@@ -149,6 +168,17 @@ func statusCell(e pipeline.SessionEvent) string {
 		return ""
 	}
 	return fmt.Sprintf("%d", e.StatusCode)
+}
+
+// tokensCell shows the total token count for inference response rows so
+// operators can spot expensive calls while scrolling. Blank for every
+// other event type (a2a, mcp, inference *request*). Uses the same
+// thousands-separator formatter as the sessions-pane totals.
+func tokensCell(e pipeline.SessionEvent) string {
+	if e.Phase != pipeline.SessionResponse || e.Inference == nil || e.Inference.TotalTokens == 0 {
+		return ""
+	}
+	return formatCount(e.Inference.TotalTokens)
 }
 
 func durationCell(e pipeline.SessionEvent) string {
@@ -243,3 +273,93 @@ func pairRequestsAndResponses(events []pipeline.SessionEvent) map[int]int {
 	}
 	return pairs
 }
+
+// identityBannerStyle renders the small bordered box above the events
+// table. Rounded border matches the outer frame; muted color keeps the
+// banner as context rather than competing with the event rows.
+var identityBannerStyle = lipgloss.NewStyle().
+	Border(lipgloss.RoundedBorder()).
+	BorderForeground(lipgloss.AdaptiveColor{Light: "#94A3B8", Dark: "#475569"}).
+	Padding(0, 1)
+
+// identityBannerHeight is the rendered height of the banner — four lines
+// of content plus two border lines. layout() subtracts this from the
+// events-table height so the banner doesn't push rows off-screen.
+const identityBannerHeight = 6
+
+// identityBanner renders a compact "IDENTITY" box summarizing the caller
+// of this session's inbound events. If callers diverge across the
+// session, it reports the count so the operator knows to check detail
+// rows. Returns an empty string when no inbound identity is present
+// (e.g. outbound-only buckets).
+func identityBanner(events []pipeline.SessionEvent) string {
+	idents := distinctInboundIdentities(events)
+	if len(idents) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString(styleTitle.Render("IDENTITY"))
+	b.WriteByte('\n')
+
+	if len(idents) == 1 {
+		id := idents[0]
+		b.WriteString(fmt.Sprintf("subject  %s\n", nonEmpty(id.Subject, "—")))
+		b.WriteString(fmt.Sprintf("client   %s\n", nonEmpty(id.ClientID, "—")))
+		b.WriteString(fmt.Sprintf("scopes   %s", nonEmpty(truncateScopes(id.Scopes, 3), "—")))
+	} else {
+		// Multiple distinct callers — surface the count; detail rows
+		// carry the full identity for drill-down.
+		subjects := make([]string, 0, len(idents))
+		for _, id := range idents {
+			subjects = append(subjects, nonEmpty(id.Subject, "—"))
+		}
+		b.WriteString(fmt.Sprintf("subjects  %d distinct: %s\n", len(idents), strings.Join(subjects, ", ")))
+		b.WriteString("client    (see individual events)\n")
+		b.WriteString("scopes    (see individual events)")
+	}
+	return identityBannerStyle.Render(b.String())
+}
+
+// identityKey is the comparable shape used to dedupe identities in the
+// banner. Using a struct avoids string concatenation (and the theoretical
+// "|" collision) — subject+clientID are the two fields that define a
+// unique caller; scopes can legitimately vary turn-to-turn.
+type identityKey struct {
+	subject  string
+	clientID string
+}
+
+// distinctInboundIdentities returns the unique EventIdentity values seen on
+// inbound events, in first-seen order.
+func distinctInboundIdentities(events []pipeline.SessionEvent) []*pipeline.EventIdentity {
+	var out []*pipeline.EventIdentity
+	seen := map[identityKey]bool{}
+	for i := range events {
+		e := &events[i]
+		if e.Direction != pipeline.Inbound || e.Identity == nil {
+			continue
+		}
+		k := identityKey{subject: e.Identity.Subject, clientID: e.Identity.ClientID}
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		out = append(out, e.Identity)
+	}
+	return out
+}
+
+// truncateScopes joins the first n scopes with commas and appends a
+// "+N more" suffix if the list was longer. Keeps the identity banner
+// from overflowing the terminal when a caller has many scopes.
+func truncateScopes(scopes []string, n int) string {
+	if len(scopes) == 0 {
+		return ""
+	}
+	if len(scopes) <= n {
+		return strings.Join(scopes, ", ")
+	}
+	return strings.Join(scopes[:n], ", ") + fmt.Sprintf(" +%d more", len(scopes)-n)
+}
+

--- a/authbridge/cmd/abctl/tui/keys.go
+++ b/authbridge/cmd/abctl/tui/keys.go
@@ -238,7 +238,12 @@ func (m *model) layout() {
 	}
 
 	m.sessionsTbl.SetHeight(bodyH)
-	m.eventsTbl.SetHeight(bodyH)
+	m.bodyHeight = bodyH
+	// The events table's height depends on whether the IDENTITY banner
+	// is rendered for the selected session. rebuildEventsTable() applies
+	// the banner-aware adjustment; call it so the size is correct after
+	// a window resize too.
+	m.rebuildEventsTable()
 	m.pipelineTbl.SetHeight(bodyH)
 	m.detailVp.Width = m.width
 	m.detailVp.Height = bodyH

--- a/authbridge/cmd/abctl/tui/sessions_pane.go
+++ b/authbridge/cmd/abctl/tui/sessions_pane.go
@@ -6,9 +6,11 @@ import (
 	"time"
 
 	"github.com/charmbracelet/bubbles/table"
+
+	"github.com/kagenti/kagenti-extensions/authbridge/authlib/pipeline"
 )
 
-// newSessionsTable builds an empty sessions table with the four columns.
+// newSessionsTable builds an empty sessions table.
 // Widths are refined later by layout() based on terminal width.
 func newSessionsTable() table.Model {
 	t := table.New(
@@ -16,6 +18,7 @@ func newSessionsTable() table.Model {
 			{Title: "ID", Width: 40},
 			{Title: "UPDATED", Width: 14},
 			{Title: "EVENTS", Width: 8},
+			{Title: "TOKENS", Width: 8},
 			{Title: "ACTIVE", Width: 8},
 		}),
 		table.WithFocused(true),
@@ -46,6 +49,7 @@ func (m *model) rebuildSessionsTable() {
 			s.ID,
 			relTime(now, s.UpdatedAt),
 			fmt.Sprintf("%d", s.EventCount),
+			sessionTokens(s.TotalTokens, m.events[s.ID]),
 			active,
 		})
 	}
@@ -83,6 +87,32 @@ func relTime(now, t time.Time) string {
 	default:
 		return t.Format("Jan 2 15:04")
 	}
+}
+
+// sessionTokens reports the total tokens for a session. Prefers the
+// server-computed count from SessionSummary (authoritative, covers the
+// full event backlog even before we've streamed anything for this
+// session). Falls back to a client-side sum over the cached events when
+// the server returned zero (older authbridge server without token
+// aggregation). Returns "—" when neither source has data.
+func sessionTokens(serverTotal int, cached []pipeline.SessionEvent) string {
+	if serverTotal > 0 {
+		return formatCount(serverTotal)
+	}
+	var total int
+	for i := range cached {
+		if cached[i].Phase != pipeline.SessionResponse {
+			continue
+		}
+		if cached[i].Inference == nil {
+			continue
+		}
+		total += cached[i].Inference.TotalTokens
+	}
+	if total == 0 {
+		return "—"
+	}
+	return formatCount(total)
 }
 
 // selectedSessionID returns the cursor row's session ID, or "".

--- a/authbridge/cmd/abctl/tui/sessions_pane.go
+++ b/authbridge/cmd/abctl/tui/sessions_pane.go
@@ -18,7 +18,7 @@ func newSessionsTable() table.Model {
 			{Title: "ID", Width: 40},
 			{Title: "UPDATED", Width: 14},
 			{Title: "EVENTS", Width: 8},
-			{Title: "TOKENS", Width: 8},
+			{Title: "TOKENS", Width: 10},
 			{Title: "ACTIVE", Width: 8},
 		}),
 		table.WithFocused(true),

--- a/authbridge/cmd/abctl/tui/util.go
+++ b/authbridge/cmd/abctl/tui/util.go
@@ -1,0 +1,38 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+)
+
+// formatCount renders an integer with thousands separators so large
+// numbers stay readable in narrow table columns. Handles negatives by
+// preserving the sign; zero and single-triplet values are passed through
+// unchanged.
+func formatCount(n int) string {
+	s := fmt.Sprintf("%d", n)
+	if len(s) <= 3 {
+		return s
+	}
+	var b strings.Builder
+	pre := len(s) % 3
+	if pre > 0 {
+		b.WriteString(s[:pre])
+	}
+	for i := pre; i < len(s); i += 3 {
+		if b.Len() > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(s[i : i+3])
+	}
+	return b.String()
+}
+
+// nonEmpty returns s if non-empty, otherwise fallback. Used by label
+// renderers where we want an em-dash sentinel in place of empty strings.
+func nonEmpty(s, fallback string) string {
+	if s == "" {
+		return fallback
+	}
+	return s
+}

--- a/authbridge/cmd/abctl/tui/util.go
+++ b/authbridge/cmd/abctl/tui/util.go
@@ -6,13 +6,21 @@ import (
 )
 
 // formatCount renders an integer with thousands separators so large
-// numbers stay readable in narrow table columns. Handles negatives by
-// preserving the sign; zero and single-triplet values are passed through
-// unchanged.
+// numbers stay readable in narrow table columns. The sign is preserved
+// for negatives (e.g. -1234 -> "-1,234"); zero and single-triplet values
+// are passed through unchanged.
 func formatCount(n int) string {
 	s := fmt.Sprintf("%d", n)
+	// Split the sign off before grouping so a leading "-" doesn't get
+	// counted as a digit in the triplet math (otherwise len("-abc") % 3
+	// == 1 produced a bogus "-,abc" prefix for 3/6/9-digit negatives).
+	sign := ""
+	if len(s) > 0 && s[0] == '-' {
+		sign = "-"
+		s = s[1:]
+	}
 	if len(s) <= 3 {
-		return s
+		return sign + s
 	}
 	var b strings.Builder
 	pre := len(s) % 3
@@ -25,7 +33,7 @@ func formatCount(n int) string {
 		}
 		b.WriteString(s[i : i+3])
 	}
-	return b.String()
+	return sign + b.String()
 }
 
 // nonEmpty returns s if non-empty, otherwise fallback. Used by label

--- a/authbridge/cmd/abctl/tui/util_test.go
+++ b/authbridge/cmd/abctl/tui/util_test.go
@@ -1,0 +1,33 @@
+package tui
+
+import "testing"
+
+// formatCount's previous implementation mishandled 3/6/9-digit negatives
+// because it counted the leading '-' as a digit when computing the first
+// triplet — e.g. formatCount(-100) produced "-,100". This table covers the
+// previously-broken bands along with the paths that already worked.
+func TestFormatCount(t *testing.T) {
+	cases := []struct {
+		in   int
+		want string
+	}{
+		{0, "0"},
+		{5, "5"},
+		{100, "100"},
+		{1000, "1,000"},
+		{1234567, "1,234,567"},
+		{10000000, "10,000,000"},
+		{-5, "-5"},
+		{-100, "-100"},
+		{-999, "-999"},
+		{-1000, "-1,000"},
+		{-12345, "-12,345"},
+		{-123456, "-123,456"},
+		{-1234567, "-1,234,567"},
+	}
+	for _, c := range cases {
+		if got := formatCount(c.in); got != c.want {
+			t.Errorf("formatCount(%d) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Three cohesive additions to the session-observability layer on top of the merged `abctl` TUI (#372).

### 1. IDENTITY banner on the events pane
Caller identity (`subject` / `client` / `scopes`) now shows once at the session level instead of repeating on every event row. Scopes truncated to 3 entries with `+N more` so long scope lists don't overflow. Banner only renders when inbound identity is present; table height accounts for it only when it renders.

### 2. `TOKENS` column on sessions + events panes
- **Server**: new `TotalTokens` field on `SessionSummary`, aggregated in `ListSessions` via `sumTokens()`.
- **Sessions pane**: prefers the server total; falls back to a client-side sum over cached events for older-server compat.
- **Events pane**: shows per-call `TotalTokens` only on inference response rows.
- Shared `formatCount` helper for thousands-separator display (`1,203`).

### 3. `pipeline.GetState[T]` / `pipeline.SetState[T]` — plugin-private per-request state
```go
type rlState struct { TokensAtStart int }

// In OnRequest:
pipeline.SetState(pctx, "rate-limiter", &rlState{TokensAtStart: 100})

// In OnResponse:
s := pipeline.GetState[rlState](pctx, "rate-limiter")
```
Lets new plugins stash typed state on `pctx.Extensions.Custom` keyed by plugin name, without extending the core `Extensions` struct for every new plugin. Named typed slots (MCP, A2A, Inference, …) stay reserved for **telemetry-worthy** extensions that flow onto the wire API; `GetState/SetState` covers everything internal to a single plugin.

## Also

- Drop `identity` from per-event detail render (banner supersedes it); yank still writes the full wire JSON.
- Use struct key `{subject, clientID}` for identity dedup instead of `"|"`-concatenation.
- Unit tests: `sumTokens`, `ListSessions.TotalTokens`, `SetState`/`GetState` round-trip, mutation visibility, wrong-type degradation, missing key, multi-plugin isolation.

## Test plan

- [x] `go test ./...` in `authlib` and `cmd/abctl` — all green.
- [x] Manual: send messages via the UI, confirm `TOKENS` column on sessions pane populates immediately (no drill-through needed).
- [x] Manual: drill into a session, confirm IDENTITY banner renders above events table.
- [x] Manual: events table row count preserved when banner renders (no cropping).
- [x] `yank` still writes the full unfiltered event JSON to `/tmp/abctl-event-*.json`.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
