### PR TITLE
fix: a2a-parser reads contextId from params.message

### DIFF
--- a/authbridge/authlib/plugins/a2aparser/plugin.go
+++ b/authbridge/authlib/plugins/a2aparser/plugin.go
@@ -56,12 +56,25 @@ func (p *A2AParser) OnRequest(_ context.Context, pctx *pipeline.Context) pipelin
 	// Extract message fields generically — any method with params.message
 	// gets full extraction (forward-compatible with future A2A methods).
 	// A2A spec uses "contextId" (current) or "sessionId" (older drafts).
+	// Some A2A clients (notably the Python SDK used by the kagenti backend)
+	// place contextId INSIDE params.message rather than at the top-level
+	// params, so fall through to params.message.contextId when neither
+	// top-level slot is set. Without this fallback every inbound turn of
+	// an established conversation lands in the "default" session bucket
+	// instead of the real contextId — response-phase extraction later
+	// populates A2A.SessionID, but that's after the listener has already
+	// keyed the event, so abctl shows every turn under "default".
 	ext.SessionID = rpc.StringParam("contextId")
 	if ext.SessionID == "" {
 		ext.SessionID = rpc.StringParam("sessionId")
 	}
 	ext.TaskID = rpc.StringParam("taskId")
 	if msg := rpc.MapParam("message"); msg != nil {
+		if ext.SessionID == "" {
+			if cid, ok := msg["contextId"].(string); ok {
+				ext.SessionID = cid
+			}
+		}
 		if role, ok := msg["role"].(string); ok {
 			ext.Role = role
 		}

--- a/authbridge/authlib/plugins/a2aparser/plugin_test.go
+++ b/authbridge/authlib/plugins/a2aparser/plugin_test.go
@@ -88,6 +88,56 @@ func TestA2AParser_MessageStream(t *testing.T) {
 	}
 }
 
+// The A2A Python SDK (and the kagenti backend that wraps it) places contextId
+// inside params.message on established-conversation turns — not at the
+// top-level params that the earlier extraction path looked at. Without this
+// fallback, the listener's request-phase session lookup sees an empty
+// SessionID and buckets every turn under "default" instead of the real
+// contextId, leading to a single overflowing "default" session in abctl.
+func TestA2AParser_MessageStream_ContextIDInsideMessage(t *testing.T) {
+	p := NewA2AParser()
+	pctx := &pipeline.Context{
+		Body: []byte(`{"jsonrpc":"2.0","method":"message/stream","id":"req-9","params":{"message":{"role":"user","parts":[{"kind":"text","text":"weather in ohio"}],"messageId":"msg-inside","contextId":"ctx-from-message"}}}`),
+	}
+
+	action := p.OnRequest(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	ext := pctx.Extensions.A2A
+	if ext == nil {
+		t.Fatal("Extensions.A2A is nil")
+	}
+	if ext.SessionID != "ctx-from-message" {
+		t.Errorf("SessionID = %q, want %q (from params.message.contextId)",
+			ext.SessionID, "ctx-from-message")
+	}
+	if ext.MessageID != "msg-inside" {
+		t.Errorf("MessageID = %q, want %q", ext.MessageID, "msg-inside")
+	}
+}
+
+// Top-level contextId wins when both are present. Clients occasionally send
+// both fields (SDK emits one at the message level, middleware sets the other
+// at the envelope level); the A2A spec treats the envelope-level contextId
+// as the session key, and the response-phase path already prefers request-
+// side over server-minted — this test pins that ordering on the request side.
+func TestA2AParser_MessageStream_TopLevelContextIDWins(t *testing.T) {
+	p := NewA2AParser()
+	pctx := &pipeline.Context{
+		Body: []byte(`{"jsonrpc":"2.0","method":"message/stream","id":"req-10","params":{"contextId":"ctx-top-level","message":{"role":"user","parts":[{"kind":"text","text":"hi"}],"messageId":"msg-both","contextId":"ctx-inside-message"}}}`),
+	}
+
+	action := p.OnRequest(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	if pctx.Extensions.A2A.SessionID != "ctx-top-level" {
+		t.Errorf("SessionID = %q, want %q (top-level params.contextId should win)",
+			pctx.Extensions.A2A.SessionID, "ctx-top-level")
+	}
+}
+
 func TestA2AParser_MultipleParts(t *testing.T) {
 	p := NewA2AParser()
 	pctx := &pipeline.Context{


### PR DESCRIPTION
## Summary

The request-phase A2A parser only looks for `contextId` (and the older `sessionId`) at the top-level `params` slot. Real clients — notably the A2A Python SDK used by the kagenti backend — place `contextId` **inside `params.message`** on established-conversation turns. The parser misses it, so `pctx.Extensions.A2A.SessionID` is empty at the moment the listener keys the session event, and every turn of an established conversation lands in the **"default"** bucket in the session store.

Response-phase extraction (`extractSessionID(pctx.ResponseBody)`) does walk the response body and populates `A2A.SessionID` via pointer mutation, so the stored event *displays* with a real `sessionId` — but that happens after the event has already been appended to the wrong session. Net effect for operators using `abctl`: a single "default" session that grows unbounded, no per-conversation bucketing, no clean way to pivot between conversations.

## The fix

Add a fallback in `OnRequest`: when both top-level `params.contextId` and `params.sessionId` are empty, check `params.message.contextId` before giving up. Top-level `params.contextId` still wins when both are present — the A2A spec treats the envelope-level `contextId` as authoritative, and this also keeps the request-side behavior consistent with the existing response-phase precedence rule (request-side `contextId` wins over server-minted).

## Evidence (captured live)

Weather agent in proxy-sidecar mode, 3 chat turns from the kagenti UI (each continuing the same conversation):

Before this PR:
```json
{"sessions":[{"id":"default","eventCount":3,"active":true}]}
```
All 3 events are under `"default"`, each with `a2a.sessionId: "2988719d-bd40-44f7-a067-3941d1402ef4"` — populated from the response side, after session keying had already locked them to "default".

Expected after (verified against the patched parser in unit tests):
- Turn 1: no `contextId` yet anywhere → bucket `"default"` (1 event). Correct.
- Turn 2 onward: request body has `params.message.contextId` → parser picks it up → event keyed to session `2988719d-...`.

## Tests

- `TestA2AParser_MessageStream_ContextIDInsideMessage` — the specific regression this fixes (`contextId` only at message-level).
- `TestA2AParser_MessageStream_TopLevelContextIDWins` — precedence (both present; top-level wins).

Existing test `TestA2AParser_MessageStream` (top-level-only) continues to pass.

## Test plan

- [x] `go vet ./plugins/...` — clean
- [x] `go test ./plugins -run MessageStream -v` — 3 tests pass (existing + 2 new)
- [x] Manual end-to-end: observed the current broken behavior on a Kind cluster (3 turns into "default")
- [ ] Operator / kagenti picks up a sidecar image built from this commit and reruns the same 3 turns — expect session `2988719d-...` to appear with 2 events (turns 2 + 3)
- [ ] CI green

Assisted-By: Claude (Anthropic AI) &lt;noreply@anthropic.com&gt;
