### PR TITLE
feat(authbridge): Single-player mode for inbound→outbound token bridging

### DIFF
--- a/authbridge/README.md
+++ b/authbridge/README.md
@@ -335,6 +335,36 @@ sequenceDiagram
 - **Transparent to Application** - Both inbound validation and outbound token exchange are handled by the sidecar; applications don't need to implement either
 - **Configurable Targets** - Route-based configuration maps destination hosts to target audiences
 
+## Token Propagation: What Agents Must Do
+
+OBO / RFC 8693 token exchange requires the inbound user JWT to reach
+the sidecar on the agent's outbound calls (as `subject_token`). Many
+agent runtimes — LangChain, CrewAI, Claude Code — do **not** propagate
+the inbound `Authorization` header to the outbound HTTP requests they
+generate, because tool execution is decoupled from request handling.
+
+AuthBridge handles this in two complementary ways:
+
+1. **Single-player mode (default-on)** — for processes that serve
+   **one user at a time**, the sidecar caches the validated inbound
+   token and injects it on outbound when the agent didn't propagate
+   the header. Transparent; no agent code changes. **Not safe for
+   concurrent multi-user agents** (last-write-wins; calls may be
+   attributed to the wrong user).
+
+2. **Multi-user / multi-session: the agent must propagate the
+   Authorization header itself.** When the outbound request already
+   carries `Authorization`, the sidecar uses that explicitly and the
+   single-player cache is bypassed. There is no transparent way for
+   the sidecar to disambiguate concurrent users without help from
+   the agent.
+
+Disable single-player mode (`single_user_mode: false` at the top of
+the runtime YAML) when running multi-user concurrent agents that DO
+propagate the Authorization header. See
+[plugin-reference.md → Single-player mode](docs/plugin-reference.md#single-player-mode-default-on-single-user-agents-only)
+for the full decision matrix and per-framework guidance.
+
 ## Prerequisites
 
 - Kubernetes cluster (Kind recommended for local development)

--- a/authbridge/authlib/auth/single_user.go
+++ b/authbridge/authlib/auth/single_user.go
@@ -42,6 +42,15 @@ var (
 	spToken   string
 	spSubject string
 	spExp     time.Time
+
+	// spSubjectChanges counts how many times Store observed a NEW
+	// subject overwriting an existing entry — the operator's
+	// programmatic tripwire for "single-player mode is being used in a
+	// multi-user context." Increments are atomic and lock-free; the
+	// WARN log emitted by jwt-validation is a human-readable
+	// counterpart but is unsuitable for alerting at high volume. Read
+	// via SingleUserSubjectChangeCount; alerts should track the delta.
+	spSubjectChanges atomic.Int64
 )
 
 func init() {
@@ -69,6 +78,18 @@ func IsSingleUserModeEnabled() bool {
 //
 // Caller is responsible for applying TTL caps before calling — see
 // CapSingleUserExpiry which encapsulates the floor/cap policy.
+//
+// Side-effect: increments the package-level subject-change counter
+// when prevSubject is non-empty AND differs from the new subject,
+// surfacing the single-player-violation signal to /stats consumers
+// and Prometheus exporters via SingleUserSubjectChangeCount.
+//
+// The spEnabled gate is checked outside the mutex deliberately. The
+// gate is set once at startup by the binary; SetSingleUserModeEnabled
+// is otherwise only called from tests. The microsecond window in
+// which a concurrent SetSingleUserModeEnabled(false) could race a
+// Store-in-flight is harmless — the worst case is one stale write
+// before the next Get returns a miss anyway.
 func StoreSingleUserToken(token, subject string, exp time.Time) (prevSubject string) {
 	if !spEnabled.Load() {
 		return ""
@@ -76,6 +97,9 @@ func StoreSingleUserToken(token, subject string, exp time.Time) (prevSubject str
 	spMu.Lock()
 	defer spMu.Unlock()
 	prevSubject = spSubject
+	if prevSubject != "" && prevSubject != subject {
+		spSubjectChanges.Add(1)
+	}
 	spToken = token
 	spSubject = subject
 	spExp = exp
@@ -85,6 +109,9 @@ func StoreSingleUserToken(token, subject string, exp time.Time) (prevSubject str
 // GetSingleUserToken returns the cached token if non-empty and not yet
 // expired at `now`. Cache miss returns ok=false with empty strings.
 // When the feature is disabled, always returns ok=false.
+//
+// See StoreSingleUserToken for the rationale on checking spEnabled
+// outside the mutex.
 func GetSingleUserToken(now time.Time) (token, subject string, ok bool) {
 	if !spEnabled.Load() {
 		return "", "", false
@@ -95,6 +122,20 @@ func GetSingleUserToken(now time.Time) (token, subject string, ok bool) {
 		return "", "", false
 	}
 	return spToken, spSubject, true
+}
+
+// SingleUserSubjectChangeCount returns the lifetime count of times
+// Store observed a new subject overwriting a different existing
+// subject — i.e., the number of times the single-player assumption
+// was violated by concurrent multi-user traffic. Operators should
+// alert on the DELTA of this counter (not the absolute value); a
+// nonzero rate indicates single-player mode is misapplied to a
+// multi-user workload.
+//
+// Lifetime counter: not reset by ResetSingleUserToken. Always returns
+// the live atomic value; safe to call concurrently.
+func SingleUserSubjectChangeCount() int64 {
+	return spSubjectChanges.Load()
 }
 
 // CapSingleUserExpiry applies the package's cap/floor policy to a
@@ -111,10 +152,22 @@ func CapSingleUserExpiry(now, exp time.Time) (time.Time, bool) {
 	return exp, true
 }
 
-// ResetSingleUserToken clears the cache. Exported for tests; pair with
-// t.Cleanup(auth.ResetSingleUserToken) to avoid cross-test leakage.
-// Does not change the enabled bit — tests that toggle that should
-// restore it explicitly.
+// ResetSingleUserToken clears the cache. TEST-ONLY entry point —
+// production code MUST NOT call this. Exported (rather than hidden in
+// an export_test.go) because external test packages such as
+// jwtvalidation_test, tokenexchange_test, and the plugins-level e2e
+// suite need to reset state across tests, and Go's _test.go visibility
+// scope wouldn't reach them.
+//
+// Pair with t.Cleanup(auth.ResetSingleUserToken) to avoid cross-test
+// leakage. Does NOT change the enabled bit and does NOT reset the
+// subject-change counter — tests that depend on either should restore
+// them explicitly.
+//
+// If a runtime "wipe the cache mid-flight" capability is ever needed,
+// add a separately-named function (e.g., InvalidateSingleUserToken)
+// rather than overloading this one — the test-only contract here is
+// load-bearing.
 func ResetSingleUserToken() {
 	spMu.Lock()
 	defer spMu.Unlock()

--- a/authbridge/authlib/auth/single_user.go
+++ b/authbridge/authlib/auth/single_user.go
@@ -1,0 +1,124 @@
+package auth
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Process-level cache for the most recent validated inbound user JWT.
+// Bridges inbound (jwt-validation captures) → outbound (token-exchange
+// reads when the agent didn't propagate the Authorization header).
+//
+// The whole feature is gated on a single atomic.Bool — set once at
+// startup from the top-level Config.SingleUserMode by the binary's
+// main.go. Plugins call Store/Get unconditionally; when disabled,
+// Store is a no-op and Get returns ok=false. This keeps the operator
+// control surface to one knob and the plugin code branch-free.
+//
+// Safe only when the process handles one user at a time. Multi-tenant
+// concurrent agents need correlation-ID-based routing — the helpers
+// here will last-write-wins, and jwt-validation logs a WARN whenever
+// the cached subject changes so operators have a tripwire.
+//
+// Each replica has its own cache. Cluster-scaled deployments need
+// stickiness or a future shared-state implementation.
+
+const (
+	singleUserMaxTTL = 5 * time.Minute   // cap regardless of token exp
+	singleUserMinTTL = 30 * time.Second  // skip capture below this floor
+)
+
+var (
+	// spEnabled gates the entire feature. Default-true: out-of-the-box
+	// behavior is to bridge inbound→outbound. Operators opt out by
+	// setting `single_user_mode: false` at the top level of the runtime
+	// YAML; the binary then calls SetSingleUserModeEnabled(false) at
+	// startup. The atomic.Bool zero value is false, so we explicitly
+	// initialize to true in init() to match the documented default.
+	spEnabled atomic.Bool
+
+	spMu      sync.RWMutex
+	spToken   string
+	spSubject string
+	spExp     time.Time
+)
+
+func init() {
+	spEnabled.Store(true)
+}
+
+// SetSingleUserModeEnabled toggles the inbound→outbound bridge. Called
+// once at startup by the binary's main.go from Config.SingleUserModeEnabled().
+// Tests use this to flip the feature on/off without restarting.
+func SetSingleUserModeEnabled(enabled bool) {
+	spEnabled.Store(enabled)
+}
+
+// IsSingleUserModeEnabled reports whether the bridge is on. Exported
+// for tests and for the binary's startup banner.
+func IsSingleUserModeEnabled() bool {
+	return spEnabled.Load()
+}
+
+// StoreSingleUserToken caches the most recent validated inbound token.
+// Returns the previous subject so callers can detect when the
+// single-player assumption is violated (subject changed between
+// captures); empty string when there was no prior entry, or when the
+// feature is disabled (no-op).
+//
+// Caller is responsible for applying TTL caps before calling — see
+// CapSingleUserExpiry which encapsulates the floor/cap policy.
+func StoreSingleUserToken(token, subject string, exp time.Time) (prevSubject string) {
+	if !spEnabled.Load() {
+		return ""
+	}
+	spMu.Lock()
+	defer spMu.Unlock()
+	prevSubject = spSubject
+	spToken = token
+	spSubject = subject
+	spExp = exp
+	return
+}
+
+// GetSingleUserToken returns the cached token if non-empty and not yet
+// expired at `now`. Cache miss returns ok=false with empty strings.
+// When the feature is disabled, always returns ok=false.
+func GetSingleUserToken(now time.Time) (token, subject string, ok bool) {
+	if !spEnabled.Load() {
+		return "", "", false
+	}
+	spMu.RLock()
+	defer spMu.RUnlock()
+	if spToken == "" || now.After(spExp) {
+		return "", "", false
+	}
+	return spToken, spSubject, true
+}
+
+// CapSingleUserExpiry applies the package's cap/floor policy to a
+// proposed cache expiry. Returns (capped, true) when exp is at or after
+// now+MinTTL; (zero, false) when below the floor (caller should skip
+// capture). The capped value is min(exp, now+MaxTTL).
+func CapSingleUserExpiry(now, exp time.Time) (time.Time, bool) {
+	if exp.Before(now.Add(singleUserMinTTL)) {
+		return time.Time{}, false
+	}
+	if cap := now.Add(singleUserMaxTTL); exp.After(cap) {
+		return cap, true
+	}
+	return exp, true
+}
+
+// ResetSingleUserToken clears the cache. Exported for tests; pair with
+// t.Cleanup(auth.ResetSingleUserToken) to avoid cross-test leakage.
+// Does not change the enabled bit — tests that toggle that should
+// restore it explicitly.
+func ResetSingleUserToken() {
+	spMu.Lock()
+	defer spMu.Unlock()
+	spToken = ""
+	spSubject = ""
+	spExp = time.Time{}
+}

--- a/authbridge/authlib/auth/single_user_test.go
+++ b/authbridge/authlib/auth/single_user_test.go
@@ -123,6 +123,81 @@ func TestStoreSingleUserToken_PrevSubjectOnOverwrite(t *testing.T) {
 	}
 }
 
+// TestSingleUserSubjectChangeCount_CountsOnlySubjectChanges pins the
+// counter semantics: it increments only when an existing entry is
+// overwritten by a DIFFERENT subject, not on first writes or
+// same-subject re-captures. Operators alert on the delta of this
+// counter; counting noop overwrites would produce false positives in
+// otherwise-safe single-user deployments.
+func TestSingleUserSubjectChangeCount_CountsOnlySubjectChanges(t *testing.T) {
+	t.Cleanup(ResetSingleUserToken)
+
+	// Snapshot the starting count — other tests in this package may
+	// have run before this one and bumped the lifetime counter.
+	start := SingleUserSubjectChangeCount()
+	exp := futureExp(t)
+
+	// First write: no prior entry → no change.
+	StoreSingleUserToken("tok-1", "alice", exp)
+	if got, want := SingleUserSubjectChangeCount()-start, int64(0); got != want {
+		t.Errorf("after first write: delta = %d, want 0", got)
+	}
+
+	// Same-subject re-capture: not a "change."
+	StoreSingleUserToken("tok-2", "alice", exp)
+	if got, want := SingleUserSubjectChangeCount()-start, int64(0); got != want {
+		t.Errorf("after same-subject re-capture: delta = %d, want 0", got)
+	}
+
+	// Different subject: counter increments.
+	StoreSingleUserToken("tok-3", "bob", exp)
+	if got, want := SingleUserSubjectChangeCount()-start, int64(1); got != want {
+		t.Errorf("after first cross-subject overwrite: delta = %d, want 1", got)
+	}
+
+	// Another different subject: counter increments again.
+	StoreSingleUserToken("tok-4", "carol", exp)
+	if got, want := SingleUserSubjectChangeCount()-start, int64(2); got != want {
+		t.Errorf("after second cross-subject overwrite: delta = %d, want 2", got)
+	}
+
+	// Back to bob: still counts as a change relative to carol.
+	StoreSingleUserToken("tok-5", "bob", exp)
+	if got, want := SingleUserSubjectChangeCount()-start, int64(3); got != want {
+		t.Errorf("after carol→bob: delta = %d, want 3", got)
+	}
+
+	// ResetSingleUserToken clears the cache but NOT the lifetime counter
+	// (documented behavior so cross-test alerting thresholds stay
+	// monotonic). After reset, a first write to charlie should NOT
+	// count as a change because the cache is empty (no prevSubject).
+	ResetSingleUserToken()
+	StoreSingleUserToken("tok-6", "charlie", exp)
+	if got, want := SingleUserSubjectChangeCount()-start, int64(3); got != want {
+		t.Errorf("after reset+first-write: delta = %d, want 3 (counter unchanged; cache was empty)", got)
+	}
+}
+
+// TestSingleUserSubjectChangeCount_NoCountWhenDisabled: when the
+// feature gate is off, Store no-ops entirely — including the counter.
+// A multi-user deployment that explicitly opted out shouldn't see
+// false-positive subject-change events from a Store path that's
+// supposed to be inert.
+func TestSingleUserSubjectChangeCount_NoCountWhenDisabled(t *testing.T) {
+	t.Cleanup(ResetSingleUserToken)
+	withEnabled(t, false)
+
+	start := SingleUserSubjectChangeCount()
+	exp := futureExp(t)
+
+	StoreSingleUserToken("tok-1", "alice", exp)
+	StoreSingleUserToken("tok-2", "bob", exp)
+
+	if got, want := SingleUserSubjectChangeCount()-start, int64(0); got != want {
+		t.Errorf("counter should not advance while disabled: delta = %d, want 0", got)
+	}
+}
+
 func TestCapSingleUserExpiry(t *testing.T) {
 	now := time.Now()
 

--- a/authbridge/authlib/auth/single_user_test.go
+++ b/authbridge/authlib/auth/single_user_test.go
@@ -1,0 +1,243 @@
+package auth
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// Helper: future-dated expiry that's safely above the MinTTL floor and
+// below the MaxTTL cap, so the happy-path tests don't accidentally
+// trigger floor/cap policy.
+func futureExp(t *testing.T) time.Time {
+	t.Helper()
+	return time.Now().Add(2 * time.Minute)
+}
+
+// withEnabled flips the package-level feature gate for a test and
+// restores the prior state on cleanup. Tests assume the feature is
+// enabled by default (matching the package init), but explicit gating
+// makes the intent visible.
+func withEnabled(t *testing.T, enabled bool) {
+	t.Helper()
+	prev := IsSingleUserModeEnabled()
+	SetSingleUserModeEnabled(enabled)
+	t.Cleanup(func() { SetSingleUserModeEnabled(prev) })
+}
+
+func TestSingleUserMode_DefaultEnabled(t *testing.T) {
+	// Package init() must set the gate to true so out-of-the-box
+	// behavior bridges inbound→outbound. Validate that here so a future
+	// regression flips it without anyone noticing.
+	if !IsSingleUserModeEnabled() {
+		t.Fatal("expected single-user mode enabled by default at init time")
+	}
+}
+
+func TestStoreSingleUserToken_RoundTrip(t *testing.T) {
+	withEnabled(t, true)
+	t.Cleanup(ResetSingleUserToken)
+
+	exp := futureExp(t)
+	prev := StoreSingleUserToken("tok-1", "alice", exp)
+	if prev != "" {
+		t.Errorf("prev subject on first store = %q, want empty", prev)
+	}
+
+	tok, sub, ok := GetSingleUserToken(time.Now())
+	if !ok {
+		t.Fatalf("GetSingleUserToken: ok = false, want true")
+	}
+	if tok != "tok-1" {
+		t.Errorf("token = %q, want tok-1", tok)
+	}
+	if sub != "alice" {
+		t.Errorf("subject = %q, want alice", sub)
+	}
+}
+
+func TestSingleUserMode_DisabledIsNoOp(t *testing.T) {
+	t.Cleanup(ResetSingleUserToken)
+
+	withEnabled(t, false)
+
+	// Store should no-op; prevSubject empty.
+	if got := StoreSingleUserToken("tok", "alice", futureExp(t)); got != "" {
+		t.Errorf("StoreSingleUserToken when disabled: prev = %q, want empty (no-op)", got)
+	}
+
+	// Get should report miss.
+	if _, _, ok := GetSingleUserToken(time.Now()); ok {
+		t.Error("GetSingleUserToken when disabled: ok = true, want false")
+	}
+
+	// Re-enable: cache should still be empty (Store was a no-op, not a
+	// queued write).
+	SetSingleUserModeEnabled(true)
+	if _, _, ok := GetSingleUserToken(time.Now()); ok {
+		t.Error("after re-enable: cache should be empty (Store was no-op while disabled)")
+	}
+}
+
+func TestGetSingleUserToken_ExpiredReturnsMiss(t *testing.T) {
+	t.Cleanup(ResetSingleUserToken)
+
+	past := time.Now().Add(-1 * time.Second)
+	StoreSingleUserToken("tok-1", "alice", past)
+
+	tok, sub, ok := GetSingleUserToken(time.Now())
+	if ok {
+		t.Errorf("ok = true, want false (token expired)")
+	}
+	if tok != "" || sub != "" {
+		t.Errorf("expected empty token/subject on miss, got %q / %q", tok, sub)
+	}
+}
+
+func TestGetSingleUserToken_EmptyCacheReturnsMiss(t *testing.T) {
+	t.Cleanup(ResetSingleUserToken)
+
+	tok, sub, ok := GetSingleUserToken(time.Now())
+	if ok {
+		t.Errorf("ok = true, want false (cache empty)")
+	}
+	if tok != "" || sub != "" {
+		t.Errorf("expected empty token/subject, got %q / %q", tok, sub)
+	}
+}
+
+func TestStoreSingleUserToken_PrevSubjectOnOverwrite(t *testing.T) {
+	t.Cleanup(ResetSingleUserToken)
+
+	exp := futureExp(t)
+	StoreSingleUserToken("tok-1", "alice", exp)
+
+	prev := StoreSingleUserToken("tok-2", "bob", exp)
+	if prev != "alice" {
+		t.Errorf("prev subject on overwrite = %q, want alice", prev)
+	}
+
+	prev2 := StoreSingleUserToken("tok-3", "bob", exp)
+	if prev2 != "bob" {
+		t.Errorf("prev subject on same-subject overwrite = %q, want bob", prev2)
+	}
+}
+
+func TestCapSingleUserExpiry(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name      string
+		exp       time.Time
+		wantOK    bool
+		wantCap   bool // true if returned exp should be capped at now+MaxTTL
+		wantPass  bool // true if returned exp should equal input exp
+	}{
+		{
+			name:     "below floor returns false",
+			exp:      now.Add(10 * time.Second), // < MinTTL (30s)
+			wantOK:   false,
+		},
+		{
+			name:     "exactly at floor returns true",
+			exp:      now.Add(singleUserMinTTL),
+			wantOK:   true,
+			wantPass: true,
+		},
+		{
+			name:     "above floor below cap passes through",
+			exp:      now.Add(2 * time.Minute),
+			wantOK:   true,
+			wantPass: true,
+		},
+		{
+			name:    "above cap is capped",
+			exp:     now.Add(1 * time.Hour),
+			wantOK:  true,
+			wantCap: true,
+		},
+		{
+			name:   "in the past returns false",
+			exp:    now.Add(-1 * time.Second),
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := CapSingleUserExpiry(now, tt.exp)
+			if ok != tt.wantOK {
+				t.Errorf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !tt.wantOK {
+				if !got.IsZero() {
+					t.Errorf("expected zero time on false, got %v", got)
+				}
+				return
+			}
+			if tt.wantCap {
+				want := now.Add(singleUserMaxTTL)
+				if !got.Equal(want) {
+					t.Errorf("capped exp = %v, want %v", got, want)
+				}
+			}
+			if tt.wantPass {
+				if !got.Equal(tt.exp) {
+					t.Errorf("passthrough exp = %v, want %v", got, tt.exp)
+				}
+			}
+		})
+	}
+}
+
+func TestResetSingleUserToken(t *testing.T) {
+	exp := futureExp(t)
+	StoreSingleUserToken("tok-1", "alice", exp)
+
+	ResetSingleUserToken()
+
+	_, _, ok := GetSingleUserToken(time.Now())
+	if ok {
+		t.Errorf("ok = true after reset, want false")
+	}
+}
+
+func TestSingleUserToken_ConcurrentSafe(t *testing.T) {
+	t.Cleanup(ResetSingleUserToken)
+
+	const goroutines = 50
+	const iterations = 100
+
+	exp := futureExp(t)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2)
+
+	// Writers
+	for i := 0; i < goroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				StoreSingleUserToken("tok", "user", exp)
+			}
+		}(i)
+	}
+
+	// Readers
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				_, _, _ = GetSingleUserToken(time.Now())
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Final state should still be readable.
+	tok, sub, ok := GetSingleUserToken(time.Now())
+	if !ok || tok != "tok" || sub != "user" {
+		t.Errorf("post-concurrency state = (%q, %q, %v), want (tok, user, true)", tok, sub, ok)
+	}
+}

--- a/authbridge/authlib/config/config.go
+++ b/authbridge/authlib/config/config.go
@@ -24,12 +24,43 @@ type Config struct {
 	Pipeline PipelineConfig `yaml:"pipeline" json:"pipeline"`
 	Session  SessionConfig  `yaml:"session" json:"session"`
 	Stats    StatsConfig    `yaml:"stats" json:"stats"`
+
 	// MTLS, when non-nil, enables transport-level mTLS using SPIRE
 	// X.509 SVIDs. Applies symmetrically to inbound (reverse-proxy)
 	// and outbound (forward-proxy) traffic in proxy-sidecar mode;
 	// envoy-sidecar mode is unaffected (Envoy handles its own TLS via
 	// SDS). Pointer so absent block = today's plaintext behavior.
 	MTLS *MTLSConfig `yaml:"mtls,omitempty" json:"mtls,omitempty"`
+
+	// SingleUserMode is the single control for the inbound→outbound
+	// token-bridging feature. When enabled (the default), jwt-validation
+	// caches each successfully-validated user JWT in a process-level
+	// store, and token-exchange consults that store on outbound when no
+	// Authorization header is present — bridging frameworks that don't
+	// propagate the inbound header (LangChain, CrewAI, Claude Code).
+	//
+	// Pointer-bool with default-true semantics, mirroring SessionConfig.
+	// nil means "unset → on"; explicit `false` opts the deployment out.
+	//
+	// This flag is intentionally at top level rather than per-plugin:
+	// the feature requires the inbound and outbound sides to be
+	// consistent, and a single knob removes the per-pipeline
+	// inconsistency footgun.
+	//
+	// Constraint: only safe for processes handling one user at a time.
+	// See authbridge/docs/plugin-reference.md for the single-player
+	// caveat and multi-replica notes.
+	SingleUserMode *bool `yaml:"single_user_mode" json:"single_user_mode"`
+}
+
+// SingleUserModeEnabled returns true when the inbound→outbound token
+// bridge should run. Defaults to true when the field is unset, so
+// operators must explicitly opt out with `single_user_mode: false`.
+func (c Config) SingleUserModeEnabled() bool {
+	if c.SingleUserMode == nil {
+		return true
+	}
+	return *c.SingleUserMode
 }
 
 // MTLSMode names the inbound + outbound TLS posture. Vocabulary

--- a/authbridge/authlib/config/config_test.go
+++ b/authbridge/authlib/config/config_test.go
@@ -439,6 +439,29 @@ func TestSessionConfig_SessionEnabled(t *testing.T) {
 	}
 }
 
+// --- Top-level Config.SingleUserMode tri-state ---
+
+func TestConfig_SingleUserModeEnabled(t *testing.T) {
+	boolP := func(b bool) *bool { return &b }
+
+	tests := []struct {
+		name string
+		cfg  Config
+		want bool
+	}{
+		{"unset defaults to true (default-on for inbound→outbound bridge)", Config{}, true},
+		{"explicit true", Config{SingleUserMode: boolP(true)}, true},
+		{"explicit false opts out of the bridge", Config{SingleUserMode: boolP(false)}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.SingleUserModeEnabled(); got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // TestPluginEntry_OnError covers the three accepted policy values plus
 // the omitted case. An invalid policy must fail loud at YAML parse
 // time so operators catch typos before the pod boots.

--- a/authbridge/authlib/plugins/e2e_single_user_test.go
+++ b/authbridge/authlib/plugins/e2e_single_user_test.go
@@ -1,0 +1,473 @@
+package plugins_test
+
+// End-to-end test for single-player mode (inbound→outbound token
+// bridging). Exercises the realistic plugin stack:
+//
+//   1. Real RSA keypair + JWKS server (mock IdP)
+//   2. Real signed JWT presented on inbound
+//   3. Real plugins built via plugins.Build (same path as production)
+//   4. Real pipeline.Run dispatch with full Context wiring
+//   5. Mock token-exchange endpoint that echoes the subject_token so the
+//      assertion can prove the cached inbound token actually reached the
+//      IdP as subject_token (closing the loop end-to-end).
+//
+// Two pipelines are built — inbound and outbound — and a request is
+// driven through each. The package-level cache in authlib/auth is the
+// only shared state between them, mirroring how the binary uses them
+// (jwt-validation in the inbound pipeline, token-exchange in the
+// outbound pipeline, cache state spans the request boundary).
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+
+	"github.com/kagenti/kagenti-extensions/authbridge/authlib/auth"
+	"github.com/kagenti/kagenti-extensions/authbridge/authlib/config"
+	"github.com/kagenti/kagenti-extensions/authbridge/authlib/pipeline"
+	"github.com/kagenti/kagenti-extensions/authbridge/authlib/plugins"
+	_ "github.com/kagenti/kagenti-extensions/authbridge/authlib/plugins/jwtvalidation"
+	_ "github.com/kagenti/kagenti-extensions/authbridge/authlib/plugins/tokenexchange"
+)
+
+// --- Test harness ---
+
+type e2eHarness struct {
+	jwksSrv     *httptest.Server
+	exchangeSrv *httptest.Server
+	privKey     *rsa.PrivateKey
+	issuer      string
+
+	// receivedSubjectTokens records every subject_token the mock token
+	// exchange endpoint observed, in order. Used to prove the cached
+	// inbound token reached the IdP.
+	receivedSubjectTokens []string
+}
+
+// newE2EHarness boots a JWKS server and a token-exchange server. Both
+// are torn down via t.Cleanup so the test owns no resources after
+// returning.
+func newE2EHarness(t *testing.T) *e2eHarness {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubJWK, err := jwk.FromRaw(priv.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = pubJWK.Set(jwk.KeyIDKey, "e2e-key-1")
+	_ = pubJWK.Set(jwk.AlgorithmKey, jwa.RS256)
+	keySet := jwk.NewSet()
+	_ = keySet.AddKey(pubJWK)
+
+	jwksSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(keySet)
+	}))
+	t.Cleanup(jwksSrv.Close)
+
+	h := &e2eHarness{
+		privKey: priv,
+		jwksSrv: jwksSrv,
+		issuer:  "http://e2e-issuer.example",
+	}
+
+	// Token-exchange endpoint: returns "exchanged-{subject_token}" so
+	// the test can verify the cached inbound token actually reached the
+	// IdP as subject_token. Records each call for later assertions.
+	h.exchangeSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		subj := r.PostFormValue("subject_token")
+		h.receivedSubjectTokens = append(h.receivedSubjectTokens, subj)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "exchanged-" + subj,
+			"token_type":   "Bearer",
+			"expires_in":   300,
+		})
+	}))
+	t.Cleanup(h.exchangeSrv.Close)
+
+	return h
+}
+
+// signJWT creates a signed RS256 JWT with reasonable defaults plus any
+// caller-supplied claims (e.g., subject, exp).
+func (h *e2eHarness) signJWT(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	defaults := map[string]any{
+		"iss": h.issuer,
+		"aud": []string{"agent-aud"},
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(2 * time.Minute).Unix(),
+	}
+	for k, v := range claims {
+		defaults[k] = v
+	}
+	builder := jwt.New()
+	for k, v := range defaults {
+		_ = builder.Set(k, v)
+	}
+	privJWK, err := jwk.FromRaw(h.privKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = privJWK.Set(jwk.KeyIDKey, "e2e-key-1")
+	_ = privJWK.Set(jwk.AlgorithmKey, jwa.RS256)
+	signed, err := jwt.Sign(builder, jwt.WithKey(jwa.RS256, privJWK))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(signed)
+}
+
+// buildInboundPipeline returns a Pipeline configured with jwt-validation
+// against the harness's JWKS server.
+func (h *e2eHarness) buildInboundPipeline(t *testing.T) *pipeline.Pipeline {
+	t.Helper()
+	jwtCfg := json.RawMessage(fmt.Sprintf(`{
+		"issuer": %q,
+		"jwks_url": %q,
+		"audience": "agent-aud"
+	}`, h.issuer, h.jwksSrv.URL))
+	p, err := plugins.Build([]config.PluginEntry{
+		{Name: "jwt-validation", Config: jwtCfg},
+	})
+	if err != nil {
+		t.Fatalf("inbound Build: %v", err)
+	}
+	return p
+}
+
+// buildOutboundPipeline returns a Pipeline configured with token-exchange
+// pointed at the harness's exchange endpoint, with one route mapping the
+// host "target-svc" to a fixed audience.
+func (h *e2eHarness) buildOutboundPipeline(t *testing.T) *pipeline.Pipeline {
+	t.Helper()
+	tokCfg := json.RawMessage(fmt.Sprintf(`{
+		"token_url": %q,
+		"default_policy": "exchange",
+		"identity": {"type":"client-secret","client_id":"agent","client_secret":"secret"},
+		"routes": {"rules": [{"host":"target-svc","target_audience":"downstream-aud"}]}
+	}`, h.exchangeSrv.URL))
+	p, err := plugins.Build([]config.PluginEntry{
+		{Name: "token-exchange", Config: tokCfg},
+	})
+	if err != nil {
+		t.Fatalf("outbound Build: %v", err)
+	}
+	return p
+}
+
+// runInbound dispatches a Context through the inbound pipeline with the
+// given Bearer token. Sets framework attribution like the real listener.
+func runInbound(t *testing.T, p *pipeline.Pipeline, bearer string) (*pipeline.Context, pipeline.Action) {
+	t.Helper()
+	pctx := &pipeline.Context{
+		Direction: pipeline.Inbound,
+		Headers:   http.Header{},
+		Path:      "/api/call",
+	}
+	if bearer != "" {
+		pctx.Headers.Set("Authorization", "Bearer "+bearer)
+	}
+	action := p.Run(context.Background(), pctx)
+	return pctx, action
+}
+
+// runOutbound dispatches a Context through the outbound pipeline with
+// the given (optional) Bearer header.
+func runOutbound(t *testing.T, p *pipeline.Pipeline, bearer string) (*pipeline.Context, pipeline.Action) {
+	t.Helper()
+	pctx := &pipeline.Context{
+		Direction: pipeline.Outbound,
+		Host:      "target-svc",
+		Headers:   http.Header{},
+	}
+	if bearer != "" {
+		pctx.Headers.Set("Authorization", "Bearer "+bearer)
+	}
+	action := p.Run(context.Background(), pctx)
+	return pctx, action
+}
+
+// withSingleUserMode flips the package-level enabled bit and restores
+// the prior state on cleanup.
+func withSingleUserMode(t *testing.T, enabled bool) {
+	t.Helper()
+	prev := auth.IsSingleUserModeEnabled()
+	auth.SetSingleUserModeEnabled(enabled)
+	t.Cleanup(func() { auth.SetSingleUserModeEnabled(prev) })
+}
+
+// --- The actual scenarios ---
+
+// TestE2E_SinglePlayerMode_HappyPath is the headline test: an agent
+// receives a user JWT inbound, then makes an outbound call WITHOUT
+// propagating the Authorization header (mimicking LangChain's tool
+// execution model). With single-player mode on, the cached inbound
+// token reaches the IdP as subject_token and the exchanged result
+// lands on the outbound request.
+func TestE2E_SinglePlayerMode_HappyPath(t *testing.T) {
+	withSingleUserMode(t, true)
+	t.Cleanup(auth.ResetSingleUserToken)
+
+	h := newE2EHarness(t)
+	inbound := h.buildInboundPipeline(t)
+	outbound := h.buildOutboundPipeline(t)
+
+	// Sign a fresh JWT for "alice" and present it on inbound.
+	userJWT := h.signJWT(t, map[string]any{"sub": "alice"})
+	pctxIn, actionIn := runInbound(t, inbound, userJWT)
+
+	if actionIn.Type != pipeline.Continue {
+		t.Fatalf("inbound: expected Continue, got %v (violation=%+v)", actionIn.Type, actionIn.Violation)
+	}
+	if pctxIn.Identity == nil || pctxIn.Identity.Subject() != "alice" {
+		t.Fatalf("inbound: Identity.Subject() = %v, want alice", pctxIn.Identity)
+	}
+
+	// The cache should now hold alice's token.
+	cached, sub, ok := auth.GetSingleUserToken(time.Now())
+	if !ok {
+		t.Fatal("inbound did not capture token into single-user store")
+	}
+	if cached != userJWT {
+		t.Errorf("cached token mismatch: got len=%d, want len=%d", len(cached), len(userJWT))
+	}
+	if sub != "alice" {
+		t.Errorf("cached subject = %q, want alice", sub)
+	}
+
+	// Now simulate the agent making an outbound call WITHOUT propagating
+	// the Authorization header (the LangChain/CrewAI/Claude Code shape).
+	pctxOut, actionOut := runOutbound(t, outbound, "")
+	if actionOut.Type != pipeline.Continue {
+		t.Fatalf("outbound: expected Continue, got %v (violation=%+v)", actionOut.Type, actionOut.Violation)
+	}
+
+	// The downstream-bound Authorization header should be the EXCHANGED
+	// version of alice's cached token.
+	gotAuth := pctxOut.Headers.Get("Authorization")
+	wantAuth := "Bearer exchanged-" + userJWT
+	if gotAuth != wantAuth {
+		t.Errorf("outbound Authorization mismatch:\n  got:  %q\n  want: %q", gotAuth, wantAuth)
+	}
+
+	// And the exchange endpoint should have seen alice's token as
+	// subject_token (closing the loop end-to-end).
+	if len(h.receivedSubjectTokens) != 1 {
+		t.Fatalf("token exchange: got %d calls, want 1", len(h.receivedSubjectTokens))
+	}
+	if h.receivedSubjectTokens[0] != userJWT {
+		t.Errorf("subject_token sent to IdP did not match captured inbound token")
+	}
+
+	// Telemetry: one cache_hit invocation from the cache lookup, one
+	// token_replaced invocation from the exchange.
+	if pctxOut.Extensions.Invocations == nil {
+		t.Fatal("outbound invocations not recorded")
+	}
+	var cacheHit, replaced bool
+	for _, inv := range pctxOut.Extensions.Invocations.Outbound {
+		if inv.Reason == "single_user_cache_hit" {
+			cacheHit = true
+		}
+		if inv.Reason == "token_replaced" {
+			replaced = true
+		}
+	}
+	if !cacheHit {
+		t.Error("expected single_user_cache_hit invocation")
+	}
+	if !replaced {
+		t.Error("expected token_replaced invocation")
+	}
+}
+
+// TestE2E_SinglePlayerMode_DisabledFallsThroughToNoTokenPolicy: the same
+// scenario as the happy path but with single_user_mode=false. The cache
+// is never consulted, so the outbound request is denied by the default
+// no_token_policy.
+func TestE2E_SinglePlayerMode_DisabledFallsThroughToNoTokenPolicy(t *testing.T) {
+	withSingleUserMode(t, false)
+	t.Cleanup(auth.ResetSingleUserToken)
+
+	h := newE2EHarness(t)
+	inbound := h.buildInboundPipeline(t)
+	outbound := h.buildOutboundPipeline(t)
+
+	userJWT := h.signJWT(t, map[string]any{"sub": "alice"})
+	if _, action := runInbound(t, inbound, userJWT); action.Type != pipeline.Continue {
+		t.Fatalf("inbound: expected Continue, got %v", action.Type)
+	}
+
+	// Capture should have been a no-op (Store gated).
+	if _, _, ok := auth.GetSingleUserToken(time.Now()); ok {
+		// We can't directly probe the gate-disabled state without
+		// re-enabling, but Get also short-circuits when disabled, so
+		// this branch can't fire under normal conditions. Still
+		// asserts the right post-condition.
+		t.Error("expected cache miss while single-user mode is disabled")
+	}
+
+	// Outbound with no header should fail the no-token-policy check.
+	_, action := runOutbound(t, outbound, "")
+	if action.Type != pipeline.Reject {
+		t.Errorf("outbound: expected Reject (no_token_policy=deny), got %v", action.Type)
+	}
+
+	// IdP must NOT have been called.
+	if len(h.receivedSubjectTokens) != 0 {
+		t.Errorf("token exchange: got %d calls, want 0 (cache never consulted when disabled)", len(h.receivedSubjectTokens))
+	}
+}
+
+// TestE2E_SinglePlayerMode_ExplicitHeaderWins: when the agent DOES
+// propagate the inbound Authorization header (the well-behaved case),
+// the cache must not override it.
+func TestE2E_SinglePlayerMode_ExplicitHeaderWins(t *testing.T) {
+	withSingleUserMode(t, true)
+	t.Cleanup(auth.ResetSingleUserToken)
+
+	h := newE2EHarness(t)
+	inbound := h.buildInboundPipeline(t)
+	outbound := h.buildOutboundPipeline(t)
+
+	// Inbound: alice's JWT — captured into the cache.
+	aliceJWT := h.signJWT(t, map[string]any{"sub": "alice"})
+	if _, action := runInbound(t, inbound, aliceJWT); action.Type != pipeline.Continue {
+		t.Fatalf("inbound: expected Continue, got %v", action.Type)
+	}
+
+	// Outbound WITH explicit (different) header — this is the
+	// well-behaved agent that propagated something itself.
+	explicitToken := "explicit-tok"
+	pctxOut, actionOut := runOutbound(t, outbound, explicitToken)
+	if actionOut.Type != pipeline.Continue {
+		t.Fatalf("outbound: expected Continue, got %v", actionOut.Type)
+	}
+
+	// The exchange should have used the EXPLICIT token, not the cached one.
+	gotAuth := pctxOut.Headers.Get("Authorization")
+	wantAuth := "Bearer exchanged-" + explicitToken
+	if gotAuth != wantAuth {
+		t.Errorf("explicit header should win:\n  got:  %q\n  want: %q", gotAuth, wantAuth)
+	}
+
+	if len(h.receivedSubjectTokens) != 1 || h.receivedSubjectTokens[0] != explicitToken {
+		t.Errorf("subject_token sent to IdP = %v, want [%s] (explicit)", h.receivedSubjectTokens, explicitToken)
+	}
+
+	// No cache_hit invocation (the lookup branch is gated on missing header).
+	if pctxOut.Extensions.Invocations != nil {
+		for _, inv := range pctxOut.Extensions.Invocations.Outbound {
+			if inv.Reason == "single_user_cache_hit" {
+				t.Error("cache_hit invocation should not fire when explicit header is present")
+			}
+		}
+	}
+}
+
+// TestE2E_SinglePlayerMode_BypassPathDoesNotPoison: a /healthz request
+// that bypasses jwt-validation should not populate the cache, even when
+// it carries an Authorization header. Otherwise an unauthenticated
+// liveness probe could poison the bridge.
+func TestE2E_SinglePlayerMode_BypassPathDoesNotPoison(t *testing.T) {
+	withSingleUserMode(t, true)
+	t.Cleanup(auth.ResetSingleUserToken)
+
+	h := newE2EHarness(t)
+	inbound := h.buildInboundPipeline(t)
+
+	// Send a /healthz request with a "Bearer suspicious-token" — it
+	// should be bypassed before validation, and the cache stays empty.
+	pctx := &pipeline.Context{
+		Direction: pipeline.Inbound,
+		Headers:   http.Header{},
+		Path:      "/healthz",
+	}
+	pctx.Headers.Set("Authorization", "Bearer suspicious-token")
+	if action := inbound.Run(context.Background(), pctx); action.Type != pipeline.Continue {
+		t.Fatalf("bypass: expected Continue, got %v", action.Type)
+	}
+
+	if _, _, ok := auth.GetSingleUserToken(time.Now()); ok {
+		t.Error("bypass path must not populate single-user cache")
+	}
+}
+
+// TestE2E_SinglePlayerMode_SecondInboundOverwrites simulates the
+// single-player assumption being violated mid-session: alice's token is
+// captured, then bob's token arrives. Last-write-wins (documented).
+// Subsequent outbound exchanges use bob's token.
+func TestE2E_SinglePlayerMode_SecondInboundOverwrites(t *testing.T) {
+	withSingleUserMode(t, true)
+	t.Cleanup(auth.ResetSingleUserToken)
+
+	h := newE2EHarness(t)
+	inbound := h.buildInboundPipeline(t)
+	outbound := h.buildOutboundPipeline(t)
+
+	aliceJWT := h.signJWT(t, map[string]any{"sub": "alice"})
+	if _, action := runInbound(t, inbound, aliceJWT); action.Type != pipeline.Continue {
+		t.Fatalf("alice inbound: %v", action.Type)
+	}
+
+	bobJWT := h.signJWT(t, map[string]any{"sub": "bob"})
+	if _, action := runInbound(t, inbound, bobJWT); action.Type != pipeline.Continue {
+		t.Fatalf("bob inbound: %v", action.Type)
+	}
+
+	// Outbound now should pick up BOB's token (last write).
+	pctxOut, actionOut := runOutbound(t, outbound, "")
+	if actionOut.Type != pipeline.Continue {
+		t.Fatalf("outbound: %v", actionOut.Type)
+	}
+	wantAuth := "Bearer exchanged-" + bobJWT
+	if got := pctxOut.Headers.Get("Authorization"); got != wantAuth {
+		t.Errorf("expected last-write-wins (bob), got Authorization=%q", got)
+	}
+
+	// IdP saw bob's token.
+	if len(h.receivedSubjectTokens) != 1 || h.receivedSubjectTokens[0] != bobJWT {
+		t.Errorf("subject_token sent to IdP did not match bob's JWT")
+	}
+}
+
+// TestE2E_SinglePlayerMode_NearExpiryTokenSkipped: a JWT that's about to
+// expire (below the MinTTL floor) should NOT be cached — otherwise the
+// next outbound exchange races the token's lifetime and may receive a
+// fresh-but-already-expired access token.
+func TestE2E_SinglePlayerMode_NearExpiryTokenSkipped(t *testing.T) {
+	withSingleUserMode(t, true)
+	t.Cleanup(auth.ResetSingleUserToken)
+
+	h := newE2EHarness(t)
+	inbound := h.buildInboundPipeline(t)
+
+	// 10-second exp is below the 30-second floor.
+	nearExpiryJWT := h.signJWT(t, map[string]any{
+		"sub": "alice",
+		"exp": time.Now().Add(10 * time.Second).Unix(),
+	})
+	if _, action := runInbound(t, inbound, nearExpiryJWT); action.Type != pipeline.Continue {
+		t.Fatalf("inbound: %v", action.Type)
+	}
+
+	if _, _, ok := auth.GetSingleUserToken(time.Now()); ok {
+		t.Error("near-expiry token should not be cached (below MinTTL floor)")
+	}
+}

--- a/authbridge/authlib/plugins/jwtvalidation/plugin.go
+++ b/authbridge/authlib/plugins/jwtvalidation/plugin.go
@@ -433,7 +433,14 @@ func (p *JWTValidation) captureSingleUserToken(authHeader string, claims *valida
 	}
 	prevSub := auth.StoreSingleUserToken(token, claims.Subject, cappedExp)
 	if prevSub != "" && prevSub != claims.Subject {
-		slog.Warn("jwt-validation: single-user cached subject changed — single-player assumption violated; last-write-wins",
+		// The auth package atomically increments the subject-change
+		// counter inside Store; jwt-validation surfaces the same event
+		// as a human-readable WARN. Operators should alert on the
+		// counter delta (auth.SingleUserSubjectChangeCount) rather
+		// than log-grepping this line — at high concurrent multi-user
+		// volumes the WARN fires per-overwrite and becomes log noise
+		// rather than a precise signal.
+		slog.Warn("jwt-validation: single-user cached subject changed — single-player assumption violated; last-write-wins. See auth.SingleUserSubjectChangeCount for the alertable counter.",
 			"previous", prevSub,
 			"current", claims.Subject)
 	}

--- a/authbridge/authlib/plugins/jwtvalidation/plugin.go
+++ b/authbridge/authlib/plugins/jwtvalidation/plugin.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/auth"
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/bypass"
@@ -397,7 +398,45 @@ func (p *JWTValidation) OnRequest(ctx context.Context, pctx *pipeline.Context) p
 			"token_scopes":   strings.Join(result.Claims.Scopes, " "),
 		},
 	})
