### PR TITLE
feat: Add on_error policy and seal built-in plugin registry

### DIFF
--- a/authbridge/authlib/config/config.go
+++ b/authbridge/authlib/config/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/kagenti/kagenti-extensions/authbridge/authlib/pipeline"
 	"gopkg.in/yaml.v3"
 )
 
@@ -67,19 +68,25 @@ type PipelineStageConfig struct {
 // PluginEntry names a plugin and optionally carries per-instance config.
 //
 // The YAML accepts both the bare-name form ("jwt-validation") and the
-// full form ({name, id, config}). The short form keeps existing pipeline
-// configs parsing unchanged; the long form is what plugins that
-// implement pipeline.Configurable actually need. See
+// full form ({name, id, on_error, config}). The short form keeps
+// existing pipeline configs parsing unchanged; the long form is what
+// plugins that implement pipeline.Configurable actually need. See
 // authbridge/docs/plugin-reference.md for the convention plugins
 // follow when decoding Config.
 //
 // Config is captured as a raw subtree via json.RawMessage so the plugin
 // can do its own DisallowUnknownFields decode against a typed struct —
 // the framework does not interpret it.
+//
+// OnError is the framework-owned wrapper policy (see ErrorPolicy).
+// Plugin authors do not consume it — it lives outside the plugin's
+// own config block so all plugins get the same rollout story without
+// each one re-implementing shadow mode.
 type PluginEntry struct {
-	Name   string          `yaml:"name" json:"name"`
-	ID     string          `yaml:"id,omitempty" json:"id,omitempty"`
-	Config json.RawMessage `yaml:"-" json:"config,omitempty"`
+	Name    string               `yaml:"name" json:"name"`
+	ID      string               `yaml:"id,omitempty" json:"id,omitempty"`
+	OnError pipeline.ErrorPolicy `yaml:"on_error,omitempty" json:"on_error,omitempty"`
+	Config  json.RawMessage      `yaml:"-" json:"config,omitempty"`
 }
 
 // UnmarshalYAML accepts either a bare string or a map. The string form
@@ -108,6 +115,16 @@ func (p *PluginEntry) UnmarshalYAML(node *yaml.Node) error {
 				if err := val.Decode(&p.ID); err != nil {
 					return fmt.Errorf("plugin entry id: %w", err)
 				}
+			case "on_error":
+				var raw string
+				if err := val.Decode(&raw); err != nil {
+					return fmt.Errorf("plugin entry on_error: %w", err)
+				}
+				policy := pipeline.ErrorPolicy(raw)
+				if !policy.Valid() {
+					return fmt.Errorf("plugin entry on_error: %q is not a valid policy (expected: enforce, observe, off)", raw)
+				}
+				p.OnError = policy
 			case "config":
 				// Explicit `config: null` (or `config:` with no value)
 				// decodes to a null-tagged scalar node. Normalize to

--- a/authbridge/authlib/config/config_test.go
+++ b/authbridge/authlib/config/config_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/kagenti/kagenti-extensions/authbridge/authlib/pipeline"
 )
 
 // --- Preset Tests ---
@@ -318,6 +320,81 @@ pipeline:
 	}
 	if nested["enabled"] != true {
 		t.Errorf("nested.enabled = %v, want true", nested["enabled"])
+	}
+}
+
+// TestPluginEntry_OnError covers the three accepted policy values plus
+// the omitted case. An invalid policy must fail loud at YAML parse
+// time so operators catch typos before the pod boots.
+func TestPluginEntry_OnError(t *testing.T) {
+	cases := []struct {
+		name     string
+		yaml     string
+		want     pipeline.ErrorPolicy
+		wantFail bool
+	}{
+		{"enforce explicit", "enforce", pipeline.ErrorPolicyEnforce, false},
+		{"observe", "observe", pipeline.ErrorPolicyObserve, false},
+		{"off", "off", pipeline.ErrorPolicyOff, false},
+		{"typo rejected", "observer", "", true},
+		{"upper rejected", "ENFORCE", "", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "config.yaml")
+			content := "mode: envoy-sidecar\n" +
+				"pipeline:\n" +
+				"  inbound:\n" +
+				"    plugins:\n" +
+				"      - name: custom-guardrail\n" +
+				"        on_error: " + c.yaml + "\n"
+			if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := Load(path)
+			if c.wantFail {
+				if err == nil {
+					t.Fatalf("expected parse error for on_error=%q", c.yaml)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			got := cfg.Pipeline.Inbound.Plugins[0].OnError
+			if got != c.want {
+				t.Errorf("OnError = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// TestPluginEntry_OnError_Omitted verifies the empty-string default.
+// Resolved() should treat an absent on_error as enforce; the parsed
+// field itself stays empty so round-tripping YAML doesn't invent a
+// value the operator didn't write.
+func TestPluginEntry_OnError_Omitted(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := "mode: envoy-sidecar\n" +
+		"pipeline:\n" +
+		"  inbound:\n" +
+		"    plugins:\n" +
+		"      - name: custom-guardrail\n"
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got := cfg.Pipeline.Inbound.Plugins[0].OnError
+	if got != "" {
+		t.Errorf("omitted OnError parsed as %q, want empty", got)
+	}
+	if got.Resolved() != pipeline.ErrorPolicyEnforce {
+		t.Errorf("Resolved() of empty = %q, want enforce", got.Resolved())
 	}
 }
 

--- a/authbridge/authlib/pipeline/context.go
+++ b/authbridge/authlib/pipeline/context.go
@@ -104,14 +104,18 @@ type Context struct {
 
 	Extensions Extensions
 
-	// currentPlugin and currentPhase are framework-owned fields set by
-	// Pipeline.Run / RunResponse around each plugin dispatch. They feed
-	// the Record / Allow / Skip / Observe / Modify / DenyAndRecord helper
-	// methods so plugin code doesn't have to repeat its own Name(),
-	// the phase it's in, or the direction on every Invocation literal.
-	// Unexported so plugins can only set them indirectly (via the framework).
+	// currentPlugin, currentPhase, and currentPolicy are framework-owned
+	// fields set by Pipeline.Run / RunResponse around each plugin
+	// dispatch. They feed the Record / Allow / Skip / Observe / Modify /
+	// DenyAndRecord helper methods so plugin code doesn't have to repeat
+	// its own Name(), the phase it's in, or the direction on every
+	// Invocation literal. currentPolicy is consulted by SetBody /
+	// SetResponseBody to suppress mutation propagation when the current
+	// plugin runs under ErrorPolicyObserve. Unexported so plugins can
+	// only set them indirectly (via the framework).
 	currentPlugin string
 	currentPhase  InvocationPhase
+	currentPolicy ErrorPolicy
 
 	// bodyMutated / responseBodyMutated flag that a plugin called
 	// SetBody / SetResponseBody on this context. Listeners read the flag
@@ -135,16 +139,35 @@ type Context struct {
 // pctx in their own dispatch loops (not strictly via Pipeline.Run) need
 // to set the same fields to get consistent Invocation attribution.
 // Production plugins should never call this directly.
+//
+// Sets the policy to the default (enforce). Call setCurrent (unexported)
+// to stamp a non-default policy — only Pipeline.Run/RunResponse should
+// supply a non-default, and they use the unexported path.
 func (c *Context) SetCurrentPlugin(name string, phase InvocationPhase) {
-	c.currentPlugin = name
-	c.currentPhase = phase
+	c.setCurrent(name, phase, ErrorPolicyEnforce)
 }
 
 // ClearCurrentPlugin resets the framework-owned attribution fields.
 // Paired with SetCurrentPlugin.
 func (c *Context) ClearCurrentPlugin() {
+	c.clearCurrent()
+}
+
+// setCurrent stamps the per-dispatch attribution including the current
+// plugin's on_error policy. Internal to the pipeline package; exported
+// SetCurrentPlugin is the listener-facing entry point and defaults
+// policy to enforce.
+func (c *Context) setCurrent(name string, phase InvocationPhase, policy ErrorPolicy) {
+	c.currentPlugin = name
+	c.currentPhase = phase
+	c.currentPolicy = policy.Resolved()
+}
+
+// clearCurrent zeroes the per-dispatch attribution fields.
+func (c *Context) clearCurrent() {
 	c.currentPlugin = ""
 	c.currentPhase = ""
+	c.currentPolicy = ""
 }
 
 // Record appends an Invocation to pctx under the current pipeline
@@ -224,6 +247,13 @@ func (c *Context) DenyAndRecord(reason, code, message string) Action {
 // SetBody mutate the in-memory Context (readers downstream see the
 // change), but the wire is unchanged.
 //
+// Under ErrorPolicyObserve (shadow mode) SetBody is a NO-OP on bytes:
+// the in-memory body is not replaced, bodyMutated stays false, and
+// downstream plugins continue to see the original. A modify
+// Invocation is still recorded — with Shadow=true — so operators can
+// count "would have redacted" on the rollout dashboard. Plugin code
+// therefore looks identical under enforce and observe.
+//
 // SetBody auto-emits a modify-action Invocation with Reason
 // "body_rewritten" and publishes a plugin-public event under
 // "body-mutation/event" carrying the before/after length and sha256 —
@@ -233,6 +263,10 @@ func (c *Context) DenyAndRecord(reason, code, message string) Action {
 // Callers should NOT assign pctx.Body directly — the listener wouldn't
 // know to propagate the change, and the Invocation wouldn't be emitted.
 func (c *Context) SetBody(newBody []byte) {
+	if c.currentPolicy == ErrorPolicyObserve {
+		c.recordShadowBodyMutation("request", c.Body, newBody)
+		return
+	}
 	old := c.Body
 	c.Body = newBody
 	c.bodyMutated = true
@@ -242,12 +276,42 @@ func (c *Context) SetBody(newBody []byte) {
 // SetResponseBody is the response-side analogue of SetBody. Used by
 // plugins that redact or rewrite the upstream response (prompt-safety
 // guardrails on LLM output, content filters, DLP). Same contract —
-// Invocation + body-mutation/event emitted; never logs the body.
+// Invocation + body-mutation/event emitted; never logs the body —
+// and the same observe-mode suppression: under ErrorPolicyObserve the
+// response body is untouched and the Invocation is marked Shadow=true.
 func (c *Context) SetResponseBody(newBody []byte) {
+	if c.currentPolicy == ErrorPolicyObserve {
+		c.recordShadowBodyMutation("response", c.ResponseBody, newBody)
+		return
+	}
 	old := c.ResponseBody
 	c.ResponseBody = newBody
 	c.responseBodyMutated = true
 	c.emitBodyMutation("response", old, newBody)
+}
+
+// recordShadowBodyMutation emits the would-mutate Invocation for a
+// SetBody / SetResponseBody call that was suppressed under observe
+// mode. Mirrors emitBodyMutation's telemetry (length + sha256 delta)
+// so dashboards get the same shape they see under enforce, just with
+// Shadow=true and no wire-level effect.
+func (c *Context) recordShadowBodyMutation(phase string, oldBody, newBody []byte) {
+	c.Record(Invocation{
+		Action: ActionModify,
+		Reason: "body_rewritten",
+		Shadow: true,
+	})
+	if c.Extensions.Custom == nil {
+		c.Extensions.Custom = map[string]any{}
+	}
+	c.Extensions.Custom["body-mutation"+PluginEventSuffix] = bodyMutationEvent{
+		Phase:        phase,
+		Plugin:       c.currentPlugin,
+		LengthBefore: len(oldBody),
+		LengthAfter:  len(newBody),
+		SHA256Before: hashHex(oldBody),
+		SHA256After:  hashHex(newBody),
+	}
 }
 
 // BodyMutated reports whether a plugin called SetBody during this
@@ -345,6 +409,40 @@ func (c *Context) appendInvocation(inv Invocation) {
 	case Outbound:
 		c.Extensions.Invocations.Outbound = append(c.Extensions.Invocations.Outbound, inv)
 	}
+}
+
+// markLastInvocationShadow finds the most recent Invocation authored
+// by pluginName in the given phase (within the current direction
+// bucket) and flips its Shadow flag to true. Returns true when a
+// matching record was found. Used by the pipeline to retroactively
+// tag a plugin's deny record as shadow once Pipeline.Run has observed
+// that the plugin returned Reject under ErrorPolicyObserve.
+//
+// Walking backwards and matching on Plugin+Phase is O(N) in the
+// worst case but typically short-circuits at index -1 — plugins
+// almost always Record right before returning Reject, so the last
+// entry matches.
+func (c *Context) markLastInvocationShadow(pluginName string, phase InvocationPhase) bool {
+	if c.Extensions.Invocations == nil {
+		return false
+	}
+	var list []Invocation
+	switch c.Direction {
+	case Inbound:
+		list = c.Extensions.Invocations.Inbound
+	case Outbound:
+		list = c.Extensions.Invocations.Outbound
+	default:
+		return false
+	}
+	for i := len(list) - 1; i >= 0; i-- {
+		if list[i].Plugin != pluginName || list[i].Phase != phase {
+			continue
+		}
+		list[i].Shadow = true
+		return true
+	}
+	return false
 }
 
 // AgentIdentity carries the agent's own workload identity.

--- a/authbridge/authlib/pipeline/extensions.go
+++ b/authbridge/authlib/pipeline/extensions.go
@@ -295,6 +295,15 @@ type Invocation struct {
 	// The session API has no auth on it — only safe-to-log data
 	// belongs in Invocation.Details.
 	Details map[string]string `json:"details,omitempty"`
+
+	// Shadow reports that the plugin ran under on_error: observe and
+	// its decision (deny or modify) was NOT applied to the request.
+	// An operator reading a would-have-blocked timeline filters on
+	// Shadow=true to count rollout-candidate events; a dashboard that
+	// aggregates "effective denies" filters Shadow=false. The
+	// framework, not the plugin, sets this — plugin code looks
+	// identical under enforce and observe.
+	Shadow bool `json:"shadow,omitempty"`
 }
 
 // DelegationExtension tracks the token delegation chain across hops.

--- a/authbridge/authlib/pipeline/pipeline.go
+++ b/authbridge/authlib/pipeline/pipeline.go
@@ -7,8 +7,14 @@ import (
 )
 
 // Pipeline holds an ordered list of plugins and runs them sequentially.
+//
+// policies is parallel to plugins: policies[i] is the on_error policy
+// for plugins[i]. An empty policy resolves to ErrorPolicyEnforce. The
+// slice is always the same length as plugins; New fills unspecified
+// entries with the zero value.
 type Pipeline struct {
-	plugins []Plugin
+	plugins  []Plugin
+	policies []ErrorPolicy
 }
 
 // defaultSlots lists the built-in extension slot names.
@@ -26,6 +32,7 @@ type Option func(*options)
 
 type options struct {
 	extraSlots []string
+	policies   []ErrorPolicy
 }
 
 // WithSlots registers additional valid extension slot names beyond the built-in set.
@@ -33,6 +40,18 @@ type options struct {
 func WithSlots(slots ...string) Option {
 	return func(o *options) {
 		o.extraSlots = append(o.extraSlots, slots...)
+	}
+}
+
+// WithPolicies attaches per-plugin on_error policies in parallel with
+// the plugin slice passed to New. policies[i] belongs to plugins[i];
+// an empty entry defaults to ErrorPolicyEnforce. If fewer policies are
+// supplied than plugins, the remaining plugins use the default
+// (enforce). Supplying more policies than plugins is a programmer
+// error and New returns an error.
+func WithPolicies(policies ...ErrorPolicy) Option {
+	return func(o *options) {
+		o.policies = append(o.policies, policies...)
 	}
 }
 
@@ -53,30 +72,53 @@ func New(plugins []Plugin, opts ...Option) (*Pipeline, error) {
 	if err := validateCapabilities(plugins, validSlots); err != nil {
 		return nil, err
 	}
-	return &Pipeline{plugins: plugins}, nil
+	if len(o.policies) > len(plugins) {
+		return nil, fmt.Errorf("pipeline: WithPolicies has %d entries but only %d plugins", len(o.policies), len(plugins))
+	}
+	policies := make([]ErrorPolicy, len(plugins))
+	copy(policies, o.policies)
+	return &Pipeline{plugins: plugins, policies: policies}, nil
 }
 
 // Run executes the request phase of the pipeline sequentially.
 // If any plugin returns Reject, the pipeline stops and returns that action
 // with Violation.PluginName populated.
 //
+// Plugins configured with ErrorPolicyOff are skipped entirely — they
+// are not dispatched and contribute no Invocation. Plugins under
+// ErrorPolicyObserve are dispatched normally, but a Reject return is
+// converted into a pass-through: the Violation is recorded as a
+// shadow Invocation and the pipeline continues to the next plugin.
+// Body mutations under observe are also suppressed — see
+// Context.SetBody / SetResponseBody.
+//
 // Before dispatching into each plugin, Run stamps pctx with the plugin's
-// name and the current phase so the plugin's Record / Allow / Skip /
-// Observe / Modify / DenyAndRecord helpers can fill Invocation.Plugin
-// and Invocation.Phase automatically. The stamp is cleared after each
-// plugin returns so a plugin that spawns a goroutine capturing pctx
-// won't mis-attribute a late-arriving Record to itself.
+// name, the current phase, and the current policy so the plugin's
+// Record / Allow / Skip / Observe / Modify / DenyAndRecord helpers can
+// fill Invocation.Plugin and Invocation.Phase automatically. The stamp
+// is cleared after each plugin returns so a plugin that spawns a
+// goroutine capturing pctx won't mis-attribute a late-arriving Record
+// to itself.
 func (p *Pipeline) Run(ctx context.Context, pctx *Context) Action {
-	for _, plugin := range p.plugins {
+	for i, plugin := range p.plugins {
+		policy := p.policyAt(i)
+		if policy == ErrorPolicyOff {
+			slog.Debug("pipeline: plugin disabled (on_error: off)", "plugin", plugin.Name())
+			continue
+		}
 		if ctx.Err() != nil {
 			slog.Info("pipeline: request cancelled", "plugin", plugin.Name())
 			return Deny("pipeline.cancelled", "request cancelled")
 		}
-		pctx.SetCurrentPlugin(plugin.Name(), InvocationPhaseRequest)
+		pctx.setCurrent(plugin.Name(), InvocationPhaseRequest, policy)
 		action := plugin.OnRequest(ctx, pctx)
-		pctx.ClearCurrentPlugin()
+		pctx.clearCurrent()
 		if action.Type == Reject {
 			stampPluginName(&action, plugin.Name())
+			if policy == ErrorPolicyObserve {
+				markShadowAndLog(pctx, plugin.Name(), InvocationPhaseRequest, action, "request")
+				continue
+			}
 			logReject(plugin.Name(), action, "pipeline: plugin rejected request")
 			return action
 		}
@@ -88,24 +130,80 @@ func (p *Pipeline) Run(ctx context.Context, pctx *Context) Action {
 // RunResponse executes the response phase in reverse order.
 // The last plugin in the chain sees the response first.
 //
-// See Run for the pctx attribution stamping. Same pattern, phase set
-// to InvocationPhaseResponse.
+// See Run for the pctx attribution stamping, the off-policy skip, and
+// the observe-policy shadow conversion. Same pattern, phase set to
+// InvocationPhaseResponse.
 func (p *Pipeline) RunResponse(ctx context.Context, pctx *Context) Action {
 	for i := len(p.plugins) - 1; i >= 0; i-- {
+		policy := p.policyAt(i)
+		if policy == ErrorPolicyOff {
+			continue
+		}
 		if ctx.Err() != nil {
 			slog.Info("pipeline: response cancelled", "plugin", p.plugins[i].Name())
 			return Deny("pipeline.cancelled", "request cancelled")
 		}
-		pctx.SetCurrentPlugin(p.plugins[i].Name(), InvocationPhaseResponse)
+		pctx.setCurrent(p.plugins[i].Name(), InvocationPhaseResponse, policy)
 		action := p.plugins[i].OnResponse(ctx, pctx)
-		pctx.ClearCurrentPlugin()
+		pctx.clearCurrent()
 		if action.Type == Reject {
 			stampPluginName(&action, p.plugins[i].Name())
+			if policy == ErrorPolicyObserve {
+				markShadowAndLog(pctx, p.plugins[i].Name(), InvocationPhaseResponse, action, "response")
+				continue
+			}
 			logReject(p.plugins[i].Name(), action, "pipeline: plugin rejected response")
 			return action
 		}
 	}
 	return Action{Type: Continue}
+}
+
+// policyAt returns the resolved policy for plugins[i]. The policies
+// slice is always the same length as plugins (New guarantees this),
+// but we check defensively so a zero-value Pipeline (constructed
+// outside New, e.g. in a test) doesn't panic.
+func (p *Pipeline) policyAt(i int) ErrorPolicy {
+	if i < len(p.policies) {
+		return p.policies[i].Resolved()
+	}
+	return ErrorPolicyEnforce
+}
+
+// markShadowAndLog records the would-have-denied Invocation as
+// Shadow=true and emits a WARN log. If the plugin already appended a
+// deny Invocation (typical for gate plugins that call
+// DenyAndRecord / Record before returning Reject), we mark that
+// record instead of appending a duplicate — otherwise dashboards
+// would double-count a single decision. Synthesize a record only
+// when the plugin returned Reject without having recorded its own
+// invocation (rare: plugin bug or non-recording denial helper).
+func markShadowAndLog(pctx *Context, pluginName string, phase InvocationPhase, action Action, phaseLabel string) {
+	status, _, _ := action.Violation.Render()
+	marked := pctx.markLastInvocationShadow(pluginName, phase)
+	if !marked {
+		inv := Invocation{
+			Plugin: pluginName,
+			Phase:  phase,
+			Action: ActionDeny,
+			Reason: "shadow_synthesized",
+			Path:   pctx.Path,
+			Shadow: true,
+		}
+		if action.Violation != nil {
+			inv.Details = map[string]string{
+				"would_deny_code":   action.Violation.Code,
+				"would_deny_reason": action.Violation.Reason,
+			}
+		}
+		pctx.Record(inv)
+	}
+	slog.Warn("pipeline: plugin would have denied (shadow)",
+		"plugin", pluginName,
+		"phase", phaseLabel,
+		"status", status,
+		"code", action.Violation.Code,
+		"reason", action.Violation.Reason)
 }
 
 // stampPluginName annotates a reject action with the plugin that produced

--- a/authbridge/authlib/pipeline/pipeline_test.go
+++ b/authbridge/authlib/pipeline/pipeline_test.go
@@ -674,3 +674,231 @@ func TestPipelineStop_NoShutdownersIsNoop(t *testing.T) {
 	}
 	p.Stop(context.Background()) // must not panic
 }
+
+// --- on_error policy tests ---
+
+// TestPipelineRun_ObservePolicyConvertsRejectToContinue is the
+// headline safety property of observe mode: a plugin that intends to
+// deny must not actually block the request. The downstream plugin
+// still runs, the caller sees Continue, and the plugin's deny record
+// lands in pctx with Shadow=true so operators can count would-have-
+// blocked events on a rollout dashboard.
+func TestPipelineRun_ObservePolicyConvertsRejectToContinue(t *testing.T) {
+	var downstreamCalled bool
+	shadow := &stubPlugin{
+		name: "would-deny",
+		onReq: func(_ context.Context, pctx *Context) Action {
+			return pctx.DenyAndRecord("guardrail_triggered", "policy.content-blocked", "blocked")
+		},
+	}
+	downstream := &stubPlugin{
+		name: "downstream",
+		onReq: func(_ context.Context, _ *Context) Action {
+			downstreamCalled = true
+			return Action{Type: Continue}
+		},
+	}
+	p, err := New([]Plugin{shadow, downstream}, WithPolicies(ErrorPolicyObserve, ErrorPolicyEnforce))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	pctx := &Context{}
+	got := p.Run(context.Background(), pctx)
+	if got.Type != Continue {
+		t.Fatalf("action type = %v, want Continue (observe suppresses Reject)", got.Type)
+	}
+	if !downstreamCalled {
+		t.Error("downstream plugin not called; observe mode must not stop the pipeline")
+	}
+	if pctx.Extensions.Invocations == nil || len(pctx.Extensions.Invocations.Inbound) == 0 {
+		t.Fatal("no invocations recorded")
+	}
+	deny := pctx.Extensions.Invocations.Inbound[0]
+	if deny.Action != ActionDeny {
+		t.Errorf("shadow invocation action = %q, want deny (plugin's own record is preserved)", deny.Action)
+	}
+	if !deny.Shadow {
+		t.Error("shadow=false on the would-deny record; observe mode must mark it")
+	}
+}
+
+// TestPipelineRun_EnforceIsDefault confirms that a plugin without a
+// specified policy behaves exactly as before: Reject stops the
+// pipeline and returns a Reject action upstream. Regression guard —
+// the point of adding WithPolicies was to NOT change existing
+// deployments.
+func TestPipelineRun_EnforceIsDefault(t *testing.T) {
+	plugin := &stubPlugin{
+		name: "denier",
+		onReq: func(_ context.Context, _ *Context) Action {
+			return Deny("policy.forbidden", "no")
+		},
+	}
+	// No WithPolicies — entries default to enforce.
+	p, err := New([]Plugin{plugin})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	got := p.Run(context.Background(), &Context{})
+	if got.Type != Reject {
+		t.Errorf("action type = %v, want Reject (default is enforce)", got.Type)
+	}
+}
+
+// TestPipelineRun_OffPolicySkipsDispatch verifies off-mode plugins
+// don't run at all — not even their OnRequest. A kill-switched
+// plugin must leave no trace in invocations, matching the "plugin
+// absent from config" behavior.
+func TestPipelineRun_OffPolicySkipsDispatch(t *testing.T) {
+	var called bool
+	disabled := &stubPlugin{
+		name: "disabled",
+		onReq: func(_ context.Context, _ *Context) Action {
+			called = true
+			return Action{Type: Continue}
+		},
+	}
+	p, err := New([]Plugin{disabled}, WithPolicies(ErrorPolicyOff))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	pctx := &Context{}
+	got := p.Run(context.Background(), pctx)
+	if got.Type != Continue {
+		t.Errorf("action = %v, want Continue", got.Type)
+	}
+	if called {
+		t.Error("disabled plugin was dispatched; off must skip it")
+	}
+	if pctx.Extensions.Invocations != nil && len(pctx.Extensions.Invocations.Inbound) > 0 {
+		t.Errorf("off-policy plugin appended invocations: %+v", pctx.Extensions.Invocations.Inbound)
+	}
+}
+
+// TestPipelineRunResponse_ObservePolicySuppressesReject ensures the
+// observe semantics apply symmetrically to the response phase.
+// Response-side guardrails (DLP on tool output, jailbreak detection
+// on model replies) are exactly the class that most needs shadow
+// rollout — they inspect generated content the author can't preview.
+func TestPipelineRunResponse_ObservePolicySuppressesReject(t *testing.T) {
+	shadow := &stubPlugin{
+		name: "would-deny-response",
+		onResp: func(_ context.Context, pctx *Context) Action {
+			return pctx.DenyAndRecord("pii_leak", "policy.content-blocked", "leak")
+		},
+	}
+	p, err := New([]Plugin{shadow}, WithPolicies(ErrorPolicyObserve))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	pctx := &Context{}
+	got := p.RunResponse(context.Background(), pctx)
+	if got.Type != Continue {
+		t.Errorf("action type = %v, want Continue (observe on response phase)", got.Type)
+	}
+	if pctx.Extensions.Invocations == nil || len(pctx.Extensions.Invocations.Inbound) == 0 {
+		t.Fatal("no response-phase invocation recorded")
+	}
+	inv := pctx.Extensions.Invocations.Inbound[0]
+	if inv.Phase != InvocationPhaseResponse {
+		t.Errorf("phase = %q, want response", inv.Phase)
+	}
+	if !inv.Shadow {
+		t.Error("response-phase shadow flag not set")
+	}
+}
+
+// TestPipelineRun_ObserveSynthesizesRecordWhenPluginSkipsIt covers
+// the defensive path: a plugin that returns Reject without first
+// recording its own Invocation (programmer error, or use of the
+// bare Deny helper instead of DenyAndRecord). The framework still
+// produces a Shadow=true record so the would-have-blocked event is
+// visible on the dashboard.
+func TestPipelineRun_ObserveSynthesizesRecordWhenPluginSkipsIt(t *testing.T) {
+	silent := &stubPlugin{
+		name: "silent-rejecter",
+		onReq: func(_ context.Context, _ *Context) Action {
+			// Note: no pctx.Record / DenyAndRecord.
+			return Deny("policy.forbidden", "no")
+		},
+	}
+	p, err := New([]Plugin{silent}, WithPolicies(ErrorPolicyObserve))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	pctx := &Context{}
+	got := p.Run(context.Background(), pctx)
+	if got.Type != Continue {
+		t.Errorf("action = %v, want Continue", got.Type)
+	}
+	if pctx.Extensions.Invocations == nil || len(pctx.Extensions.Invocations.Inbound) != 1 {
+		t.Fatalf("want exactly one synthesized invocation, got: %+v", pctx.Extensions.Invocations)
+	}
+	inv := pctx.Extensions.Invocations.Inbound[0]
+	if inv.Reason != "shadow_synthesized" {
+		t.Errorf("reason = %q, want shadow_synthesized", inv.Reason)
+	}
+	if !inv.Shadow {
+		t.Error("Shadow flag not set on synthesized record")
+	}
+	if inv.Details["would_deny_code"] != "policy.forbidden" {
+		t.Errorf("would_deny_code = %q, want policy.forbidden", inv.Details["would_deny_code"])
+	}
+}
+
+// TestSetBody_ObserveModeIsNoop verifies the body-mutation side of
+// observe mode: SetBody records a shadow Invocation but does not
+// replace the in-memory body or flip bodyMutated. Downstream readers
+// and the wire both continue to see the original bytes, so a
+// redaction plugin running in shadow can be trusted to leave
+// production traffic unchanged.
+func TestSetBody_ObserveModeIsNoop(t *testing.T) {
+	mutator := &stubPlugin{
+		name: "redactor",
+		caps: PluginCapabilities{WritesBody: true},
+		onReq: func(_ context.Context, pctx *Context) Action {
+			pctx.SetBody([]byte("REDACTED"))
+			return Action{Type: Continue}
+		},
+	}
+	p, err := New([]Plugin{mutator}, WithPolicies(ErrorPolicyObserve))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	pctx := &Context{Body: []byte("secret")}
+	got := p.Run(context.Background(), pctx)
+	if got.Type != Continue {
+		t.Fatalf("action = %v, want Continue", got.Type)
+	}
+	if string(pctx.Body) != "secret" {
+		t.Errorf("body = %q, want untouched (observe mode must not replace bytes)", pctx.Body)
+	}
+	if pctx.BodyMutated() {
+		t.Error("BodyMutated=true under observe; wire must see original body")
+	}
+	if pctx.Extensions.Invocations == nil || len(pctx.Extensions.Invocations.Inbound) != 1 {
+		t.Fatalf("want one invocation, got: %+v", pctx.Extensions.Invocations)
+	}
+	inv := pctx.Extensions.Invocations.Inbound[0]
+	if !inv.Shadow || inv.Reason != "body_rewritten" {
+		t.Errorf("expected shadow modify invocation, got action=%q reason=%q shadow=%v",
+			inv.Action, inv.Reason, inv.Shadow)
+	}
+}
+
+// TestNew_RejectsTooManyPolicies locks the defensive check in New:
+// a caller that supplies more policies than plugins is making a
+// parallel-slice mistake, not a well-formed pipeline. Fail loud at
+// construction rather than silently truncate.
+func TestNew_RejectsTooManyPolicies(t *testing.T) {
+	_, err := New(
+		[]Plugin{&stubPlugin{name: "a"}},
+		WithPolicies(ErrorPolicyEnforce, ErrorPolicyObserve),
+	)
+	if err == nil {
+		t.Fatal("expected error; 2 policies for 1 plugin is a parallel-slice bug")
+	}
+	if !strings.Contains(err.Error(), "WithPolicies") {
+		t.Errorf("error should name WithPolicies: %q", err)
+	}
+}

--- a/authbridge/authlib/pipeline/policy.go
+++ b/authbridge/authlib/pipeline/policy.go
@@ -1,0 +1,58 @@
+package pipeline
+
+// ErrorPolicy controls how the pipeline reacts when a plugin returns a
+// Reject action (i.e., decides to deny a request or response). The
+// policy wraps the plugin — plugin authors do not consume it.
+//
+// Default is ErrorPolicyEnforce: Reject becomes an HTTP error response
+// and pipeline execution stops. Operators roll out a new guardrail in
+// ErrorPolicyObserve first: the plugin still evaluates and may still
+// return Reject, but the framework converts the Reject into a
+// pass-through and records the would-have-denied Invocation as
+// Shadow=true. ErrorPolicyOff is a kill-switch — the plugin is
+// not dispatched at all.
+//
+// Reserved built-in gates (jwt-validation, token-exchange) are locked
+// to ErrorPolicyEnforce: shadowing auth is an authentication bypass
+// dressed as a feature. plugins.BuildChain validates this at startup.
+type ErrorPolicy string
+
+const (
+	// ErrorPolicyEnforce is the default. A Reject action becomes the
+	// HTTP error the Violation describes, and the pipeline stops.
+	ErrorPolicyEnforce ErrorPolicy = "enforce"
+
+	// ErrorPolicyObserve (shadow mode) evaluates the plugin normally
+	// but turns a Reject into a pass-through. Used to canary a new
+	// guardrail: operators watch the shadow-deny counter before
+	// flipping to enforce. Body mutations (SetBody / SetResponseBody)
+	// also do not propagate to the wire under observe — the plugin's
+	// decision logic runs identically, but its effect is muted.
+	ErrorPolicyObserve ErrorPolicy = "observe"
+
+	// ErrorPolicyOff disables the plugin. The plugin is not dispatched.
+	// Off is an operator kill-switch without a redeploy.
+	ErrorPolicyOff ErrorPolicy = "off"
+)
+
+// Valid reports whether p is a recognized ErrorPolicy. The empty
+// string is valid and means "use the default" (enforce); callers that
+// need the defaulted value use the Resolved method instead.
+func (p ErrorPolicy) Valid() bool {
+	switch p {
+	case "", ErrorPolicyEnforce, ErrorPolicyObserve, ErrorPolicyOff:
+		return true
+	default:
+		return false
+	}
+}
+
+// Resolved returns the policy with "" normalized to ErrorPolicyEnforce.
+// Callers that dispatch on policy value should use Resolved so they
+// don't have to treat "" as a synonym for "enforce" themselves.
+func (p ErrorPolicy) Resolved() ErrorPolicy {
+	if p == "" {
+		return ErrorPolicyEnforce
+	}
+	return p
+}

--- a/authbridge/authlib/plugins/jwtvalidation/plugin.go
+++ b/authbridge/authlib/plugins/jwtvalidation/plugin.go
@@ -162,7 +162,7 @@ type JWTValidation struct {
 func NewJWTValidation() *JWTValidation { return &JWTValidation{} }
 
 func init() {
-	plugins.RegisterPlugin("jwt-validation", func() pipeline.Plugin { return NewJWTValidation() })
+	plugins.RegisterBuiltin("jwt-validation", func() pipeline.Plugin { return NewJWTValidation() })
 }
 
 func (p *JWTValidation) Name() string { return "jwt-validation" }

--- a/authbridge/authlib/plugins/registry.go
+++ b/authbridge/authlib/plugins/registry.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	"fmt"
+	"log/slog"
 	"sort"
 	"sync"
 
@@ -26,6 +27,22 @@ var (
 	registry   = map[string]PluginFactory{}
 )
 
+// reservedBuiltinNames are plugin names owned by authlib's built-in
+// gate plugins. Third-party plugins may not register or unregister
+// them: a custom plugin named "jwt-validation" or "token-exchange"
+// would silently replace the shipped auth gates, which is an
+// authentication bypass dressed as a feature. Built-ins register
+// themselves via RegisterBuiltin (below), which bypasses this set.
+//
+// Parsers (a2a-parser, mcp-parser, inference-parser) are deliberately
+// NOT reserved — replacing a parser is a legitimate extension point
+// (a team might ship a dialect-specific A2A parser), and it's
+// observational, not security-relevant.
+var reservedBuiltinNames = map[string]bool{
+	"jwt-validation": true,
+	"token-exchange": true,
+}
+
 // RegisterPlugin adds a plugin factory under name. Intended to be
 // called from package init() functions of plugin implementations:
 //
@@ -49,6 +66,29 @@ var (
 // Empty name or nil factory also panics — both are programmer errors,
 // not recoverable conditions.
 func RegisterPlugin(name string, factory PluginFactory) {
+	if reservedBuiltinNames[name] {
+		panic(fmt.Sprintf("plugins: %q is a reserved built-in name; custom plugins cannot override it (use a different name)", name))
+	}
+	registerPlugin(name, factory)
+}
+
+// RegisterBuiltin is the in-tree equivalent of RegisterPlugin for
+// authlib's own gate plugins (jwt-validation, token-exchange). It
+// exists so built-ins can register names listed in
+// reservedBuiltinNames — which RegisterPlugin refuses for everyone
+// else. Not part of the third-party plugin API; only authlib's own
+// plugin packages should call it.
+//
+// The unexported registerPlugin does the actual work; having two
+// exported entry points lets RegisterPlugin enforce the reserved-name
+// rule while RegisterBuiltin bypasses it.
+func RegisterBuiltin(name string, factory PluginFactory) {
+	registerPlugin(name, factory)
+}
+
+// registerPlugin is the shared implementation behind RegisterPlugin
+// and RegisterBuiltin. The panic checks here apply to both.
+func registerPlugin(name string, factory PluginFactory) {
 	if name == "" {
 		panic("plugins: RegisterPlugin called with empty name")
 	}
@@ -61,6 +101,14 @@ func RegisterPlugin(name string, factory PluginFactory) {
 		panic(fmt.Sprintf("plugins: %q already registered", name))
 	}
 	registry[name] = factory
+}
+
+// IsReservedBuiltin reports whether name is a reserved authlib
+// built-in gate plugin. Exposed so higher-level validators (config
+// loader, chain-placement check) can produce helpful error messages
+// without duplicating the reserved-names list.
+func IsReservedBuiltin(name string) bool {
+	return reservedBuiltinNames[name]
 }
 
 // RegisteredPlugins returns the names of every registered plugin in
@@ -88,6 +136,79 @@ func factoryFor(name string) (PluginFactory, bool) {
 	return f, ok
 }
 
+// ChainDirection identifies which side of the pipeline a Build call is
+// producing. The zero value deliberately has no valid meaning — callers
+// that don't care about built-in placement validation use Build (which
+// uses ChainUnspecified and skips the check). Callers that do care use
+// BuildChain with Inbound or Outbound so misplaced gates fail loudly.
+type ChainDirection int
+
+const (
+	// ChainUnspecified disables built-in placement validation. Used by
+	// callers that don't know the chain direction (tests, tools that
+	// build a single list without inbound/outbound semantics).
+	ChainUnspecified ChainDirection = iota
+	ChainInbound
+	ChainOutbound
+)
+
+// builtinChainExpectation records which chain each reserved built-in
+// gate is expected to appear on. A misplaced gate is a silent auth
+// bypass (jwt-validation in the outbound chain never runs inbound
+// traffic through auth; token-exchange in inbound attaches a useless
+// token to the wrong direction). Validated in BuildChain.
+var builtinChainExpectation = map[string]ChainDirection{
+	"jwt-validation": ChainInbound,
+	"token-exchange": ChainOutbound,
+}
+
+// BuildChain is Build plus chain-aware placement validation: it rejects
+// a built-in gate appearing in the wrong chain (e.g., jwt-validation
+// configured on the outbound side). Chain-agnostic callers use Build.
+//
+// Validation runs BEFORE factory construction so a misplaced gate
+// produces an error instead of attempting to Configure an off-chain
+// plugin.
+func BuildChain(direction ChainDirection, entries []config.PluginEntry, opts ...pipeline.Option) (*pipeline.Pipeline, error) {
+	for _, e := range entries {
+		// Reserved built-ins cannot run under a non-enforce policy:
+		// on_error: observe on jwt-validation is an auth bypass, and
+		// on_error: off removes the gate entirely. The placement
+		// check below is the companion seal; together they prevent
+		// YAML from silently disabling the shipped auth gates.
+		if IsReservedBuiltin(e.Name) && e.OnError.Resolved() != pipeline.ErrorPolicyEnforce {
+			return nil, fmt.Errorf(
+				"plugin %q is a reserved built-in gate and must run with on_error: enforce (got %q); shadow mode and off are not permitted for auth plugins",
+				e.Name, e.OnError)
+		}
+		if direction == ChainUnspecified {
+			continue
+		}
+		want, reserved := builtinChainExpectation[e.Name]
+		if !reserved {
+			continue
+		}
+		if want != direction {
+			return nil, fmt.Errorf("plugin %q is a reserved built-in for the %s chain; it must not appear in the %s chain",
+				e.Name, directionName(want), directionName(direction))
+		}
+	}
+	return Build(entries, opts...)
+}
+
+// directionName returns the YAML keyword matching a ChainDirection.
+// Internal to the package — only error messages need the string form.
+func directionName(d ChainDirection) string {
+	switch d {
+	case ChainInbound:
+		return "inbound"
+	case ChainOutbound:
+		return "outbound"
+	default:
+		return "unspecified"
+	}
+}
+
 // Build constructs a pipeline from an ordered list of plugin entries.
 // For every plugin that implements pipeline.Configurable, Build calls
 // Configure with the entry's Config bytes (nil when omitted). Passing
@@ -97,9 +218,25 @@ func factoryFor(name string) (PluginFactory, bool) {
 //
 // Unknown plugin names fail fast with an error that lists every
 // currently-registered plugin — typo-catching diagnostic.
+//
+// Build does NOT validate that reserved built-in gates appear in the
+// correct chain — callers that know their direction (inbound vs
+// outbound) should call BuildChain instead.
 func Build(entries []config.PluginEntry, opts ...pipeline.Option) (*pipeline.Pipeline, error) {
 	ps := make([]pipeline.Plugin, 0, len(entries))
+	policies := make([]pipeline.ErrorPolicy, 0, len(entries))
 	for _, e := range entries {
+		// ErrorPolicyOff removes the plugin from the running
+		// pipeline entirely — no Configure, no Init, no dispatch.
+		// Operators use off as a kill-switch without deleting the
+		// entry from YAML (so a later re-enable is a single field
+		// flip). A mistyped on_error was already rejected at
+		// config.Load time, so reaching here means the value is
+		// valid.
+		if e.OnError.Resolved() == pipeline.ErrorPolicyOff {
+			slog.Info("plugins: skipping plugin (on_error: off)", "plugin", e.Name)
+			continue
+		}
 		factory, ok := factoryFor(e.Name)
 		if !ok {
 			return nil, fmt.Errorf("unknown plugin %q (registered: %v)", e.Name, RegisteredPlugins())
@@ -113,6 +250,8 @@ func Build(entries []config.PluginEntry, opts ...pipeline.Option) (*pipeline.Pip
 			return nil, fmt.Errorf("plugin %q does not accept configuration", e.Name)
 		}
 		ps = append(ps, p)
+		policies = append(policies, e.OnError.Resolved())
 	}
+	opts = append(opts, pipeline.WithPolicies(policies...))
 	return pipeline.New(ps, opts...)
 }

--- a/authbridge/authlib/plugins/registry_test.go
+++ b/authbridge/authlib/plugins/registry_test.go
@@ -86,6 +86,106 @@ func TestUnregisterPlugin(t *testing.T) {
 	}
 }
 
+// TestRegisterPlugin_ReservedBuiltin_Panics locks the seal on built-in
+// gate names. A custom plugin registering "jwt-validation" or
+// "token-exchange" would silently replace the shipped auth gates — an
+// authentication bypass. RegisterPlugin must refuse reserved names so
+// a mistake at import time fails loud instead of at request time.
+func TestRegisterPlugin_ReservedBuiltin_Panics(t *testing.T) {
+	for _, name := range []string{"jwt-validation", "token-exchange"} {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				r := recover()
+				if r == nil {
+					t.Errorf("expected panic for reserved name %q", name)
+					return
+				}
+				msg, ok := r.(string)
+				if !ok {
+					t.Errorf("panic value not a string: %T", r)
+					return
+				}
+				if !containsSubstring(msg, "reserved built-in name") {
+					t.Errorf("panic message should explain the reservation: %q", msg)
+				}
+			}()
+			RegisterPlugin(name, func() pipeline.Plugin { return nil })
+		})
+	}
+}
+
+// TestIsReservedBuiltin verifies the exported predicate — higher-level
+// validators consume it to avoid duplicating the reserved-names list.
+func TestIsReservedBuiltin(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"jwt-validation", true},
+		{"token-exchange", true},
+		{"a2a-parser", false}, // parsers are intentionally not reserved
+		{"mcp-parser", false},
+		{"custom-guardrail", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := IsReservedBuiltin(c.name); got != c.want {
+			t.Errorf("IsReservedBuiltin(%q) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// TestBuildChain_RejectsMisplacedBuiltin covers the placement seal:
+// jwt-validation must not appear in outbound, token-exchange must not
+// appear in inbound. Silent misplacement would disable auth.
+func TestBuildChain_RejectsMisplacedBuiltin(t *testing.T) {
+	cases := []struct {
+		name      string
+		direction ChainDirection
+		entry     string
+		wantChain string // chain keyword that should appear in the error
+	}{
+		{"jwt-validation-on-outbound", ChainOutbound, "jwt-validation", "inbound"},
+		{"token-exchange-on-inbound", ChainInbound, "token-exchange", "outbound"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := BuildChain(c.direction, []config.PluginEntry{{Name: c.entry}})
+			if err == nil {
+				t.Fatalf("expected error for %s on %v chain", c.entry, c.direction)
+			}
+			if !containsSubstring(err.Error(), c.entry) {
+				t.Errorf("error should name the misplaced plugin: %q", err)
+			}
+			if !containsSubstring(err.Error(), c.wantChain) {
+				t.Errorf("error should mention the expected chain %q: %q", c.wantChain, err)
+			}
+		})
+	}
+}
+
+// TestBuildChain_AcceptsCorrectPlacement is the positive counterpart —
+// built-ins on their expected chain must pass placement validation.
+// (The plugin's own Configure may still fail because no config is
+// provided; we only care that the placement check didn't trip.)
+func TestBuildChain_AcceptsCorrectPlacement(t *testing.T) {
+	cases := []struct {
+		direction ChainDirection
+		entry     string
+	}{
+		{ChainInbound, "jwt-validation"},
+		{ChainOutbound, "token-exchange"},
+	}
+	for _, c := range cases {
+		t.Run(c.entry, func(t *testing.T) {
+			_, err := BuildChain(c.direction, []config.PluginEntry{{Name: c.entry}})
+			if err != nil && containsSubstring(err.Error(), "reserved built-in") {
+				t.Errorf("placement check wrongly rejected %s on its own chain: %q", c.entry, err)
+			}
+		})
+	}
+}
+
 // TestBuild_UnknownPlugin_ListsRegistered verifies the "unknown plugin"
 // error includes the list of registered names so operators get a
 // typo-catching diagnostic instead of a generic not-found.

--- a/authbridge/authlib/plugins/tokenexchange/plugin.go
+++ b/authbridge/authlib/plugins/tokenexchange/plugin.go
@@ -205,7 +205,7 @@ type TokenExchange struct {
 func NewTokenExchange() *TokenExchange { return &TokenExchange{} }
 
 func init() {
-	plugins.RegisterPlugin("token-exchange", func() pipeline.Plugin { return NewTokenExchange() })
+	plugins.RegisterBuiltin("token-exchange", func() pipeline.Plugin { return NewTokenExchange() })
 }
 
 func (p *TokenExchange) Name() string { return "token-exchange" }

--- a/authbridge/cmd/authbridge/main.go
+++ b/authbridge/cmd/authbridge/main.go
@@ -115,11 +115,11 @@ func main() {
 		if err := config.Validate(c); err != nil {
 			return nil, nil, nil, err
 		}
-		in, err := plugins.Build(c.Pipeline.Inbound.Plugins)
+		in, err := plugins.BuildChain(plugins.ChainInbound, c.Pipeline.Inbound.Plugins)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("inbound: %w", err)
 		}
-		out, err := plugins.Build(c.Pipeline.Outbound.Plugins)
+		out, err := plugins.BuildChain(plugins.ChainOutbound, c.Pipeline.Outbound.Plugins)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("outbound: %w", err)
 		}

--- a/authbridge/docs/plugin-reference.md
+++ b/authbridge/docs/plugin-reference.md
@@ -40,15 +40,86 @@ pipeline:
           audience_file: "/shared/client-id.txt"
           bypass_paths:
             - "/healthz"
+      - name: pii-scrubber
+        on_error: observe                # canary: log would-blocks, don't block
+        config:
+          patterns: [ssn, credit_card]
 ```
 
 - **`name`** — required. Must match a key in the plugin registry.
 - **`id`** — optional. Defaults to `name`. Lets two instances of the same
   plugin coexist with different config (not yet exercised, but the shape
   is reserved).
+- **`on_error`** — optional. One of `enforce` (default), `observe`, or
+  `off`. See [`on_error` policy](#on_error-policy) below.
 - **`config`** — optional. Arbitrary YAML sub-tree owned by the plugin.
   The framework does not interpret it; it's captured as `json.RawMessage`
   and handed to `Configure`.
+
+## `on_error` policy
+
+`on_error` is a **framework-owned** wrapper around the plugin — plugin
+authors do not read it, implement it, or branch on it. Its job is to
+let operators roll out a new guardrail without risking production.
+
+| Policy | Plugin dispatched? | Reject → | Body mutation → | Typical use |
+|---|---|---|---|---|
+| `enforce` (default) | yes | HTTP error, pipeline stops | applied to wire | Production guardrails |
+| `observe` | yes | shadow `Invocation`, request passes | suppressed (no-op) | Canarying a new plugin |
+| `off` | **no** | n/a | n/a | Kill-switch without redeploy |
+
+### Observe is plugin-transparent
+
+Under `observe`, the plugin's `OnRequest` / `OnResponse` runs exactly as
+under `enforce`. If it returns `pipeline.Deny(...)`, the framework
+intercepts: it marks the plugin's `Invocation` with `Shadow: true`, logs
+a `WARN pipeline: plugin would have denied (shadow)` line, and continues
+the pipeline. The request is not blocked. Body-mutation calls
+(`SetBody` / `SetResponseBody`) likewise record a `Shadow: true`
+invocation but do not alter the in-memory body or the wire bytes —
+downstream plugins and the upstream see the original.
+
+The upshot: the same plugin binary, dispatched the same way, is safe to
+ship in `observe` for a week while operators watch shadow metrics,
+then flipped to `enforce` with confidence.
+
+### Shadow timeline query
+
+Operators count would-have-blocked events by filtering Invocations on
+`shadow: true`:
+
+- `count(Invocations where shadow=true)` — rollout candidate volume
+- `count(Invocations where shadow=true and action="deny") by plugin` —
+  per-plugin shadow block rate
+- `count(Invocations where shadow=false and action="deny") by plugin` —
+  enforced denials (unchanged by this feature)
+
+### Reserved built-in gates are locked
+
+`jwt-validation` and `token-exchange` are **always** dispatched under
+`enforce`. Setting `on_error: observe` or `on_error: off` on either of
+them fails at startup with a `reserved built-in gate` error. Shadowing
+auth is an authentication bypass dressed as a feature.
+
+### Off vs. removing the entry
+
+Both achieve "don't run this plugin." `off` exists so a single field
+flip re-enables the plugin without re-adding the whole block to YAML.
+An `off` entry is not `Configure`d and not added to the running
+pipeline; its `config:` subtree is not validated. Remove the entry
+entirely if you don't anticipate re-enabling it.
+
+### What `on_error` does not do
+
+- Not a circuit breaker — a crashing plugin in `observe` still crashes
+  on every request. Bound crash loops with a separate mechanism.
+- Not sampling — `observe` runs the plugin on 100% of traffic.
+  Percentage rollout is a future feature.
+- Not a timeout — a slow plugin still blocks the request. Per-plugin
+  deadlines are a separate knob.
+- Does not cover runtime `error` returns / panics from `OnRequest`.
+  Policy applies only to intentional `Reject` actions; a panic in
+  `observe` still surfaces as a 500.
 
 ## The Configurable interface
 
@@ -315,6 +386,13 @@ type Invocation struct {
     // Plugin-specific diagnostic context. Opaque to the framework;
     // abctl renders as key=value rows in the detail pane.
     Details map[string]string
+
+    // Shadow is framework-set; plugins never write it. True when the
+    // plugin ran under on_error: observe and its decision (deny or
+    // modify) was NOT applied to the request. Dashboards partition
+    // on Shadow: enforced outcomes (shadow=false) vs rollout
+    // candidates (shadow=true).
+    Shadow bool
 }
 ```
 

--- a/authbridge/docs/plugin-tutorial.md
+++ b/authbridge/docs/plugin-tutorial.md
@@ -129,6 +129,26 @@ When you want to emit an invocation AND reject in one call, use
 return pctx.DenyAndRecord("caller_not_allowed", "policy.forbidden", "caller not permitted")
 ```
 
+### Ship in observe mode first
+
+For any guardrail or policy plugin that can false-positive — PII
+detection, prompt-injection scoring, jailbreak classifiers — roll it
+out under `on_error: observe` before flipping to `enforce`:
+
+```yaml
+- name: your-new-guardrail
+  on_error: observe          # log would-blocks, don't actually block
+  config: { ... }
+```
+
+In `observe`, the framework converts the plugin's `Deny` into a
+pass-through and marks the deny `Invocation` with `Shadow: true`. Your
+plugin code is unchanged — the rollout knob lives outside the plugin.
+After a soak period, compare the shadow-deny rate against your
+acceptable false-positive threshold, then flip to `enforce`. See
+[`plugin-reference.md`](./plugin-reference.md#on_error-policy) for
+full semantics.
+
 ## Step 4 — Add config
 
 If your plugin needs configurable knobs, implement


### PR DESCRIPTION
## Summary

- **Per-plugin `on_error: enforce | observe | off`** — lets operators canary a new guardrail in shadow mode before flipping to enforce, and kill-switch a misbehaving plugin without redeploying. Plugin code is unchanged across policies: the framework intercepts the plugin's `Reject` and converts it, and suppresses `SetBody` / `SetResponseBody` so the wire sees the original bytes.
- **Sealed built-in registry** — `jwt-validation` and `token-exchange` are reserved names; custom plugins cannot override them. New `BuildChain` rejects built-in gates placed on the wrong chain (e.g., `jwt-validation` in outbound) and locks reserved gates to `on_error: enforce` — shadowing auth is an authentication bypass dressed as a feature.
- **`Invocation.Shadow` field** — framework-set, true when the plugin ran under `observe` and its decision was not applied. Dashboards partition on `shadow` to count rollout candidates vs enforced outcomes without muddying existing "blocked requests" queries.

## Why

This unblocks third-party guardrail adoption. Without shadow mode, no operator enables a plugin from an external vendor in production: one false-positive and rollback. With `on_error: observe`, a plugin ships in `observe` for a week, operators watch the shadow-block rate (`WARN pipeline: plugin would have denied (shadow)` logs + `Invocation.Shadow=true` in `/v1/sessions`), then flip to `enforce` with confidence.

## Not included (deliberate scope limits)

- Not a circuit breaker — a crashing plugin in `observe` still crashes every request. Bound crash loops separately.
- Not sampling — `observe` runs at 100%. Percentage rollout is a future feature.
- Not a timeout — a slow plugin still blocks. Per-plugin deadlines are a separate knob.
- Does not cover panics / runtime `error` returns from `OnRequest` — policy applies only to intentional `Reject` actions; a panic in `observe` still surfaces as 500.

## Test plan

- [x] `go test ./...` green in both `authlib/` and `cmd/authbridge/`
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean on touched files
- [ ] Verify existing configs (no `on_error` field) behave unchanged (default = enforce)
- [ ] Attempt `on_error: observe` on `jwt-validation` in a dev deploy; confirm startup error
- [ ] Deploy a guardrail with `on_error: observe`, confirm `WARN pipeline: plugin would have denied (shadow)` logs fire but requests pass through
- [ ] Verify `/v1/sessions/<id>` shows `shadow: true` on would-have-denied invocations
- [ ] Confirm `on_error: off` on a plugin removes it from `/stats` and `/config` — entry is not dispatched

## Migration

Zero-migration. Missing `on_error` = current behavior (`enforce`). No public interface change for plugin authors. Placement validation at `BuildChain` time is the only new error surface a valid existing deployment could hit, and only if the deployment has `jwt-validation` in outbound or `token-exchange` in inbound — both of which are silent auth bypasses today.

## Docs

- New `## on_error policy` section in `authbridge/docs/plugin-reference.md` (table, observe semantics, shadow query examples, built-in lock, off vs remove, non-goals)
- Invocation struct field reference updated with `Shadow`
- New "Ship in observe mode first" subsection in `authbridge/docs/plugin-tutorial.md` Step 3

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
