### PR TITLE
fix(authbridge): robust credential provisioning with continuous polling

### DIFF
--- a/authbridge/authlib/auth/auth.go
+++ b/authbridge/authlib/auth/auth.go
@@ -259,6 +259,12 @@ func (a *Auth) UpdateIdentity(id IdentityConfig, clientAuth exchange.ClientAuth)
 	a.log.Info("identity updated", "client_id", id.ClientID)
 }
 
+// Ready returns true if the identity has been loaded (audience is non-empty).
+func (a *Auth) Ready() bool {
+	id := a.identity.Load()
+	return id != nil && id.Audience != ""
+}
+
 // HandleInbound validates an inbound request's JWT token.
 // audience overrides the default expected audience when non-empty. This supports
 // waypoint mode where audience is derived per-request from the destination host.
@@ -303,6 +309,13 @@ func (a *Auth) HandleInbound(ctx context.Context, authHeader, path, audience str
 	}
 	if audience == "" {
 		audience = a.identity.Load().Audience
+	}
+	if audience == "" {
+		return &InboundResult{
+			Action:     ActionDeny,
+			DenyStatus: http.StatusServiceUnavailable,
+			DenyReason: "identity not yet configured (credentials pending)",
+		}
 	}
 	a.log.Debug("validating inbound JWT", "path", path, "expectedAudience", audience)
 	claims, err := a.verifier.Verify(ctx, token, audience)

--- a/authbridge/authlib/config/config.go
+++ b/authbridge/authlib/config/config.go
@@ -77,14 +77,15 @@ type OutboundConfig struct {
 
 // IdentityConfig holds agent identity and credentials.
 type IdentityConfig struct {
-	Type             string   `yaml:"type" json:"type"` // "spiffe", "client-secret", "k8s-sa"
-	ClientID         string   `yaml:"client_id" json:"client_id"`
-	ClientSecret     string   `yaml:"client_secret" json:"client_secret"`
-	ClientIDFile     string   `yaml:"client_id_file" json:"client_id_file"`         // alternative: read client_id from file
-	ClientSecretFile string   `yaml:"client_secret_file" json:"client_secret_file"` // alternative: read client_secret from file
-	SocketPath       string   `yaml:"socket_path" json:"socket_path"`               // SPIFFE Workload API
-	JWTSVIDPath      string   `yaml:"jwt_svid_path" json:"jwt_svid_path"`           // file-based SPIFFE
-	JWTAudience      []string `yaml:"jwt_audience" json:"jwt_audience"`             // SPIFFE JWT audience
+	Type                  string   `yaml:"type" json:"type"`                                     // "spiffe", "client-secret", "k8s-sa"
+	ClientID              string   `yaml:"client_id" json:"client_id"`
+	ClientSecret          string   `yaml:"client_secret" json:"client_secret"`
+	ClientIDFile          string   `yaml:"client_id_file" json:"client_id_file"`                 // alternative: read client_id from file
+	ClientSecretFile      string   `yaml:"client_secret_file" json:"client_secret_file"`         // alternative: read client_secret from file
+	SocketPath            string   `yaml:"socket_path" json:"socket_path"`                       // SPIFFE Workload API
+	JWTSVIDPath           string   `yaml:"jwt_svid_path" json:"jwt_svid_path"`                   // file-based SPIFFE
+	JWTAudience           []string `yaml:"jwt_audience" json:"jwt_audience"`                     // SPIFFE JWT audience
+	CredentialWaitTimeout string   `yaml:"credential_wait_timeout" json:"credential_wait_timeout"` // initial fast-poll duration, e.g. "120s"
 }
 
 // ListenerConfig holds per-mode listener addresses.

--- a/authbridge/authlib/config/resolve.go
+++ b/authbridge/authlib/config/resolve.go
@@ -118,26 +118,70 @@ func deriveJWKSURL(cfg *Config) {
 	}
 }
 
-// ResolveCredentialFiles waits for and reads credential files when configured.
+// ResolveCredentialFiles polls for credential files and signals readiness.
+// It never gives up: after initialTimeout it switches to exponential backoff.
 // Call this after the server listener starts to avoid blocking startup.