+
+	// Capture the validated token into the process-level single-user
+	// store so the outbound token-exchange plugin can use it as
+	// subject_token when the agent didn't propagate the Authorization
+	// header. The store itself is gated on the top-level
+	// Config.SingleUserMode flag (auth.SetSingleUserModeEnabled, called
+	// once at startup): when disabled, Store is a no-op and this branch
+	// is harmless. See authbridge/docs/plugin-reference.md for the
+	// single-player constraint.
+	p.captureSingleUserToken(authHeader, result.Claims)
 	return pipeline.Action{Type: pipeline.Continue}
+}
+
+// captureSingleUserToken caches the freshly-validated bearer for the
+// outbound side to consume. Re-uses the jwt-validation-trusted exp from
+// claims rather than re-parsing the JWT, and applies the package-level
+// cap/floor policy in auth.CapSingleUserExpiry.
+//
+// Best-effort: any branch that returns early (empty token, near-expiry
+// floor) is silent because the operational outcome is identical to
+// "feature disabled" — the outbound side will fall through to its
+// no-token policy on cache miss. The tripwire WARN fires only when a
+// successful capture overwrites a different subject, which is the
+// situation the operator needs to know about.
+func (p *JWTValidation) captureSingleUserToken(authHeader string, claims *validation.Claims) {
+	token := auth.ExtractBearer(authHeader)
+	if token == "" {
+		return
+	}
+	cappedExp, ok := auth.CapSingleUserExpiry(time.Now(), claims.ExpiresAt)
+	if !ok {
+		return
+	}
+	prevSub := auth.StoreSingleUserToken(token, claims.Subject, cappedExp)
+	if prevSub != "" && prevSub != claims.Subject {
+		slog.Warn("jwt-validation: single-user cached subject changed — single-player assumption violated; last-write-wins",
+			"previous", prevSub,
+			"current", claims.Subject)
+	}
 }
 
 func (p *JWTValidation) OnResponse(_ context.Context, _ *pipeline.Context) pipeline.Action {

--- a/authbridge/authlib/plugins/jwtvalidation/plugin_test.go
+++ b/authbridge/authlib/plugins/jwtvalidation/plugin_test.go
@@ -1,12 +1,16 @@
 package jwtvalidation
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/auth"
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/bypass"
@@ -389,5 +393,200 @@ func TestJWTValidation_Configure_AllowedAudiencesUnionsLiteral(t *testing.T) {
 	want := []string{"public-ui", "spi-like-id"}
 	if !slices.Equal(got, want) {
 		t.Errorf("InboundAudiences() = %#v, want %#v", got, want)
+	}
+}
+
+// --- Single-user capture (single-player mode) ---
+
+// allowClaimsForCapture builds a Claims that satisfies the inner Auth's
+// allow path with a future-dated ExpiresAt comfortably above MinTTL and
+// below MaxTTL — so capture happens via the happy-path code branch
+// rather than getting elided by the cap/floor policy.
+func allowClaimsForCapture(t *testing.T, subject string) *validation.Claims {
+	t.Helper()
+	return &validation.Claims{
+		Subject:   subject,
+		Issuer:    "http://issuer.example",
+		Audience:  []string{"agent-aud"},
+		ClientID:  "caller",
+		Scopes:    []string{"openid"},
+		ExpiresAt: time.Now().Add(2 * time.Minute),
+	}
+}
+
+func newCapturePlugin(t *testing.T, claims *validation.Claims) *JWTValidation {
+	t.Helper()
+	inner := auth.New(auth.Config{
+		Verifier: &mockJWTVerifier{claims: claims},
+		Identity: auth.IdentityConfig{Audiences: []string{"agent-aud"}},
+	})
+	return newTestJWTValidation(t, "http://issuer.example", inner)
+}
+
+// withSingleUserMode flips the package-level enabled bit for the test
+// and restores it on cleanup.
+func withSingleUserMode(t *testing.T, enabled bool) {
+	t.Helper()
+	prev := auth.IsSingleUserModeEnabled()
+	auth.SetSingleUserModeEnabled(enabled)
+	t.Cleanup(func() { auth.SetSingleUserModeEnabled(prev) })
+}
+
+func TestJWTValidation_Capture_Enabled_ValidToken(t *testing.T) {
+	withSingleUserMode(t, true)
+	t.Cleanup(auth.ResetSingleUserToken)
+
+	p := newCapturePlugin(t, allowClaimsForCapture(t, "alice"))
+
+	pctx := &pipeline.Context{Headers: http.Header{}, Path: "/api/call"}
+	pctx.Headers.Set("Authorization", "Bearer tok-1")
+
+	if got := invokeOnRequest(p, pctx).Type; got != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", got)
+	}
+
+	tok, sub, ok := auth.GetSingleUserToken(time.Now())
+	if !ok {
+		t.Fatal("expected cache hit after capture")
+	}
+	if tok != "tok-1" || sub != "alice" {
+		t.Errorf("cache = (%q, %q), want (tok-1, alice)", tok, sub)
+	}
+}
+
+func TestJWTValidation_Capture_Disabled_NoCacheWrite(t *testing.T) {
+	withSingleUserMode(t, false)
+	t.Cleanup(auth.ResetSingleUserToken)
+
+	p := newCapturePlugin(t, allowClaimsForCapture(t, "alice"))
+
+	pctx := &pipeline.Context{Headers: http.Header{}, Path: "/api/call"}
+	pctx.Headers.Set("Authorization", "Bearer tok-1")
+
+	invokeOnRequest(p, pctx)
+
+	// Re-enable for the read so we can confirm the cache really is
+	// empty (rather than just gated on Get).
+	auth.SetSingleUserModeEnabled(true)
+	if _, _, ok := auth.GetSingleUserToken(time.Now()); ok {
+		t.Error("cache should not be populated when single_user_mode is disabled at the top level")
+	}
+}
+
+func TestJWTValidation_Capture_NearExpiry_Skipped(t *testing.T) {
+	withSingleUserMode(t, true)
+	t.Cleanup(auth.ResetSingleUserToken)
+
+	// 10s from now < MinTTL (30s); CapSingleUserExpiry returns false
+	// and capture is skipped.
+	claims := allowClaimsForCapture(t, "alice")
+	claims.ExpiresAt = time.Now().Add(10 * time.Second)
+
+	p := newCapturePlugin(t, claims)
+
+	pctx := &pipeline.Context{Headers: http.Header{}, Path: "/api/call"}
+	pctx.Headers.Set("Authorization", "Bearer tok-1")
+
+	invokeOnRequest(p, pctx)
+
+	if _, _, ok := auth.GetSingleUserToken(time.Now()); ok {
+		t.Error("cache should not be populated when token is near expiry (below MinTTL floor)")
+	}
+}
+
+func TestJWTValidation_Capture_LongLived_Capped(t *testing.T) {
+	withSingleUserMode(t, true)
+	t.Cleanup(auth.ResetSingleUserToken)
+
+	// 1h from now > MaxTTL (5m); cached exp should be capped at
+	// approximately now+MaxTTL — verify by probing Get with a future "now".
+	claims := allowClaimsForCapture(t, "alice")
+	claims.ExpiresAt = time.Now().Add(1 * time.Hour)
+
+	p := newCapturePlugin(t, claims)
+
+	pctx := &pipeline.Context{Headers: http.Header{}, Path: "/api/call"}
+	pctx.Headers.Set("Authorization", "Bearer tok-1")
+
+	invokeOnRequest(p, pctx)
+
+	// Just past MaxTTL: cache should report miss, proving the exp was
+	// capped (otherwise the original 1h exp would still be valid).
+	pastMaxTTL := time.Now().Add(6 * time.Minute)
+	if _, _, ok := auth.GetSingleUserToken(pastMaxTTL); ok {
+		t.Error("cache should expire at MaxTTL even when token's natural exp is later")
+	}
+
+	// Sanity: still valid right now.
+	if _, _, ok := auth.GetSingleUserToken(time.Now()); !ok {
+		t.Error("cache should be populated immediately after capture")
+	}
+}
+
+func TestJWTValidation_Capture_SubjectChange_EmitsWarn(t *testing.T) {
+	withSingleUserMode(t, true)
+	t.Cleanup(auth.ResetSingleUserToken)
+
+	var logBuf bytes.Buffer
+	prevDefault := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prevDefault) })
+
+	// First capture: alice. No warn.
+	p := newCapturePlugin(t, allowClaimsForCapture(t, "alice"))
+	pctx := &pipeline.Context{Headers: http.Header{}, Path: "/api/call"}
+	pctx.Headers.Set("Authorization", "Bearer tok-alice")
+	invokeOnRequest(p, pctx)
+
+	if strings.Contains(logBuf.String(), "subject changed") {
+		t.Fatalf("first capture should not warn, got: %s", logBuf.String())
+	}
+
+	// Second capture: bob — single-player assumption violated.
+	p2 := newCapturePlugin(t, allowClaimsForCapture(t, "bob"))
+	pctx2 := &pipeline.Context{Headers: http.Header{}, Path: "/api/call"}
+	pctx2.Headers.Set("Authorization", "Bearer tok-bob")
+	invokeOnRequest(p2, pctx2)
+
+	out := logBuf.String()
+	if !strings.Contains(out, "single-user cached subject changed") {
+		t.Errorf("expected subject-change WARN, log was: %s", out)
+	}
+	if !strings.Contains(out, "previous=alice") || !strings.Contains(out, "current=bob") {
+		t.Errorf("expected previous=alice and current=bob in log, got: %s", out)
+	}
+
+	// Same subject re-captured: no warn.
+	logBuf.Reset()
+	p3 := newCapturePlugin(t, allowClaimsForCapture(t, "bob"))
+	pctx3 := &pipeline.Context{Headers: http.Header{}, Path: "/api/call"}
+	pctx3.Headers.Set("Authorization", "Bearer tok-bob-2")
+	invokeOnRequest(p3, pctx3)
+	if strings.Contains(logBuf.String(), "subject changed") {
+		t.Errorf("same-subject re-capture should not warn, got: %s", logBuf.String())
+	}
+}
+
+func TestJWTValidation_Capture_BypassPath_NoCacheWrite(t *testing.T) {
+	withSingleUserMode(t, true)
+	t.Cleanup(auth.ResetSingleUserToken)
+
+	matcher, _ := bypass.NewMatcher(bypass.DefaultPatterns)
+	inner := auth.New(auth.Config{
+		Bypass:   matcher,
+		Verifier: &mockJWTVerifier{claims: allowClaimsForCapture(t, "alice")},
+		Identity: auth.IdentityConfig{Audiences: []string{"agent-aud"}},
+	})
+	p := newTestJWTValidation(t, "http://issuer.example", inner)
+
+	// /healthz is in DefaultPatterns; bypass returns Continue with nil
+	// Claims, the capture branch is gated on the success path which
+	// runs only after pctx.Identity is set.
+	pctx := &pipeline.Context{Headers: http.Header{}, Path: "/healthz"}
+	pctx.Headers.Set("Authorization", "Bearer tok-1")
+	invokeOnRequest(p, pctx)
+
+	if _, _, ok := auth.GetSingleUserToken(time.Now()); ok {
+		t.Error("bypass path should not populate single-user cache")
 	}
 }

