### PR TITLE
feat(abctl): Events-table PHASE rendering — hide skips, tree glyphs, lifecycle-only PHASE

### DIFF
--- a/authbridge/cmd/abctl/README.md
+++ b/authbridge/cmd/abctl/README.md
@@ -67,6 +67,7 @@ The UI has three panes. `Enter` drills in; `Esc` backs out.
 | `Enter` / `→` / `l` | sessions, events | drill into selection |
 | `Esc` / `←` / `h` | detail, events | back out |
 | `/` | sessions, events | filter (substring match; Enter commits, Esc cancels) |
+| `s` | events | toggle skip-row visibility (default: hidden; the events footer shows the hidden count) |
 | `p` | any | pause/resume stream |
 | `y` | detail | yank event JSON to `/tmp` |
 | `g` / `G` | lists | jump to top / bottom |

--- a/authbridge/cmd/abctl/tui/app.go
+++ b/authbridge/cmd/abctl/tui/app.go
@@ -101,11 +101,19 @@ type model struct {
 	connState connStateInfo
 
 	// UI state.
-	pane          paneID
-	selectedSess  string
-	filter        string
-	filtering     bool
-	paused        bool
+	pane         paneID
+	selectedSess string
+	filter       string
+	filtering    bool
+	paused       bool
+	// showSkips toggles whether Action=skip rows render in the events
+	// table. False (default) hides them — most operators care about
+	// allow/deny/modify/observe events. Toggle with `s`. hiddenSkips
+	// is the count from the most recent rebuildEventsTable, surfaced
+	// in the footer so a sparse-looking timeline doesn't read as
+	// data loss.
+	showSkips     bool
+	hiddenSkips   int
 	flash         string
 	flashUntil    time.Time
 	width, height int

--- a/authbridge/cmd/abctl/tui/events_pane.go
+++ b/authbridge/cmd/abctl/tui/events_pane.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -109,30 +110,28 @@ func (m *model) rebuildEventsTable() {
 		continuation := lastEvent == rs.event
 
 		var idCell, timeCell, dirCell, phaseCell, statusC, durCell, tokC, hostC string
+		// Up to two levels of (req, resp) span nesting are surfaced as
+		// box-drawing prefixes in PHASE so operators can trace pairs
+		// even when other rows interleave. Width fits the 6-char PHASE
+		// budget: outer (1) + inner (1) + base phase ("resp"/"deny" =
+		// 4) → 6 max.
+		prefix := spanGlyphs[i].prefix()
 		if !continuation {
 			if id, ok := eventIDs[rs.event]; ok {
 				idCell = strconv.Itoa(id)
 			}
 			timeCell = rs.event.At.Format("15:04:05.00")
 			dirCell = shortDirection(rs.event.Direction)
-			phaseCell = shortPhase(rs.event.Phase)
-			// Tree-glyph prefix (┌ / │ / └) when this row sits at a
-			// pair endpoint or inside a pair span. The 6-char PHASE
-			// width budget accommodates the prefix plus the longest
-			// base phase ("resp"/"deny" → 5 chars total).
-			if g := spanGlyphs[i]; g != glyphNone {
-				phaseCell = string(rune(g)) + phaseCell
-			}
+			phaseCell = prefix + shortPhase(rs.event.Phase)
 			statusC = statusCell(*rs.event)
 			durCell = durationCell(*rs.event)
 			tokC = tokensCell(*rs.event)
 			hostC = truncStr(rs.event.Host, 20)
-		} else if g := spanGlyphs[i]; g == glyphMiddle {
-			// Continuation row inside a pair span: render the vertical
-			// connector even though the rest of the event-level columns
-			// stay blank, so the operator's eye can follow the pair
-			// across multi-invocation events.
-			phaseCell = string(rune(g))
+		} else if prefix != "" {
+			// Continuation row inside a pair span: render only the
+			// connectors (no base phase text) so the operator's eye
+			// can follow the pair across multi-invocation events.
+			phaseCell = prefix
 		}
 
 		rows = append(rows, table.Row{
@@ -236,47 +235,89 @@ const (
 	glyphEnd    spanGlyph = '└' // response row paired with an earlier request
 )
 
-// computeSpanGlyphs assigns each row a tree glyph drawn from its
-// position relative to ALL (req, resp) spans in the row list. Priority
-// when a row could carry multiple glyphs (overlapping pairs): end
-// beats start beats middle. The user only needs "this row is part of
-// some pair structure" — not which specific pair.
+// spanLevels holds the box-drawing glyphs for up to two levels of
+// nested (req, resp) spans on a single row. outer is the largest span
+// containing the row; inner is the next-largest. Deeper nesting is
+// not surfaced — operators only need the broad shape, not the full
+// nesting tree.
+type spanLevels struct {
+	outer spanGlyph
+	inner spanGlyph
+}
+
+// prefix returns the concatenated rune string for the PHASE-column
+// prefix: e.g. "│┌" when the row is inside an outer span and at the
+// start of an inner span; "└" alone when only an outer endpoint
+// applies; "" when the row is in no pair span.
+func (s spanLevels) prefix() string {
+	switch {
+	case s.outer == glyphNone:
+		return ""
+	case s.inner == glyphNone:
+		return string(rune(s.outer))
+	default:
+		return string([]rune{rune(s.outer), rune(s.inner)})
+	}
+}
+
+// computeSpanGlyphs assigns each row up to two tree glyphs (outer +
+// inner) drawn from its position relative to all (req, resp) spans in
+// the row list. The two largest spans containing the row are surfaced;
+// deeper nesting is dropped so the PHASE column doesn't blow its
+// 6-char width budget.
 //
 // pairs is the bidirectional map from pairInvocationRows: pairs[i]=j
 // AND pairs[j]=i for any matched pair (i, j). Unpaired rows are absent.
 // n is the total row count.
-func computeSpanGlyphs(pairs map[int]int, n int) []spanGlyph {
-	out := make([]spanGlyph, n)
+func computeSpanGlyphs(pairs map[int]int, n int) []spanLevels {
+	out := make([]spanLevels, n)
 	if len(pairs) == 0 {
 		return out
 	}
-	// First pass: stamp middle glyphs for every row strictly inside
-	// any pair span. A row may sit inside multiple overlapping spans;
-	// stamping is idempotent because the glyph is the same.
+	// Collect each pair (a, b) with a < b once; the resp→req mirror
+	// entries are skipped.
+	type span struct{ a, b int }
+	spans := make([]span, 0, len(pairs)/2)
 	for a, b := range pairs {
-		if a >= b {
-			continue // skip the resp→req mirror; iterate each pair once
-		}
-		for k := a + 1; k < b && k < n; k++ {
-			out[k] = glyphMiddle
+		if a < b {
+			spans = append(spans, span{a, b})
 		}
 	}
-	// Second pass: endpoints overwrite middle so the corners always win.
-	for a, b := range pairs {
-		if a >= b {
-			continue
+
+	glyphAt := func(s span, i int) spanGlyph {
+		switch {
+		case i == s.a:
+			return glyphStart
+		case i == s.b:
+			return glyphEnd
+		case s.a < i && i < s.b:
+			return glyphMiddle
 		}
-		if a < n {
-			// Don't overwrite end with start; if both fire on the same
-			// row (a chain that closes one pair and opens another at
-			// the same index), end wins because closing a pair is the
-			// stronger visual anchor.
-			if out[a] != glyphEnd {
-				out[a] = glyphStart
+		return glyphNone
+	}
+
+	for i := range n {
+		// Find every span this row participates in (endpoint or
+		// strictly inside).
+		var participating []span
+		for _, s := range spans {
+			if s.a <= i && i <= s.b {
+				participating = append(participating, s)
 			}
 		}
-		if b < n {
-			out[b] = glyphEnd
+		if len(participating) == 0 {
+			continue
+		}
+		// Sort by width descending — outer (widest) first, then inner.
+		// Stable so equal-width spans keep their declaration order
+		// (irrelevant in practice but keeps tests deterministic).
+		sort.SliceStable(participating, func(p, q int) bool {
+			return (participating[p].b - participating[p].a) >
+				(participating[q].b - participating[q].a)
+		})
+		out[i].outer = glyphAt(participating[0], i)
+		if len(participating) > 1 {
+			out[i].inner = glyphAt(participating[1], i)
 		}
 	}
 	return out

--- a/authbridge/cmd/abctl/tui/events_pane.go
+++ b/authbridge/cmd/abctl/tui/events_pane.go
@@ -80,9 +80,17 @@ func (m *model) rebuildEventsTable() {
 
 	rows := make([]table.Row, 0, len(rowSpecs))
 	m.visibleRows = m.visibleRows[:0]
+	m.hiddenSkips = 0
 	var lastEvent *pipeline.SessionEvent // most-recent event already rendered (post-filter)
 	for i, rs := range rowSpecs {
 		if m.filter != "" && !matchInvocationRow(rs, m.filter) {
+			continue
+		}
+		// Hide plugin-didn't-act rows by default. The footer hint
+		// shows the count + the toggle key so an operator who
+		// expected more rows can press `s` to surface them.
+		if !m.showSkips && isSkipRow(rs) {
+			m.hiddenSkips++
 			continue
 		}
 		// A "continuation" row is one whose event is the same as the
@@ -193,6 +201,15 @@ func (r invocationRow) pluginCell() string {
 		return "—"
 	}
 	return r.inv.Plugin
+}
+
+// isSkipRow reports whether r represents a plugin that ran but didn't
+// act on the message (jwt-validation on a bypass path, IBAC on a bypass
+// host, token-exchange with no matching route). Operators usually want
+// these hidden so the timeline shows decisions, not non-events. The
+// `s` keybinding toggles visibility.
+func isSkipRow(r invocationRow) bool {
+	return r.inv != nil && r.inv.Action == pipeline.ActionSkip
 }
 
 // flattenInvocations walks the event slice in order and, for each event,

--- a/authbridge/cmd/abctl/tui/events_pane.go
+++ b/authbridge/cmd/abctl/tui/events_pane.go
@@ -368,7 +368,12 @@ func shortPhase(p pipeline.SessionPhase) string {
 	case pipeline.SessionResponse:
 		return "resp"
 	case pipeline.SessionDenied:
-		return "deny"
+		// A denied event is a request that didn't reach the response
+		// phase. The terminal-deny semantics are already conveyed by
+		// the ACTION column ("deny") and STATUS column (4xx/5xx);
+		// rendering "deny" in PHASE too is duplicative. Show "req" so
+		// PHASE always communicates lifecycle position.
+		return "req"
 	}
 	return "?"
 }

--- a/authbridge/cmd/abctl/tui/events_pane.go
+++ b/authbridge/cmd/abctl/tui/events_pane.go
@@ -78,6 +78,11 @@ func (m *model) rebuildEventsTable() {
 	// └resp glyph, so the two visual cues stay consistent.
 	eventIDs := computeEventPairIDs(rowSpecs, pairs)
 
+	// Per-row tree glyph (┌ / │ / └) for the PHASE column. Lets
+	// operators trace a paired (req, resp) span visually even when
+	// other rows interleave between them.
+	spanGlyphs := computeSpanGlyphs(pairs, len(rowSpecs))
+
 	rows := make([]table.Row, 0, len(rowSpecs))
 	m.visibleRows = m.visibleRows[:0]
 	m.hiddenSkips = 0
@@ -111,17 +116,23 @@ func (m *model) rebuildEventsTable() {
 			timeCell = rs.event.At.Format("15:04:05.00")
 			dirCell = shortDirection(rs.event.Direction)
 			phaseCell = shortPhase(rs.event.Phase)
-			if rs.event.Phase == pipeline.SessionResponse {
-				if _, paired := pairs[i]; paired {
-					// └ prefix visually connects the response row to its
-					// request row in the same (direction, plugin) pair.
-					phaseCell = "└" + phaseCell
-				}
+			// Tree-glyph prefix (┌ / │ / └) when this row sits at a
+			// pair endpoint or inside a pair span. The 6-char PHASE
+			// width budget accommodates the prefix plus the longest
+			// base phase ("resp"/"deny" → 5 chars total).
+			if g := spanGlyphs[i]; g != glyphNone {
+				phaseCell = string(rune(g)) + phaseCell
 			}
 			statusC = statusCell(*rs.event)
 			durCell = durationCell(*rs.event)
 			tokC = tokensCell(*rs.event)
 			hostC = truncStr(rs.event.Host, 20)
+		} else if g := spanGlyphs[i]; g == glyphMiddle {
+			// Continuation row inside a pair span: render the vertical
+			// connector even though the rest of the event-level columns
+			// stay blank, so the operator's eye can follow the pair
+			// across multi-invocation events.
+			phaseCell = string(rune(g))
 		}
 
 		rows = append(rows, table.Row{
@@ -210,6 +221,65 @@ func (r invocationRow) pluginCell() string {
 // `s` keybinding toggles visibility.
 func isSkipRow(r invocationRow) bool {
 	return r.inv != nil && r.inv.Action == pipeline.ActionSkip
+}
+
+// spanGlyph names which corner / side of a (request, response) pair
+// span a row sits at, for tree-style rendering in the PHASE column.
+// rune (not byte) because the box-drawing characters are multi-byte
+// in UTF-8 and would overflow a byte.
+type spanGlyph rune
+
+const (
+	glyphNone   spanGlyph = 0
+	glyphStart  spanGlyph = '┌' // request row that pairs with a later response
+	glyphMiddle spanGlyph = '│' // row strictly between a paired request and its response
+	glyphEnd    spanGlyph = '└' // response row paired with an earlier request
+)
+
+// computeSpanGlyphs assigns each row a tree glyph drawn from its
+// position relative to ALL (req, resp) spans in the row list. Priority
+// when a row could carry multiple glyphs (overlapping pairs): end
+// beats start beats middle. The user only needs "this row is part of
+// some pair structure" — not which specific pair.
+//
+// pairs is the bidirectional map from pairInvocationRows: pairs[i]=j
+// AND pairs[j]=i for any matched pair (i, j). Unpaired rows are absent.
+// n is the total row count.
+func computeSpanGlyphs(pairs map[int]int, n int) []spanGlyph {
+	out := make([]spanGlyph, n)
+	if len(pairs) == 0 {
+		return out
+	}
+	// First pass: stamp middle glyphs for every row strictly inside
+	// any pair span. A row may sit inside multiple overlapping spans;
+	// stamping is idempotent because the glyph is the same.
+	for a, b := range pairs {
+		if a >= b {
+			continue // skip the resp→req mirror; iterate each pair once
+		}
+		for k := a + 1; k < b && k < n; k++ {
+			out[k] = glyphMiddle
+		}
+	}
+	// Second pass: endpoints overwrite middle so the corners always win.
+	for a, b := range pairs {
+		if a >= b {
+			continue
+		}
+		if a < n {
+			// Don't overwrite end with start; if both fire on the same
+			// row (a chain that closes one pair and opens another at
+			// the same index), end wins because closing a pair is the
+			// stronger visual anchor.
+			if out[a] != glyphEnd {
+				out[a] = glyphStart
+			}
+		}
+		if b < n {
+			out[b] = glyphEnd
+		}
+	}
+	return out
 }
 
 // flattenInvocations walks the event slice in order and, for each event,

--- a/authbridge/cmd/abctl/tui/events_pane_test.go
+++ b/authbridge/cmd/abctl/tui/events_pane_test.go
@@ -358,3 +358,76 @@ func TestFlattenPair_AuthOnlyEndToEnd(t *testing.T) {
 		t.Errorf("statusCell = %q, want 200", got)
 	}
 }
+
+// TestIsSkipRow checks the predicate the events table uses to decide
+// whether a row should be hidden under the default skip-hiding mode.
+// Only Action=skip rows return true; the pseudo-row with no
+// Invocation, and rows for any other action, are kept.
+func TestIsSkipRow(t *testing.T) {
+	cases := []struct {
+		name string
+		row  invocationRow
+		want bool
+	}{
+		{
+			name: "skip action",
+			row:  invocationRow{inv: &pipeline.Invocation{Action: pipeline.ActionSkip}},
+			want: true,
+		},
+		{
+			name: "allow action",
+			row:  invocationRow{inv: &pipeline.Invocation{Action: pipeline.ActionAllow}},
+			want: false,
+		},
+		{
+			name: "deny action",
+			row:  invocationRow{inv: &pipeline.Invocation{Action: pipeline.ActionDeny}},
+			want: false,
+		},
+		{
+			name: "observe action",
+			row:  invocationRow{inv: &pipeline.Invocation{Action: pipeline.ActionObserve}},
+			want: false,
+		},
+		{
+			name: "modify action",
+			row:  invocationRow{inv: &pipeline.Invocation{Action: pipeline.ActionModify}},
+			want: false,
+		},
+		{
+			name: "pseudo-row with no invocation",
+			// Parser-only events emit a pseudo-row so they remain
+			// reachable. These should never be classified as skips —
+			// hiding them would lose protocol-only events from the
+			// timeline.
+			row:  invocationRow{event: &pipeline.SessionEvent{}, inv: nil},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isSkipRow(tc.row); got != tc.want {
+				t.Errorf("isSkipRow = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPlural matches the helper used by the events footer hint:
+// "1 skip hidden" vs "2 skips hidden".
+func TestPlural(t *testing.T) {
+	cases := []struct {
+		n    int
+		want string
+	}{
+		{0, "s"},
+		{1, ""},
+		{2, "s"},
+		{17, "s"},
+	}
+	for _, tc := range cases {
+		if got := plural(tc.n); got != tc.want {
+			t.Errorf("plural(%d) = %q, want %q", tc.n, got, tc.want)
+		}
+	}
+}

--- a/authbridge/cmd/abctl/tui/events_pane_test.go
+++ b/authbridge/cmd/abctl/tui/events_pane_test.go
@@ -413,40 +413,39 @@ func TestIsSkipRow(t *testing.T) {
 	}
 }
 
-// TestComputeSpanGlyphs covers the tree-glyph assignment for the PHASE
-// column. Glyphs anchor a (request, response) pair visually so an
-// operator can trace the span even when other rows interleave.
+// TestComputeSpanGlyphs covers per-row tree-glyph assignment for the
+// PHASE column. Up to two levels of (req, resp) span nesting are
+// surfaced — the largest containing span as outer, the next-largest
+// as inner, deeper levels dropped.
 func TestComputeSpanGlyphs(t *testing.T) {
+	none := spanLevels{}
+	outer := func(g spanGlyph) spanLevels { return spanLevels{outer: g} }
+	both := func(o, i spanGlyph) spanLevels { return spanLevels{outer: o, inner: i} }
+
 	cases := []struct {
 		name  string
 		pairs map[int]int
 		n     int
-		want  []spanGlyph
+		want  []spanLevels
 	}{
 		{
 			name:  "no pairs",
 			pairs: nil,
 			n:     3,
-			want:  []spanGlyph{glyphNone, glyphNone, glyphNone},
+			want:  []spanLevels{none, none, none},
 		},
 		{
 			name: "adjacent pair (req at 0, resp at 1)",
 			// Bidirectional, like pairInvocationRows emits.
 			pairs: map[int]int{0: 1, 1: 0},
 			n:     2,
-			want:  []spanGlyph{glyphStart, glyphEnd},
+			want:  []spanLevels{outer(glyphStart), outer(glyphEnd)},
 		},
 		{
 			name:  "pair with one row in between",
 			pairs: map[int]int{0: 2, 2: 0},
 			n:     3,
-			want:  []spanGlyph{glyphStart, glyphMiddle, glyphEnd},
-		},
-		{
-			name:  "pair spanning four rows",
-			pairs: map[int]int{0: 3, 3: 0},
-			n:     4,
-			want:  []spanGlyph{glyphStart, glyphMiddle, glyphMiddle, glyphEnd},
+			want:  []spanLevels{outer(glyphStart), outer(glyphMiddle), outer(glyphEnd)},
 		},
 		{
 			name: "two non-overlapping pairs",
@@ -454,36 +453,85 @@ func TestComputeSpanGlyphs(t *testing.T) {
 				0: 2, 2: 0,
 				3: 5, 5: 3,
 			},
-			n:    6,
-			want: []spanGlyph{glyphStart, glyphMiddle, glyphEnd, glyphStart, glyphMiddle, glyphEnd},
+			n: 6,
+			want: []spanLevels{
+				outer(glyphStart), outer(glyphMiddle), outer(glyphEnd),
+				outer(glyphStart), outer(glyphMiddle), outer(glyphEnd),
+			},
 		},
 		{
 			name: "nested pairs — outer (0,5), inner (2,3)",
-			// Inner pair's endpoints overwrite outer's middle. Operators
-			// see two distinct corners in the gap.
+			// Both levels are now visible: the outer's continuation
+			// glyph sits next to the inner's corner so an operator can
+			// see "row 2 is inside an outer span AND opens an inner
+			// span" at a glance.
 			pairs: map[int]int{
 				0: 5, 5: 0,
 				2: 3, 3: 2,
 			},
 			n: 6,
-			want: []spanGlyph{
-				glyphStart,  // 0: outer start
-				glyphMiddle, // 1: inside outer
-				glyphStart,  // 2: inner start (overwrites outer middle)
-				glyphEnd,    // 3: inner end (overwrites outer middle)
-				glyphMiddle, // 4: still inside outer
-				glyphEnd,    // 5: outer end
+			want: []spanLevels{
+				outer(glyphStart),             // 0: outer starts here
+				outer(glyphMiddle),            // 1: only outer participates
+				both(glyphMiddle, glyphStart), // 2: outer continues, inner starts
+				both(glyphMiddle, glyphEnd),   // 3: outer continues, inner ends
+				outer(glyphMiddle),            // 4: only outer participates
+				outer(glyphEnd),               // 5: outer ends here
+			},
+		},
+		{
+			name: "real-world shape — long outer pair with inner pairs interleaved",
+			// Mirrors the IBAC demo timeline:
+			//   row 0: a2a-parser req     ┌
+			//   row 1: jwt-validation     │            (event-1 continuation)
+			//   row 2: inference-parser req  ┌
+			//   row 3: inference-parser resp └
+			//   row 4: a2a-parser resp    └
+			pairs: map[int]int{
+				0: 4, 4: 0, // outer a2a-parser
+				2: 3, 3: 2, // inner inference-parser
+			},
+			n: 5,
+			want: []spanLevels{
+				outer(glyphStart),
+				outer(glyphMiddle),
+				both(glyphMiddle, glyphStart),
+				both(glyphMiddle, glyphEnd),
+				outer(glyphEnd),
+			},
+		},
+		{
+			name: "deeper nesting collapses to two levels",
+			// outer (0, 7), middle (1, 6), innermost (2, 5). Row 3 sits
+			// inside all three; only the two largest surface so the
+			// PHASE column doesn't blow its width budget.
+			pairs: map[int]int{
+				0: 7, 7: 0,
+				1: 6, 6: 1,
+				2: 5, 5: 2,
+			},
+			n: 8,
+			want: []spanLevels{
+				outer(glyphStart),
+				both(glyphMiddle, glyphStart),  // outer middle + middle-pair start
+				both(glyphMiddle, glyphMiddle), // middle-pair middle wins over innermost (deeper dropped)
+				both(glyphMiddle, glyphMiddle), // same
+				both(glyphMiddle, glyphMiddle), // same
+				both(glyphMiddle, glyphMiddle), // middle-pair middle (innermost dropped)
+				both(glyphMiddle, glyphEnd),    // middle-pair ends here, outer continues
+				outer(glyphEnd),
 			},
 		},
 		{
 			name: "out-of-bounds endpoint gracefully ignored",
 			// Defensive: pairInvocationRows shouldn't emit pairs with
-			// indices >= n, but the helper must not panic if it ever
-			// happens (e.g. a future caller reusing the helper on a
-			// truncated row slice).
+			// indices >= n, but the helper must not panic if a future
+			// caller reuses it on a truncated row slice. The span (0,10)
+			// is still treated as containing rows 1 and 2 because they
+			// satisfy a < i < b.
 			pairs: map[int]int{0: 10, 10: 0},
 			n:     3,
-			want:  []spanGlyph{glyphStart, glyphMiddle, glyphMiddle},
+			want:  []spanLevels{outer(glyphStart), outer(glyphMiddle), outer(glyphMiddle)},
 		},
 	}
 	for _, tc := range cases {
@@ -494,10 +542,36 @@ func TestComputeSpanGlyphs(t *testing.T) {
 			}
 			for i := range tc.want {
 				if got[i] != tc.want[i] {
-					t.Errorf("row %d: got %q (%d), want %q (%d)",
-						i, string(rune(got[i])), got[i],
-						string(rune(tc.want[i])), tc.want[i])
+					t.Errorf("row %d: got {outer=%q inner=%q}, want {outer=%q inner=%q}",
+						i,
+						string(rune(got[i].outer)), string(rune(got[i].inner)),
+						string(rune(tc.want[i].outer)), string(rune(tc.want[i].inner)))
 				}
+			}
+		})
+	}
+}
+
+// TestSpanLevels_Prefix locks the rendered prefix the rebuildEventsTable
+// uses to populate the PHASE column. Empty levels render as empty
+// string; one level renders one glyph; two levels render two glyphs.
+func TestSpanLevels_Prefix(t *testing.T) {
+	cases := []struct {
+		name string
+		s    spanLevels
+		want string
+	}{
+		{"none", spanLevels{}, ""},
+		{"outer only — start", spanLevels{outer: glyphStart}, "┌"},
+		{"outer only — middle", spanLevels{outer: glyphMiddle}, "│"},
+		{"outer only — end", spanLevels{outer: glyphEnd}, "└"},
+		{"both levels — outer middle, inner start", spanLevels{outer: glyphMiddle, inner: glyphStart}, "│┌"},
+		{"both levels — outer middle, inner end", spanLevels{outer: glyphMiddle, inner: glyphEnd}, "│└"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.s.prefix(); got != tc.want {
+				t.Errorf("prefix() = %q, want %q", got, tc.want)
 			}
 		})
 	}

--- a/authbridge/cmd/abctl/tui/events_pane_test.go
+++ b/authbridge/cmd/abctl/tui/events_pane_test.go
@@ -8,12 +8,24 @@ import (
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/pipeline"
 )
 
-// TestShortPhase_Denied locks the abctl rendering string for the
-// denied phase — changing this silently would ripple into the events
-// table and teatest snapshots.
-func TestShortPhase_Denied(t *testing.T) {
-	if got := shortPhase(pipeline.SessionDenied); got != "deny" {
-		t.Errorf("shortPhase(SessionDenied) = %q, want deny", got)
+// TestShortPhase covers the rendered string for every SessionPhase.
+// SessionDenied renders as "req" (not "deny") because the deny
+// outcome is already on the row in the ACTION + STATUS columns —
+// duplicating it in PHASE was redundant. PHASE communicates
+// lifecycle position; ACTION communicates outcome.
+func TestShortPhase(t *testing.T) {
+	cases := []struct {
+		phase pipeline.SessionPhase
+		want  string
+	}{
+		{pipeline.SessionRequest, "req"},
+		{pipeline.SessionResponse, "resp"},
+		{pipeline.SessionDenied, "req"},
+	}
+	for _, tc := range cases {
+		if got := shortPhase(tc.phase); got != tc.want {
+			t.Errorf("shortPhase(%v) = %q, want %q", tc.phase, got, tc.want)
+		}
 	}
 }
 

--- a/authbridge/cmd/abctl/tui/events_pane_test.go
+++ b/authbridge/cmd/abctl/tui/events_pane_test.go
@@ -413,6 +413,96 @@ func TestIsSkipRow(t *testing.T) {
 	}
 }
 
+// TestComputeSpanGlyphs covers the tree-glyph assignment for the PHASE
+// column. Glyphs anchor a (request, response) pair visually so an
+// operator can trace the span even when other rows interleave.
+func TestComputeSpanGlyphs(t *testing.T) {
+	cases := []struct {
+		name  string
+		pairs map[int]int
+		n     int
+		want  []spanGlyph
+	}{
+		{
+			name:  "no pairs",
+			pairs: nil,
+			n:     3,
+			want:  []spanGlyph{glyphNone, glyphNone, glyphNone},
+		},
+		{
+			name: "adjacent pair (req at 0, resp at 1)",
+			// Bidirectional, like pairInvocationRows emits.
+			pairs: map[int]int{0: 1, 1: 0},
+			n:     2,
+			want:  []spanGlyph{glyphStart, glyphEnd},
+		},
+		{
+			name:  "pair with one row in between",
+			pairs: map[int]int{0: 2, 2: 0},
+			n:     3,
+			want:  []spanGlyph{glyphStart, glyphMiddle, glyphEnd},
+		},
+		{
+			name:  "pair spanning four rows",
+			pairs: map[int]int{0: 3, 3: 0},
+			n:     4,
+			want:  []spanGlyph{glyphStart, glyphMiddle, glyphMiddle, glyphEnd},
+		},
+		{
+			name: "two non-overlapping pairs",
+			pairs: map[int]int{
+				0: 2, 2: 0,
+				3: 5, 5: 3,
+			},
+			n:    6,
+			want: []spanGlyph{glyphStart, glyphMiddle, glyphEnd, glyphStart, glyphMiddle, glyphEnd},
+		},
+		{
+			name: "nested pairs — outer (0,5), inner (2,3)",
+			// Inner pair's endpoints overwrite outer's middle. Operators
+			// see two distinct corners in the gap.
+			pairs: map[int]int{
+				0: 5, 5: 0,
+				2: 3, 3: 2,
+			},
+			n: 6,
+			want: []spanGlyph{
+				glyphStart,  // 0: outer start
+				glyphMiddle, // 1: inside outer
+				glyphStart,  // 2: inner start (overwrites outer middle)
+				glyphEnd,    // 3: inner end (overwrites outer middle)
+				glyphMiddle, // 4: still inside outer
+				glyphEnd,    // 5: outer end
+			},
+		},
+		{
+			name: "out-of-bounds endpoint gracefully ignored",
+			// Defensive: pairInvocationRows shouldn't emit pairs with
+			// indices >= n, but the helper must not panic if it ever
+			// happens (e.g. a future caller reusing the helper on a
+			// truncated row slice).
+			pairs: map[int]int{0: 10, 10: 0},
+			n:     3,
+			want:  []spanGlyph{glyphStart, glyphMiddle, glyphMiddle},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeSpanGlyphs(tc.pairs, tc.n)
+			if len(got) != len(tc.want) {
+				t.Fatalf("len = %d, want %d (got %v)", len(got), len(tc.want), got)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Errorf("row %d: got %q (%d), want %q (%d)",
+						i, string(rune(got[i])), got[i],
+						string(rune(tc.want[i])), tc.want[i])
+				}
+			}
+		})
+	}
+}
+
 // TestPlural matches the helper used by the events footer hint:
 // "1 skip hidden" vs "2 skips hidden".
 func TestPlural(t *testing.T) {

--- a/authbridge/cmd/abctl/tui/keys.go
+++ b/authbridge/cmd/abctl/tui/keys.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -55,6 +56,16 @@ func (m *model) handleKey(msg tea.KeyMsg) tea.Cmd {
 
 	case "p":
 		m.paused = !m.paused
+		return nil
+
+	case "s":
+		// Toggle skip-row visibility. Only meaningful while the events
+		// pane is active, but accepting the key on any pane keeps the
+		// keybinding simple and lets operators "set their preference"
+		// before drilling into a session. rebuildEventsTable is a no-op
+		// when no session is selected.
+		m.showSkips = !m.showSkips
+		m.rebuildEventsTable()
 		return nil
 
 	case "esc", "left", "h":
@@ -120,7 +131,7 @@ func (m *model) handleKey(msg tea.KeyMsg) tea.Cmd {
 		m.goBottom()
 		return nil
 
-	// Dispatch j/k/up/down to the active component's Update.
+		// Dispatch j/k/up/down to the active component's Update.
 	}
 
 	// Fall through: let the active pane's component handle it.
@@ -214,7 +225,15 @@ func (m *model) helpView() string {
 	case paneSessions:
 		return "[↑↓] nav  [↵] drill  [tab] pipeline  [/] filter  [p] pause  [q] quit"
 	case paneEvents:
-		return "[↑↓] nav  [↵] detail  [esc] back  [/] filter  [p] pause  [q] quit"
+		base := "[↑↓] nav  [↵] detail  [esc] back  [/] filter  [s] skips  [p] pause  [q] quit"
+		// Surface the hidden-skip count so a sparse timeline doesn't
+		// look like data loss. Only annotate when there's something
+		// to say (skips off AND at least one row was hidden).
+		if !m.showSkips && m.hiddenSkips > 0 {
+			base = fmt.Sprintf("%s  ·  %d skip%s hidden",
+				base, m.hiddenSkips, plural(m.hiddenSkips))
+		}
+		return base
 	case paneDetail:
 		return "[↑↓] scroll  [y] yank  [esc] back  [q] quit"
 	case panePipeline:

--- a/authbridge/cmd/abctl/tui/util.go
+++ b/authbridge/cmd/abctl/tui/util.go
@@ -44,3 +44,13 @@ func nonEmpty(s, fallback string) string {
 	}
 	return s
 }
+
+// plural returns "s" when n != 1, "" otherwise. Lets footer hints write
+// "1 skip hidden" / "2 skips hidden" without a separate format-string
+// branch per case.
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}


### PR DESCRIPTION
## Summary

Four related improvements to the abctl events-table rendering, all in the PHASE column / row-visibility area:

1. **Hide skip-action rows by default; toggle with `s`** (1758824). Skip rows from auth gates that didn't fire (jwt-validation on `/.well-known/*`, IBAC on bypass hosts, token-exchange on unrouted hosts) are diagnostic noise — the interesting signal is in `allow` / `deny` / `modify` / `observe`. Press `s` to reveal them. The events-pane footer hint surfaces the toggle and the hidden count.
2. **Connect paired req/resp rows with a tree glyph in PHASE** (e274645). The existing `└resp` glyph on a paired response row gets a sibling `┌req` on the request row and `│` on rows in the gap. Operators can trace a paired span at a glance.
3. **Show one nesting level of paired req/resp** (81f582b). Real timelines have an outer a2a-parser pair wrapping inner inference-parser / mcp-parser pairs. The PHASE column now renders up to two levels of glyphs (e.g. `│┌req`) so operators see both the outer span and the nearest inner one. Deeper nesting collapses to the two outermost levels.
4. **Render denied PHASE as `req` instead of `deny`** (c313478). **UX contract change** — see "Behavior change" below.

## Why

Anyone running the IBAC demo or any kagenti install with multiple plugins per chain sees the events table dominated by skip rows from gates that legitimately didn't apply, and struggles to visually correlate request rows with their response rows when they're separated by other plugins' rows. These four changes together turn the events table into a scannable timeline.

## Behavior change: SessionDenied → "req" in PHASE

A SessionDenied event is a request that didn't reach the response phase. The deny outcome is already on the row in the **ACTION** column (`deny`) and the **STATUS** column (`403` / etc), so showing "deny" in PHASE was duplicative. PHASE now always communicates lifecycle position; ACTION conveys outcome.

Concretely, an IBAC deny that previously rendered:

```
6  ... out  │deny  deny  ibac  403  ibac-evil-server.te…
```

now renders:

```
6  ... out  │req   deny  ibac  403  ibac-evil-server.te…
```

If you have screencasts, runbooks, or external docs that reference `PHASE=deny`, those will need a refresh. The substring filter `/deny` keeps working — it matches against `Invocation.Action` and `SessionEvent.Phase` (the underlying enum, not the rendered string).

## Test plan

- [x] `go build ./...` from `cmd/abctl`
- [x] `go vet ./...` clean
- [x] `go test -race -count=1 ./tui/...` green
- [x] `gofmt -l` clean on changed files
- [x] New tests: `TestIsSkipRow`, `TestPlural`, `TestComputeSpanGlyphs` (8 cases including IBAC-shape, deeper-nesting, out-of-bounds), `TestSpanLevels_Prefix`. `TestShortPhase_Denied` rewritten as `TestShortPhase` covering all three phases.
- [ ] CI passes
- [ ] Manual: `make demo-ibac` then `make show-result`, confirm:
  - Default events table no longer dominated by skip rows
  - Press `s` to verify the toggle restores them and the hidden count clears
  - Outer a2a-parser pair shows `┌req` and `└resp` on its endpoint rows; rows in the gap show `│`
  - Inner inference-parser / mcp-parser pairs render as `│┌req` / `│└resp`
  - IBAC deny row shows `│req` in PHASE, `deny` in ACTION, `403` in STATUS

## Files

- `cmd/abctl/tui/app.go` — model fields `showSkips`, `hiddenSkips`
- `cmd/abctl/tui/events_pane.go` — `isSkipRow` predicate; `spanGlyph` / `spanLevels` types and `computeSpanGlyphs`; `shortPhase` rendering update; row-loop integration
- `cmd/abctl/tui/keys.go` — `s` handler; events-pane footer hint
- `cmd/abctl/tui/util.go` — `plural` helper
- `cmd/abctl/tui/events_pane_test.go` — new test coverage
- `cmd/abctl/README.md` — keybinding row

Net: ~+340 / −85.

## Performance note (non-blocking)

`computeSpanGlyphs` is O(n × p) with a per-row stable sort, where n = rows and p = pairs. For typical TUI sessions (tens of events, single-digit pairs) this is fine; the explicit clarity is worth more than the asymptotic optimum. If abctl ever streams 1000+ events into a single session view, this becomes the hot path and would warrant an interval-tree or sweep-line rewrite. Tracking only as a comment, not blocking.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