-// This handles the startup race with client-registration and spiffe-helper.
-func ResolveCredentialFiles(cfg *Config) {
-	if cfg.Identity.ClientIDFile != "" {
-		if err := waitAndReadFile(cfg.Identity.ClientIDFile, &cfg.Identity.ClientID, 60*time.Second); err != nil {
-			slog.Warn("client_id_file not available, using client_id from config", "error", err)
+func ResolveCredentialFiles(cfg *Config, initialTimeout time.Duration) <-chan struct{} {
+	ready := make(chan struct{})
+
+	needClientID := cfg.Identity.ClientIDFile != ""
+	needClientSecret := cfg.Identity.ClientSecretFile != ""
+	needSVID := cfg.Identity.Type == "spiffe" && cfg.Identity.JWTSVIDPath != ""
+
+	if !needClientID && !needClientSecret && !needSVID {
+		close(ready)
+		return ready
+	}
+
+	go func() {
+		// Phase 1: fast poll (2s interval) up to initialTimeout
+		if resolveAllCredentials(cfg, needClientID, needClientSecret, needSVID, initialTimeout) {
+			close(ready)
+			return
+		}
+		slog.Warn("credential files not available after initial timeout, continuing in background",
+			"timeout", initialTimeout)
+
+		// Phase 2: exponential backoff, never gives up
+		backoff := 5 * time.Second
+		const maxBackoff = 60 * time.Second
+		for {
+			time.Sleep(backoff)
+			if resolveAllCredentials(cfg, needClientID, needClientSecret, needSVID, 0) {
+				close(ready)
+				slog.Info("credential files loaded after extended wait")
+				return
+			}
+			if backoff < maxBackoff {
+				backoff = min(backoff*2, maxBackoff)
+			}
+		}
+	}()
+	return ready
+}
+
+// resolveAllCredentials attempts to read all needed credential files.
+// With timeout=0 it does a single non-blocking check.
+// Returns true only when ALL needed files have been successfully loaded.
+func resolveAllCredentials(cfg *Config, needClientID, needClientSecret, needSVID bool, timeout time.Duration) bool {
+	allOK := true
+
+	if needClientID {
+		if err := waitAndReadFile(cfg.Identity.ClientIDFile, &cfg.Identity.ClientID, timeout); err != nil {
+			allOK = false
 		}
 	}
-	if cfg.Identity.ClientSecretFile != "" {
-		if err := waitAndReadFile(cfg.Identity.ClientSecretFile, &cfg.Identity.ClientSecret, 60*time.Second); err != nil {
-			slog.Warn("client_secret_file not available, using client_secret from config", "error", err)
+	if needClientSecret {
+		if err := waitAndReadFile(cfg.Identity.ClientSecretFile, &cfg.Identity.ClientSecret, timeout); err != nil {
+			allOK = false
 		}
 	}
-	// Wait for JWT-SVID file if SPIFFE identity is configured
-	if cfg.Identity.Type == "spiffe" && cfg.Identity.JWTSVIDPath != "" {
-		if err := waitForFile(cfg.Identity.JWTSVIDPath, 60*time.Second); err != nil {
-			slog.Warn("jwt_svid_path not available at startup, will be read on each exchange", "error", err)
+	if needSVID {
+		if err := waitForFile(cfg.Identity.JWTSVIDPath, timeout); err != nil {
+			allOK = false
 		}
 	}
+	return allOK
 }
 
 // waitAndReadFile polls for a file to exist, then reads its content into dest.
@@ -155,13 +199,20 @@ func waitAndReadFile(path string, dest *string, timeout time.Duration) error {
 }
 
 // waitForFile polls for a file to exist, returning nil when found or error on timeout.
+// With timeout=0, performs a single non-blocking check.
 func waitForFile(path string, timeout time.Duration) error {
+	if info, err := os.Stat(path); err == nil && info.Size() > 0 {
+		return nil
+	}
+	if timeout <= 0 {
+		return fmt.Errorf("file not ready: %s", path)
+	}
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
+		time.Sleep(2 * time.Second)
 		if info, err := os.Stat(path); err == nil && info.Size() > 0 {
 			return nil
 		}
-		time.Sleep(2 * time.Second)
 	}
 	return fmt.Errorf("timeout waiting for %s (%v)", path, timeout)
 }

--- a/authbridge/cmd/authbridge/main.go
+++ b/authbridge/cmd/authbridge/main.go
@@ -199,14 +199,21 @@ func main() {
 
 	slog.Info("authbridge starting", "mode", cfg.Mode, "logLevel", logLevel.Level().String())
 
+	// Parse configurable credential wait timeout (default 120s).
+	credentialTimeout := 120 * time.Second
+	if t := cfg.Identity.CredentialWaitTimeout; t != "" {
+		if d, err := time.ParseDuration(t); err == nil {
+			credentialTimeout = d
+		}
+	}
+
 	// Resolve credentials in background — doesn't block the listener.
-	// Once credential files are available, update the handler's identity
-	// and exchanger so token exchange requests use the loaded credentials.
+	// Never gives up: after initialTimeout switches to exponential backoff.
+	credReady := config.ResolveCredentialFiles(cfg, credentialTimeout)
+
+	// Update handler identity once credentials are available.
 	go func() {
-		slog.Info("resolving credentials in background...")
-		config.ResolveCredentialFiles(cfg)
-		// Safe to read cfg.Identity here — ResolveCredentialFiles completed
-		// and this is the only goroutine that writes these fields.
+		<-credReady
 		clientAuth, err := config.ResolveClientAuth(cfg)
 		if err != nil {
 			slog.Warn("failed to resolve client auth after credential load", "error", err)
@@ -216,6 +223,25 @@ func main() {
 			ClientID: cfg.Identity.ClientID,
 			Audience: cfg.Identity.ClientID,
 		}, clientAuth)
+	}()
+
+	// Health/readiness server — reflects credential readiness for K8s probes.
+	go func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+			if handler.Ready() {
+				w.WriteHeader(http.StatusOK)
+			} else {
+				http.Error(w, "credentials pending", http.StatusServiceUnavailable)
+			}
+		})
+		slog.Info("health server listening", "addr", ":9091")
+		if err := http.ListenAndServe(":9091", mux); err != nil {
+			slog.Warn("health server failed", "error", err)
+		}
 	}()
 
 	// Wait for shutdown signal


### PR DESCRIPTION
## Summary

- Replace fire-once 60s credential file poll with continuous polling + exponential backoff (never gives up)
- Add configurable `credential_wait_timeout` (default 120s) for the initial fast-poll phase
- Return HTTP 503 (not silent 401) when identity credentials are still pending
- Add `/healthz` and `/readyz` endpoints on port 9091 for Kubernetes readiness probes

## Problem

The `kagenti-client-registration` sidecar occasionally takes >60s to register with Keycloak and write credential files. When this happens, AuthBridge's fire-once poll expires silently, leaving `client_id=""`. All subsequent inbound JWT validation fails with 401 because audience defaults to the empty client_id.

This was observed as a transient E2E failure in kagenti/kagenti#1480 (HyperShift CI).

## Solution

1. **Continuous polling**: After the initial timeout (120s), keep trying with exponential backoff (5s, 10s, 20s... capped at 60s). Credentials are picked up whenever they appear.
2. **503 pending state**: Instead of a confusing 401 "audience is required" error, return 503 "identity not yet configured (credentials pending)" — a clear signal to retry.
3. **Readiness probe**: The new `/readyz` endpoint returns 200 only after credentials load, preventing Kubernetes from routing traffic to the pod prematurely.

## Test plan

- [x] All 13 authlib packages pass (`go test ./...`)
- [x] `go build` succeeds for authlib and cmd/authbridge
- [ ] Deploy to Kind with delayed client-registration (add sleep 90) and verify pod becomes Ready only after credentials load
- [ ] Re-run PR #1480 E2E HyperShift check

Fixes: kagenti/kagenti#1480

Assisted-By: Claude Code