--- a/authbridge/authlib/plugins/tokenexchange/plugin.go
+++ b/authbridge/authlib/plugins/tokenexchange/plugin.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/auth"
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/config"
@@ -473,6 +474,29 @@ func (p *TokenExchange) OnRequest(ctx context.Context, pctx *pipeline.Context) p
 	}
 	authHeader := pctx.Headers.Get("Authorization")
 	host := pctx.Host
+
+	// Single-player fallback: if the outbound request arrived without an
+	// Authorization header, fetch the most recent validated inbound
+	// token from the process-level single-user store and inject it.
+	// The whole feature is gated on the top-level Config.SingleUserMode
+	// flag (auth.SetSingleUserModeEnabled, called once at startup):
+	// when disabled, GetSingleUserToken returns ok=false and this
+	// branch is a no-op. Explicit outbound headers always win — we
+	// never override an agent-supplied token. Cache miss is silent and
+	// falls through to the existing no-token policy in HandleOutbound.
+	if authHeader == "" {
+		if cached, _, ok := auth.GetSingleUserToken(time.Now()); ok {
+			authHeader = "Bearer " + cached
+			pctx.Headers.Set("Authorization", authHeader)
+			pctx.Record(pipeline.Invocation{
+				Action: pipeline.ActionModify,
+				Reason: "single_user_cache_hit",
+				Details: map[string]string{
+					"route_host": host,
+				},
+			})
+		}
+	}
 
 	result := p.inner.HandleOutbound(ctx, authHeader, host)
 	// Record an Auth.Outbound entry on every branch so operators have

