### PR TITLE
fix(weather-demo): teach pick_log_container the proxy-sidecar container name

### DIFF
--- a/authbridge/demos/weather-agent/deploy_and_verify_advanced.sh
+++ b/authbridge/demos/weather-agent/deploy_and_verify_advanced.sh
@@ -121,13 +121,24 @@ pick_log_container() {
   local pod=$1
   local names
   names=$(kubectl get pod -n "$NAMESPACE" "$pod" -o jsonpath='{.spec.containers[*].name}' | tr ' ' '\n')
-  if echo "$names" | grep -qx 'envoy-proxy'; then
-    echo envoy-proxy
-  elif echo "$names" | grep -qx 'authbridge'; then
-    echo authbridge
-  else
-    die "pod $pod has neither envoy-proxy nor authbridge container ($names)"
-  fi
+  # Container name depends on the resolved AuthBridge mode (per
+  # kagenti-operator/internal/webhook/injector/container_builder.go):
+  #   proxy-sidecar (cluster default after kagenti-operator#361):
+  #     AuthBridgeProxyContainerName = "authbridge-proxy"
+  #   envoy-sidecar:
+  #     EnvoyProxyContainerName = "envoy-proxy"
+  # The earlier `combinedSidecar` feature gate produced a bare
+  # "authbridge" container, but that gate (and the constant) were
+  # removed in #361 — and this script already requires the post-#361
+  # AgentRuntime CRD just above, so there's no pre-#361 path to
+  # support here.
+  for c in authbridge-proxy envoy-proxy; do
+    if echo "$names" | grep -qx "$c"; then
+      echo "$c"
+      return 0
+    fi
+  done
+  die "pod $pod has no AuthBridge sidecar (expected one of authbridge-proxy / envoy-proxy; got: $(echo $names))"
 }
 
 TOOL_LOG_C=$(pick_log_container "$ADV_TOOL_POD")


### PR DESCRIPTION
## Summary

`pick_log_container` in `deploy_and_verify_advanced.sh` only knew two AuthBridge sidecar container names — `envoy-proxy` (envoy-sidecar mode) and `authbridge`. After #411 + kagenti-operator#361 the cluster default became proxy-sidecar with container name **`authbridge-proxy`**, which the script doesn't recognize, so every CI run dies on the first `pick_log_container` call.

Caught on [kagenti#1592](https://github.com/kagenti/kagenti/pull/1592)'s `Deploy & Test` lane:

```
ERROR: pod weather-tool-advanced-... has neither envoy-proxy
       nor authbridge container (mcp
       authbridge-proxy)
```

The pod actually had `mcp` + `authbridge-proxy` — the webhook injected fine and the demo flow was healthy. The script just couldn't tell which container to read logs from. The error message itself was misleading (the multi-line container list got split across two log lines, so casual readers saw "(mcp" and assumed no sidecar was injected).

## Fix

The two recognized names in `pick_log_container` are now the only two the operator actually produces today:

* `authbridge-proxy` — proxy-sidecar mode, the post-#361 cluster default. From `AuthBridgeProxyContainerName` in `kagenti-operator/internal/webhook/injector/constants.go:34`.
* `envoy-proxy` — envoy-sidecar mode. From `EnvoyProxyContainerName` in `kagenti-operator/internal/webhook/injector/container_builder.go:34`.

The bare `authbridge` name from the pre-#361 `combinedSidecar` feature gate is **not kept** as a fallback. That gate (and its `AuthBridgeContainerName = "authbridge"` constant) was removed in #361, and `deploy_and_verify_advanced.sh` already requires the post-#361 `agentruntimes.agent.kagenti.dev` CRD a few lines above, so there's no pre-#361 path to keep working.

Also reformat the diagnostic message — wrap `$names` in `$(echo $names)` so the pod's container list renders on a single line, making the error read `expected one of …; got: mcp authbridge-proxy` instead of visually truncating.

## Test plan

- [x] `bash -n` on the script
- [x] `grep -r` for similar restricted name lists across other shell / Python helpers — none found
- [x] Cross-checked against the operator's container-name constants — only the two names this PR keeps are still produced
- [ ] Re-run kagenti#1592's `Deploy & Test` once this lands and the e2e clone of extensions main picks up the fix

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