--- a/authbridge/authlib/plugins/tokenexchange/plugin_test.go
+++ b/authbridge/authlib/plugins/tokenexchange/plugin_test.go
@@ -6,7 +6,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/kagenti/kagenti-extensions/authbridge/authlib/auth"
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/pipeline"
 )
 
@@ -325,5 +327,206 @@ func TestTokenExchange_NoToken_Deny(t *testing.T) {
 	status, _, _ := action.Violation.Render()
 	if status != http.StatusUnauthorized {
 		t.Errorf("status = %d, want 401", status)
+	}
+}
+
+// --- Single-player mode (cache-fallback for missing inbound header) ---
+
+// newSPExchangeServer returns an httptest token endpoint that responds
+// with "exchanged-{subject_token}" as the access token, so the test can
+// assert that the right subject_token reached the IdP.
+func newSPExchangeServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		subj := r.PostFormValue("subject_token")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "exchanged-" + subj,
+			"token_type":   "Bearer",
+			"expires_in":   300,
+		})
+	}))
+}
+
+// configureSPPlugin configures a plugin against a stand-up exchange
+// server with a single route mapping any host to a target audience.
+// The single-player feature is now controlled top-level via
+// auth.SetSingleUserModeEnabled, not via plugin config.
+func configureSPPlugin(t *testing.T, exchangeURL string) *TokenExchange {
+	t.Helper()
+	p := NewTokenExchange()
+	cfg := map[string]any{
+		"token_url":      exchangeURL,
+		"default_policy": "exchange",
+		"identity": map[string]any{
+			"type":          "client-secret",
+			"client_id":     "agent",
+			"client_secret": "secret",
+		},
+		"routes": map[string]any{
+			"rules": []map[string]any{
+				{"host": "target-svc", "target_audience": "downstream-aud"},
+			},
+		},
+	}
+	raw, _ := json.Marshal(cfg)
+	if err := p.Configure(raw); err != nil {
+		t.Fatalf("Configure: %v", err)
+	}
+	return p
+}
+
+// withSingleUserMode flips the package-level enabled bit for the test
+// and restores it on cleanup.
+func withSingleUserMode(t *testing.T, enabled bool) {
+	t.Helper()
+	prev := auth.IsSingleUserModeEnabled()
+	auth.SetSingleUserModeEnabled(enabled)
+	t.Cleanup(func() { auth.SetSingleUserModeEnabled(prev) })
+}
+
+func TestTokenExchange_SingleUserMode_CacheHit_InjectsToken(t *testing.T) {
+	withSingleUserMode(t, true)
+	t.Cleanup(auth.ResetSingleUserToken)
+	srv := newSPExchangeServer(t)
+	defer srv.Close()
+
+	auth.StoreSingleUserToken("inbound-tok", "alice", time.Now().Add(2*time.Minute))
+
+	p := configureSPPlugin(t, srv.URL)
+
+	// Outbound request with NO Authorization header.
+	pctx := &pipeline.Context{
+		Direction: pipeline.Outbound,
+		Host:      "target-svc",
+		Headers:   http.Header{},
+	}
+	if got := invokeOnRequest(p, pctx).Type; got != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", got)
+	}
+
+	// Authorization should be the exchanged token derived from the
+	// cached subject_token.
+	got := pctx.Headers.Get("Authorization")
+	want := "Bearer exchanged-inbound-tok"
+	if got != want {
+		t.Errorf("Authorization = %q, want %q (proves cached token used as subject_token)", got, want)
+	}
+
+	// Two outbound entries: cache_hit modify, plus the actual exchange's
+	// token_replaced modify.
+	if pctx.Extensions.Invocations == nil {
+		t.Fatal("expected invocations recorded")
+	}
+	var cacheHit, replaced bool
+	for _, inv := range pctx.Extensions.Invocations.Outbound {
+		if inv.Reason == "single_user_cache_hit" {
+			cacheHit = true
+		}
+		if inv.Reason == "token_replaced" {
+			replaced = true
+		}
+	}
+	if !cacheHit {
+		t.Error("expected single_user_cache_hit invocation")
+	}
+	if !replaced {
+		t.Error("expected token_replaced invocation (exchange should have run on the cached token)")
+	}
+}
+
+func TestTokenExchange_SingleUserMode_CacheMiss_NoTokenPolicy(t *testing.T) {
+	withSingleUserMode(t, true)
+	t.Cleanup(auth.ResetSingleUserToken)
+	srv := newSPExchangeServer(t)
+	defer srv.Close()
+
+	// Cache empty — verify reset is in effect.
+	if _, _, ok := auth.GetSingleUserToken(time.Now()); ok {
+		t.Fatal("test prelude: cache should be empty after reset")
+	}
+
+	p := configureSPPlugin(t, srv.URL)
+
+	pctx := &pipeline.Context{
+		Direction: pipeline.Outbound,
+		Host:      "target-svc",
+		Headers:   http.Header{},
+	}
+	action := invokeOnRequest(p, pctx)
+
+	// Default no_token_policy is "deny".
+	if action.Type != pipeline.Reject {
+		t.Errorf("got %v, want Reject (cache miss should fall through to no_token_policy=deny)", action.Type)
+	}
+	if pctx.Headers.Get("Authorization") != "" {
+		t.Error("Authorization should remain empty on cache miss")
+	}
+}
+
+func TestTokenExchange_SingleUserMode_ExplicitHeaderWins(t *testing.T) {
+	withSingleUserMode(t, true)
+	t.Cleanup(auth.ResetSingleUserToken)
+	srv := newSPExchangeServer(t)
+	defer srv.Close()
+
+	auth.StoreSingleUserToken("inbound-tok", "alice", time.Now().Add(2*time.Minute))
+
+	p := configureSPPlugin(t, srv.URL)
+
+	pctx := &pipeline.Context{
+		Direction: pipeline.Outbound,
+		Host:      "target-svc",
+		Headers:   http.Header{"Authorization": []string{"Bearer explicit-tok"}},
+	}
+	if got := invokeOnRequest(p, pctx).Type; got != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", got)
+	}
+
+	// Explicit header should be used as subject_token, not the cached one.
+	got := pctx.Headers.Get("Authorization")
+	want := "Bearer exchanged-explicit-tok"
+	if got != want {
+		t.Errorf("Authorization = %q, want %q (explicit header must win over cache)", got, want)
+	}
+
+	// No cache_hit invocation should be recorded — the cache lookup
+	// branch is gated on authHeader == "".
+	if pctx.Extensions.Invocations != nil {
+		for _, inv := range pctx.Extensions.Invocations.Outbound {
+			if inv.Reason == "single_user_cache_hit" {
+				t.Error("cache_hit invocation should not fire when explicit header is present")
+			}
+		}
+	}
+}
+
+func TestTokenExchange_SingleUserMode_DisabledIgnoresCache(t *testing.T) {
+	withSingleUserMode(t, false)
+	t.Cleanup(auth.ResetSingleUserToken)
+	srv := newSPExchangeServer(t)
+	defer srv.Close()
+
+	// Populate the cache while disabled — Store will no-op. Re-enable
+	// briefly to populate, then disable for the actual test.
+	auth.SetSingleUserModeEnabled(true)
+	auth.StoreSingleUserToken("inbound-tok", "alice", time.Now().Add(2*time.Minute))
+	auth.SetSingleUserModeEnabled(false)
+
+	p := configureSPPlugin(t, srv.URL)
+
+	pctx := &pipeline.Context{
+		Direction: pipeline.Outbound,
+		Host:      "target-svc",
+		Headers:   http.Header{},
+	}
+	action := invokeOnRequest(p, pctx)
+
+	// With the top-level flag disabled, GetSingleUserToken short-circuits
+	// to ok=false, so the cache lookup misses and we fall through to
+	// no_token_policy=deny.
+	if action.Type != pipeline.Reject {
+		t.Errorf("got %v, want Reject (cache should be ignored when single_user_mode is disabled at the top level)", action.Type)
 	}
 }

--- a/authbridge/cmd/authbridge-envoy/main.go
+++ b/authbridge/cmd/authbridge-envoy/main.go
@@ -132,7 +132,19 @@ func main() {
 	// auth package's inbound→outbound token bridge. Read from top-level
 	// config once at startup; jwt-validation captures and token-exchange
 	// reads the cache only when this is true.
-	auth.SetSingleUserModeEnabled(cfg.SingleUserModeEnabled())
+	//
+	// The startup log line below makes the active posture discoverable
+	// on every restart — important because the default-on behavior
+	// changes the security profile on upgrade for deployments that were
+	// previously failing OBO-with-non-propagating-agents at the
+	// no-token-policy boundary.
+	spmEnabled := cfg.SingleUserModeEnabled()
+	auth.SetSingleUserModeEnabled(spmEnabled)
+	if spmEnabled {
+		slog.Info("authbridge: single-user mode is ACTIVE — sidecar will bridge inbound→outbound user tokens for non-propagating agent runtimes. Safe ONLY for single-user-per-process workloads; multi-user concurrent agents must propagate the inbound Authorization header themselves and should set single_user_mode: false. See docs/plugin-reference.md.")
+	} else {
+		slog.Info("authbridge: single-user mode is DISABLED — agent must propagate the inbound Authorization header to outbound calls for OBO to work. See docs/plugin-reference.md.")
+	}
 
 	initCtx, initCancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer initCancel()

--- a/authbridge/cmd/authbridge-envoy/main.go
+++ b/authbridge/cmd/authbridge-envoy/main.go
@@ -128,6 +128,12 @@ func main() {
 		log.Fatalf("initial pipeline build: %v", err)
 	}
 
+	// Single-player mode is a process-wide feature gate consumed by the
+	// auth package's inbound→outbound token bridge. Read from top-level
+	// config once at startup; jwt-validation captures and token-exchange
+	// reads the cache only when this is true.
+	auth.SetSingleUserModeEnabled(cfg.SingleUserModeEnabled())
+
 	initCtx, initCancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer initCancel()
 	if err := inboundPipeline.Start(initCtx); err != nil {

--- a/authbridge/cmd/authbridge-lite/main.go
+++ b/authbridge/cmd/authbridge-lite/main.go
@@ -121,6 +121,12 @@ func main() {
 		log.Fatalf("initial pipeline build: %v", err)
 	}
 
+	// Single-player mode is a process-wide feature gate consumed by the
+	// auth package's inbound→outbound token bridge. Read from top-level
+	// config once at startup; jwt-validation captures and token-exchange
+	// reads the cache only when this is true.
+	auth.SetSingleUserModeEnabled(cfg.SingleUserModeEnabled())
+
 	initCtx, initCancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer initCancel()
 	if err := inboundPipeline.Start(initCtx); err != nil {

--- a/authbridge/cmd/authbridge-lite/main.go
+++ b/authbridge/cmd/authbridge-lite/main.go
@@ -125,7 +125,19 @@ func main() {
 	// auth package's inbound→outbound token bridge. Read from top-level
 	// config once at startup; jwt-validation captures and token-exchange
 	// reads the cache only when this is true.
-	auth.SetSingleUserModeEnabled(cfg.SingleUserModeEnabled())
+	//
+	// The startup log line below makes the active posture discoverable
+	// on every restart — important because the default-on behavior
+	// changes the security profile on upgrade for deployments that were
+	// previously failing OBO-with-non-propagating-agents at the
+	// no-token-policy boundary.
+	spmEnabled := cfg.SingleUserModeEnabled()
+	auth.SetSingleUserModeEnabled(spmEnabled)
+	if spmEnabled {
+		slog.Info("authbridge: single-user mode is ACTIVE — sidecar will bridge inbound→outbound user tokens for non-propagating agent runtimes. Safe ONLY for single-user-per-process workloads; multi-user concurrent agents must propagate the inbound Authorization header themselves and should set single_user_mode: false. See docs/plugin-reference.md.")
+	} else {
+		slog.Info("authbridge: single-user mode is DISABLED — agent must propagate the inbound Authorization header to outbound calls for OBO to work. See docs/plugin-reference.md.")
+	}
 
 	initCtx, initCancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer initCancel()

--- a/authbridge/cmd/authbridge-proxy/main.go
+++ b/authbridge/cmd/authbridge-proxy/main.go
@@ -130,7 +130,19 @@ func main() {
 	// auth package's inbound→outbound token bridge. Read from top-level
 	// config once at startup; jwt-validation captures and token-exchange
 	// reads the cache only when this is true.
-	auth.SetSingleUserModeEnabled(cfg.SingleUserModeEnabled())
+	//
+	// The startup log line below makes the active posture discoverable
+	// on every restart — important because the default-on behavior
+	// changes the security profile on upgrade for deployments that were
+	// previously failing OBO-with-non-propagating-agents at the
+	// no-token-policy boundary.
+	spmEnabled := cfg.SingleUserModeEnabled()
+	auth.SetSingleUserModeEnabled(spmEnabled)
+	if spmEnabled {
+		slog.Info("authbridge: single-user mode is ACTIVE — sidecar will bridge inbound→outbound user tokens for non-propagating agent runtimes. Safe ONLY for single-user-per-process workloads; multi-user concurrent agents must propagate the inbound Authorization header themselves and should set single_user_mode: false. See docs/plugin-reference.md.")
+	} else {
+		slog.Info("authbridge: single-user mode is DISABLED — agent must propagate the inbound Authorization header to outbound calls for OBO to work. See docs/plugin-reference.md.")
+	}
 
 	initCtx, initCancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer initCancel()

--- a/authbridge/cmd/authbridge-proxy/main.go
+++ b/authbridge/cmd/authbridge-proxy/main.go
@@ -126,6 +126,12 @@ func main() {
 		log.Fatalf("initial pipeline build: %v", err)
 	}
 
+	// Single-player mode is a process-wide feature gate consumed by the
+	// auth package's inbound→outbound token bridge. Read from top-level
+	// config once at startup; jwt-validation captures and token-exchange
+	// reads the cache only when this is true.
+	auth.SetSingleUserModeEnabled(cfg.SingleUserModeEnabled())
+
 	initCtx, initCancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer initCancel()
 	if err := inboundPipeline.Start(initCtx); err != nil {

--- a/authbridge/docs/plugin-reference.md
+++ b/authbridge/docs/plugin-reference.md
@@ -84,6 +84,56 @@ and `expected_audience_host` (waypoint per-request derived audience, may
 be empty). Update saved queries and dashboards that filtered on the old
 key.
 
+### Single-player mode (default-on)
+
+Most agent runtimes — LangChain, CrewAI, Claude Code — don't propagate
+the inbound `Authorization` header to the outbound HTTP requests they
+generate. AuthBridge bridges the two sides automatically:
+
+- `jwt-validation` caches each successfully-validated inbound user JWT
+  in a process-level store.
+- `token-exchange` consults that store on outbound when the request
+  arrived with no `Authorization` header, and injects the cached token
+  as the OBO subject.
+
+This is governed by a single top-level flag in the runtime YAML:
+
+```yaml
+single_user_mode: true   # default; omit to inherit
+pipeline:
+  inbound:
+    plugins: [...]
+  outbound:
+    plugins: [...]
+```
+
+Set `single_user_mode: false` to opt out. There are no per-plugin flags
+— the pairing is enforced at the framework level so inbound and
+outbound can't drift apart.
+
+An explicit outbound `Authorization` header always wins; the cache
+lookup only fires when the header is empty.
+
+**Cap / floor.** Cached entries respect `min(token.exp, now+5m)` and
+skip capture when the token has under 30 seconds of life. Not
+configurable; one less thing to tune.
+
+**The single-player constraint.** This bridge is only safe when a
+process serves one user at a time. With multi-user concurrent traffic
+the cache is last-write-wins, so a downstream tool call could be
+attributed to the wrong user. Whenever a successful capture overwrites
+a different subject, jwt-validation emits a WARN log
+(`single-user cached subject changed`) so operators have a tripwire.
+
+**Cluster scaling.** Each replica has its own in-memory cache. For
+horizontally-scaled agents, route a user's session to a sticky replica
+or use a future correlation-ID-based design. Default Kagenti deployments
+run a single replica per agent, so this is typically a non-issue.
+
+**When you don't want this.** Set `single_user_mode: false` at the top
+level for any deployment that genuinely handles concurrent users with
+mixed identities, until a correlation-ID-based bridge ships.
+
 ## `on_error` policy
 
 > **Naming caveat.** Despite the name, `on_error` controls how the

--- a/authbridge/docs/plugin-reference.md
+++ b/authbridge/docs/plugin-reference.md
@@ -208,10 +208,65 @@ last-write-wins behavior.
 | Your agent's behavior | Use this configuration |
 |---|---|
 | Single user per process; agent does NOT propagate Authorization | `single_user_mode: true` (default). Bridge handles it. |
-| Single user per process; agent DOES propagate Authorization | Either works. Cache is harmless under single-user load. |
+| Single user per process; agent DOES propagate Authorization | Either works. Cache is harmless under single-user load, but **explicit `single_user_mode: false` is recommended** — it documents the deployment posture and removes the cache from the picture entirely. |
 | Multi-user concurrent; agent DOES propagate Authorization | `single_user_mode: false` (recommended). Avoid cache-based last-write-wins. |
 | Multi-user concurrent; agent does NOT propagate Authorization | **Currently unsupported.** Either fix the agent to propagate, or wait for the correlation-ID-based bridge. |
 | No inbound HTTP at all (TUI, stdio) | Single-player mode does not apply; needs a different design. |
+
+#### How to confirm single-player mode in production
+
+The active posture is logged at every binary startup, so a quick
+`kubectl logs -c authbridge ... | grep "single-user mode"` answers
+"is the bridge on for this pod?":
+
+```
+INFO authbridge: single-user mode is ACTIVE — sidecar will bridge inbound→outbound user tokens for non-propagating agent runtimes...
+```
+
+or, when opted out:
+
+```
+INFO authbridge: single-user mode is DISABLED — agent must propagate the inbound Authorization header to outbound calls for OBO to work...
+```
+
+For programmatic monitoring of the single-player-violation tripwire,
+the auth package exposes a lifetime counter that increments only when
+Store overwrites a *different* prior subject (concurrent multi-user
+traffic mis-routed through a bridge intended for single-user
+workloads):
+
+```go
+// authlib/auth
+auth.SingleUserSubjectChangeCount() int64
+```
+
+Operators should alert on the **delta** of this counter (e.g.,
+"non-zero rate over 5 minutes" indicates single-player mode is
+misapplied). The corresponding `WARN` log line
+(`single-user cached subject changed`) is intended for human
+investigation, not as the alert itself — at high concurrent volumes
+the WARN fires per-overwrite and floods the log.
+
+A subsequent change will surface this counter through the existing
+`/stats` endpoint so Prometheus and similar exporters can scrape it
+without bespoke wiring.
+
+#### What single-player mode does NOT capture
+
+Two cases where the cache stays empty by design — flagged here so
+operators don't chase support threads about them:
+
+- **Bypass paths (e.g., `/healthz`).** The jwt-validation plugin's
+  `BypassPaths` list short-circuits validation entirely; tokens
+  presented on those paths are never validated and therefore never
+  captured. A monitoring tool that probes liveness with a synthetic
+  Bearer header will not poison the bridge — its token is silently
+  ignored.
+- **Tokens with under 30 seconds of remaining life.** Caching a
+  near-expiry token leads to near-immediate exchange failures on the
+  next outbound. The `MinTTL` floor skips capture in that case; the
+  outbound side falls through to the no-token policy, exactly as if
+  no inbound token had been seen.
 
 ## `on_error` policy
 

--- a/authbridge/docs/plugin-reference.md
+++ b/authbridge/docs/plugin-reference.md
@@ -84,17 +84,30 @@ and `expected_audience_host` (waypoint per-request derived audience, may
 be empty). Update saved queries and dashboards that filtered on the old
 key.
 
-### Single-player mode (default-on)
+### Single-player mode (default-on, single-user agents only)
 
-Most agent runtimes — LangChain, CrewAI, Claude Code — don't propagate
-the inbound `Authorization` header to the outbound HTTP requests they
-generate. AuthBridge bridges the two sides automatically:
+#### The problem this solves
 
-- `jwt-validation` caches each successfully-validated inbound user JWT
-  in a process-level store.
-- `token-exchange` consults that store on outbound when the request
-  arrived with no `Authorization` header, and injects the cached token
-  as the OBO subject.
+OBO / RFC 8693 token exchange needs the user's inbound JWT to appear on
+the **outbound** request as `subject_token`. Most agent runtimes —
+LangChain, CrewAI, Claude Code, MCP-stdio — **do not propagate the
+inbound `Authorization` header** to the outbound HTTP calls they
+generate, because tool execution is decoupled from request handling.
+Without help, AuthBridge sees no inbound token on the outbound side and
+falls into the no-token policy (deny by default), breaking OBO entirely
+for those frameworks.
+
+#### What single-player mode does
+
+- `jwt-validation` (inbound) caches each successfully-validated user
+  JWT in a process-level store.
+- `token-exchange` (outbound) consults that store when the outbound
+  request arrived with no `Authorization` header, and uses the cached
+  token as `subject_token` for the exchange.
+
+The result: agents that don't propagate Authorization themselves still
+get correct OBO behavior — **as long as the process is serving one
+user at a time.**
 
 This is governed by a single top-level flag in the runtime YAML:
 
@@ -108,31 +121,97 @@ pipeline:
 ```
 
 Set `single_user_mode: false` to opt out. There are no per-plugin flags
-— the pairing is enforced at the framework level so inbound and
-outbound can't drift apart.
+— the inbound/outbound pairing is enforced at the framework level so
+the two sides can't drift apart.
 
 An explicit outbound `Authorization` header always wins; the cache
-lookup only fires when the header is empty.
+lookup only fires when the outbound header is empty.
 
 **Cap / floor.** Cached entries respect `min(token.exp, now+5m)` and
 skip capture when the token has under 30 seconds of life. Not
 configurable; one less thing to tune.
 
-**The single-player constraint.** This bridge is only safe when a
-process serves one user at a time. With multi-user concurrent traffic
-the cache is last-write-wins, so a downstream tool call could be
-attributed to the wrong user. Whenever a successful capture overwrites
-a different subject, jwt-validation emits a WARN log
-(`single-user cached subject changed`) so operators have a tripwire.
+#### Limitation: single user per process
 
-**Cluster scaling.** Each replica has its own in-memory cache. For
-horizontally-scaled agents, route a user's session to a sticky replica
-or use a future correlation-ID-based design. Default Kagenti deployments
-run a single replica per agent, so this is typically a non-issue.
+**This is a workaround, not a multi-user solution.** The bridge is only
+safe when the process serves one user at a time:
 
-**When you don't want this.** Set `single_user_mode: false` at the top
-level for any deployment that genuinely handles concurrent users with
-mixed identities, until a correlation-ID-based bridge ships.
+- The cache is process-global, so concurrent inbound requests from
+  different users overwrite each other (last-write-wins).
+- A tool call started by Alice may pick up Bob's cached token if Bob's
+  request arrived between Alice's inbound validation and her agent's
+  outbound exchange — attributing Alice's call to Bob downstream.
+- Each replica has its own in-memory cache; horizontally-scaled agents
+  need session stickiness for the bridge to behave consistently.
+
+When the assumption is violated, jwt-validation emits a WARN log so
+operators have a tripwire:
+
+```
+WARN jwt-validation: single-user cached subject changed —
+single-player assumption violated; last-write-wins
+previous=alice current=bob
+```
+
+#### Enabling multi-user / multi-session: agent must cooperate
+
+There is no transparent fix for multi-user concurrent traffic on the
+sidecar side alone — the sidecar cannot know which inbound request
+triggered a given outbound call without help from the agent code.
+
+To support multi-user / multi-session, **the agent itself must
+propagate the inbound `Authorization` header to outbound HTTP calls**
+made on behalf of that request. When the outbound `Authorization` is
+already populated, single-player mode's cache is not consulted (the
+explicit header wins), and OBO works correctly per-user without
+relying on the global cache.
+
+In practice this means:
+
+- **HTTP-based frameworks (FastAPI, Flask, etc.)**: read
+  `request.headers["authorization"]` in your tool handler and pass it
+  through to outbound clients (`httpx.AsyncClient(headers=...)`,
+  `requests.post(headers=...)`, etc.).
+- **LangChain / CrewAI tools**: tools are functions that don't see HTTP
+  context by default. Propagation requires adapting the framework to
+  thread the Authorization header through your tool's outbound calls
+  (e.g., a context-propagating HTTP client class, or framework-specific
+  middleware). This is agent-side engineering work; AuthBridge cannot
+  do it for you.
+- **MCP servers over HTTP**: MCP supports Authorization headers; agent
+  must forward the inbound Bearer to the outbound MCP request.
+- **Frameworks with no inbound HTTP at all** (Claude Code TUI,
+  MCP-stdio): no Authorization header to propagate. These cases need
+  a different design (workload-identity-only, or a gateway-mediated
+  user-context-injection scheme); single-player mode does not apply.
+
+A future `X-Kagenti-Request-Id` correlation-header design will let the
+sidecar bridge multi-user traffic without agent header propagation —
+not yet shipped.
+
+#### When to disable single-player mode
+
+Set `single_user_mode: false` at the top level when:
+
+- The process genuinely handles **concurrent users with mixed
+  identities**, AND
+- The agent code already propagates the `Authorization` header to its
+  outbound calls (so the cache is unnecessary).
+
+In that configuration, the cache is never populated and never read,
+and OBO works correctly per-user via the agent's own header
+forwarding. No data-attribution risk from the single-player
+last-write-wins behavior.
+
+#### Decision matrix
+
+| Your agent's behavior | Use this configuration |
+|---|---|
+| Single user per process; agent does NOT propagate Authorization | `single_user_mode: true` (default). Bridge handles it. |
+| Single user per process; agent DOES propagate Authorization | Either works. Cache is harmless under single-user load. |
+| Multi-user concurrent; agent DOES propagate Authorization | `single_user_mode: false` (recommended). Avoid cache-based last-write-wins. |
+| Multi-user concurrent; agent does NOT propagate Authorization | **Currently unsupported.** Either fix the agent to propagate, or wait for the correlation-ID-based bridge. |
+| No inbound HTTP at all (TUI, stdio) | Single-player mode does not apply; needs a different design. |
 
 ## `on_error` policy
 


### PR DESCRIPTION
## Summary

Most agent runtimes — LangChain, CrewAI, Claude Code, MCP-stdio — don't
propagate the inbound `Authorization` header to the outbound HTTP
requests they generate, because tool execution is decoupled from
request handling. Today the token-exchange plugin's `HandleOutbound`
falls into the no-token policy when the agent didn't forward the user
JWT, breaking OBO / RFC 8693 delegation entirely for those frameworks.

This PR bridges the two sides automatically through a process-level
cache:

- `jwt-validation` captures each successfully-validated user token.
- `token-exchange` consults the cache on outbound when no
  `Authorization` header is present, and uses the cached token as
  `subject_token`. Explicit outbound headers always win; cache miss
  falls through to the existing no-token policy.

## One control knob, top-level

The feature is governed by a single top-level flag in the runtime YAML:

```yaml
single_user_mode: true   # default; omit to inherit
pipeline:
  inbound:
    plugins: [...]
  outbound:
    plugins: [...]
```

Each binary reads `Config.SingleUserModeEnabled()` once at startup and
calls `auth.SetSingleUserModeEnabled(...)`, which gates an atomic bit
in `authlib/auth`. Plugins call `Store/Get` unconditionally; when
disabled, `Store` is a no-op and `Get` returns `ok=false`. **No
per-plugin flags** — the inbound/outbound pairing is enforced at the
framework level so the two sides can't drift apart, and operators have
exactly one knob.

Default-on, so new and existing deployments pick it up without YAML
changes. Opt out with `single_user_mode: false` at top level.

## Constraint: single-player

Only safe for processes handling one user at a time. With multi-user
concurrent traffic the cache is last-write-wins; whenever a successful
capture overwrites a different subject, `jwt-validation` emits a WARN
log (`single-user cached subject changed`) as an operator tripwire.

Each replica has its own in-memory cache. Horizontally-scaled agents
need stickiness or a future correlation-ID-based design (out of scope).

Frameworks with no inbound HTTP context at all (Claude Code TUI,
MCP-stdio) aren't addressed here — there's no header to capture.

## Cap / floor

Cached entries respect `min(token.exp, now+5m)` and capture is skipped
below 30s of remaining life. Not configurable — one less thing to tune.

## How it's wired

```
INBOUND PIPELINE                   OUTBOUND PIPELINE
─────────────────                   ──────────────────
jwt-validation                     token-exchange
  (verify token)                     (read auth header)
  (set Identity)                     (if empty):
  (always capture):                    └─→ auth.GetSingleUserToken()
    └─→ auth.StoreSingleUserToken(          if hit: inject Bearer
          token, sub, exp)                  else: existing no-token policy
                  │                      (perform exchange)
                  ▼                      │
       ┌────────────────────────────────────┐
       │ auth/single_user.go                │
       │ atomic.Bool spEnabled (gate)       │
       │ + (token, sub, exp) state          │
       │ + sync.RWMutex                     │
       └────────────────────────────────────┘
                                ▲
            auth.SetSingleUserModeEnabled(cfg.SingleUserModeEnabled())
            (called once at startup by each binary's main.go)
```

No new package, no new plugin; both `jwt-validation` and
`token-exchange` already import `authlib/auth`, so the shared state
lives there.

## Files

**New:**
- `authbridge/authlib/auth/single_user.go`
- `authbridge/authlib/auth/single_user_test.go`

**Modified:**
- `authbridge/authlib/config/config.go` — top-level `SingleUserMode *bool` + `SingleUserModeEnabled()`
- `authbridge/authlib/config/config_test.go` — tri-state coverage
- `authbridge/authlib/plugins/jwtvalidation/plugin.go` — capture on success path
- `authbridge/authlib/plugins/jwtvalidation/plugin_test.go` — capture coverage
- `authbridge/authlib/plugins/tokenexchange/plugin.go` — cache lookup on missing header
- `authbridge/authlib/plugins/tokenexchange/plugin_test.go` — table-driven coverage
- `authbridge/cmd/authbridge-envoy/main.go` — wire `SetSingleUserModeEnabled`
- `authbridge/cmd/authbridge-proxy/main.go` — wire `SetSingleUserModeEnabled`
- `authbridge/cmd/authbridge-lite/main.go` — wire `SetSingleUserModeEnabled`
- `authbridge/docs/plugin-reference.md` — top-level flag + caveats

## Test plan

- [x] `go test -race ./auth/... ./config/... ./plugins/jwtvalidation/... ./plugins/tokenexchange/...` — all green
- [x] `go test -race ./...` (full authlib) — all green
- [x] All three `cmd/*` binaries build (`authbridge-envoy`, `authbridge-proxy`, `authbridge-lite`)
- [x] Concurrent Store/Get under `-race` — no data races
- [x] Subject-change WARN tripwire fires when expected; not on same-subject re-capture
- [x] Explicit outbound `Authorization` header always wins (cache not consulted)
- [x] Top-level `single_user_mode: false` disables both Store and Get (verified by populating cache, disabling, then asserting cache miss on read)
- [x] Default-on at the top level (Config.SingleUserModeEnabled() returns true when unset)
- [x] Package init() sets the gate to true so default behavior is bridged out-of-the-box
- [ ] End-to-end on Kind cluster with a LangChain-shaped agent (manual)

## References

- Adel's *Agent Auth Without Keycloak Lock-in: IdP Compatibility Analysis and Recommendations* (May 2026)
- Slack thread: token propagation gap discussion (Roland, Gordon, Maia, David, Hai, Rong, Gosia)
- Single-player mode flag was specifically suggested by @huang195 as a concrete shippable fix for the HTTP-agent category

Assisted-By: Claude Code
