### PR TITLE
feat(authbridge): Allow empty pipeline plugin lists

### DIFF
--- a/authbridge/authlib/config/config_test.go
+++ b/authbridge/authlib/config/config_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -120,31 +119,25 @@ func TestValidate_ValidConfigs(t *testing.T) {
 	}
 }
 
-// TestValidate_EmptyPipelineRejected guards the "open proxy" failure
-// mode: before this check, an operator who kept the pre-migration
-// top-level schema (inbound:, outbound:, identity:, bypass:, routes:)
-// in their ConfigMap would upgrade the image, land on a config where
-// yaml.v3 silently dropped the unknown top-level keys, end up with an
-// empty Pipeline, and boot successfully. Listeners would then run
-// pipelines with zero plugins — every request would pass through
-// without JWT validation or token exchange.
+// TestValidate_EmptyPipelineAllowed pins the "empty pipeline = pass-through"
+// contract. An operator who wants to run AuthBridge without inbound
+// validation (e.g. for testing, or asymmetric deployments where only
+// outbound token exchange is desired) should be able to do so without
+// adding a new opt-in config item. WarnEmptyPipelines emits a startup
+// WARN so the open-proxy condition is still visible in logs.
 //
-// Empty pipelines being a configuration error forces the operator to
-// either migrate to the new shape or leave the old image tagged. The
-// error message names the offending section and points at the new
-// schema.
-func TestValidate_EmptyPipelineRejected(t *testing.T) {
+// Previously this case was a hard rejection. The schema-migration
+// scenario it guarded against (operators upgrading from the pre-migration
+// top-level schema and silently landing on an empty pipeline) is now
+// surfaced by the WARN log instead of by a boot failure.
+func TestValidate_EmptyPipelineAllowed(t *testing.T) {
 	cfg := &Config{Mode: ModeEnvoySidecar}
-	err := Validate(cfg)
-	if err == nil {
-		t.Fatal("expected error for empty pipeline")
-	}
-	if !strings.Contains(err.Error(), "pipeline.inbound.plugins is empty") {
-		t.Errorf("error does not name the offending section: %q", err)
+	if err := Validate(cfg); err != nil {
+		t.Fatalf("empty pipeline should be allowed, got: %v", err)
 	}
 }
 
-func TestValidate_EmptyOutboundPipelineRejected(t *testing.T) {
+func TestValidate_EmptyOutboundPipelineAllowed(t *testing.T) {
 	cfg := &Config{
 		Mode: ModeEnvoySidecar,
 		Pipeline: PipelineConfig{
@@ -152,12 +145,8 @@ func TestValidate_EmptyOutboundPipelineRejected(t *testing.T) {
 			// Outbound intentionally empty
 		},
 	}
-	err := Validate(cfg)
-	if err == nil {
-		t.Fatal("expected error for empty outbound pipeline")
-	}
-	if !strings.Contains(err.Error(), "pipeline.outbound.plugins is empty") {
-		t.Errorf("error does not name the offending section: %q", err)
+	if err := Validate(cfg); err != nil {
+		t.Fatalf("empty outbound pipeline should be allowed, got: %v", err)
 	}
 }
 
@@ -759,4 +748,3 @@ listener:
 		t.Errorf("MTLS = %+v, want nil (absent block)", cfg.MTLS)
 	}
 }
-

--- a/authbridge/authlib/config/validate.go
+++ b/authbridge/authlib/config/validate.go
@@ -4,21 +4,16 @@ import (
 	"fmt"
 )
 
-// Validate checks the top-level runtime config: mode, listener combo,
-// and that the pipeline composition is populated. Plugin-specific
-// validation (issuer, token URL, identity type, jwt_audience) lives
-// inside each plugin's Configure and runs at pipeline build time.
+// Validate checks the top-level runtime config: mode and listener combo.
+// Plugin-specific validation (issuer, token URL, identity type,
+// jwt_audience) lives inside each plugin's Configure and runs at
+// pipeline build time.
 //
-// Empty pipelines are rejected. Under the per-plugin config shape,
-// a valid runtime config always names at least one inbound plugin
-// (jwt-validation) and one outbound plugin (token-exchange). Silently
-// accepting empty pipelines caused the whole point of authbridge to
-// disappear — inbound traffic passing without JWT validation, outbound
-// passing without token exchange. Operators upgrading from the old
-// top-level-block schema ("inbound:", "outbound:", etc.) whose YAML
-// does not yet include a pipeline section fail loudly here rather
-// than shipping an open proxy. See the schema migration note in
-// cmd/authbridge/README.md.
+// Empty pipelines are permitted: AuthBridge will run as a pass-through
+// on any stage with no plugins. This supports testing scenarios and
+// asymmetric deployments (e.g. inbound auth only, no outbound token
+// exchange). Operators get a startup WARN per empty stage from
+// WarnEmptyPipelines so the open-proxy condition is visible in logs.
 func Validate(cfg *Config) error {
 	switch cfg.Mode {
 	case ModeEnvoySidecar, ModeWaypoint, ModeProxySidecar:
@@ -28,25 +23,7 @@ func Validate(cfg *Config) error {
 	default:
 		return fmt.Errorf("unknown mode %q (valid: envoy-sidecar, waypoint, proxy-sidecar)", cfg.Mode)
 	}
-	if err := validateListeners(cfg); err != nil {
-		return err
-	}
-	return validatePipeline(cfg)
-}
-
-func validatePipeline(cfg *Config) error {
-	if len(cfg.Pipeline.Inbound.Plugins) == 0 {
-		return fmt.Errorf("pipeline.inbound.plugins is empty; specify at least one plugin " +
-			"(typically jwt-validation) — see cmd/authbridge/README.md. " +
-			"If you see this after an upgrade, your config.yaml is using the old top-level shape " +
-			"(inbound:, outbound:, identity:, bypass:, routes:) — move those settings under " +
-			"pipeline.*.plugins[].config")
-	}
-	if len(cfg.Pipeline.Outbound.Plugins) == 0 {
-		return fmt.Errorf("pipeline.outbound.plugins is empty; specify at least one plugin " +
-			"(typically token-exchange) — see cmd/authbridge/README.md")
-	}
-	return nil
+	return validateListeners(cfg)
 }
 
 func validateListeners(cfg *Config) error {

--- a/authbridge/authlib/config/warn.go
+++ b/authbridge/authlib/config/warn.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"log/slog"
+)
+
+// WarnEmptyPipelines emits a startup WARN for every pipeline stage that has
+// no plugins. An empty stage is a supported configuration (pass-through),
+// not an error, but it means traffic on that direction flows without
+// authentication, JWT validation, or token exchange. Surfacing this once
+// at startup makes the open-proxy condition visible in logs without
+// blocking deployments that intentionally run without plugins (e.g.
+// testing, asymmetric deployments).
+//
+// Call this from each cmd entry point AFTER Validate succeeds and BEFORE
+// the pipelines are built. Pass slog.Default() unless you need a scoped
+// logger.
+func WarnEmptyPipelines(cfg *Config, logger *slog.Logger) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if len(cfg.Pipeline.Inbound.Plugins) == 0 {
+		logger.Warn("inbound pipeline has no plugins — incoming traffic will pass through without authentication")
+	}
+	if len(cfg.Pipeline.Outbound.Plugins) == 0 {
+		logger.Warn("outbound pipeline has no plugins — outgoing traffic will pass through without token exchange")
+	}
+}

--- a/authbridge/authlib/config/warn_test.go
+++ b/authbridge/authlib/config/warn_test.go
@@ -1,0 +1,98 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// captureWarns runs fn with a logger that records warning records into a
+// JSON-line buffer, then returns the captured records.
+func captureWarns(t *testing.T, fn func(*slog.Logger)) []map[string]any {
+	t.Helper()
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	fn(logger)
+	var out []map[string]any
+	for _, line := range strings.Split(strings.TrimRight(buf.String(), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("decode log line %q: %v", line, err)
+		}
+		out = append(out, rec)
+	}
+	return out
+}
+
+func TestWarnEmptyPipelines_BothEmpty(t *testing.T) {
+	cfg := &Config{Mode: ModeEnvoySidecar}
+	recs := captureWarns(t, func(l *slog.Logger) { WarnEmptyPipelines(cfg, l) })
+	if len(recs) != 2 {
+		t.Fatalf("expected 2 warn records, got %d: %#v", len(recs), recs)
+	}
+	if !strings.Contains(recs[0]["msg"].(string), "inbound pipeline has no plugins") {
+		t.Errorf("first record should be the inbound warn, got: %v", recs[0]["msg"])
+	}
+	if !strings.Contains(recs[1]["msg"].(string), "outbound pipeline has no plugins") {
+		t.Errorf("second record should be the outbound warn, got: %v", recs[1]["msg"])
+	}
+}
+
+func TestWarnEmptyPipelines_OnlyInboundEmpty(t *testing.T) {
+	cfg := &Config{
+		Mode: ModeEnvoySidecar,
+		Pipeline: PipelineConfig{
+			Outbound: PipelineStageConfig{Plugins: []PluginEntry{{Name: "token-exchange"}}},
+		},
+	}
+	recs := captureWarns(t, func(l *slog.Logger) { WarnEmptyPipelines(cfg, l) })
+	if len(recs) != 1 {
+		t.Fatalf("expected 1 warn record, got %d", len(recs))
+	}
+	if !strings.Contains(recs[0]["msg"].(string), "inbound pipeline has no plugins") {
+		t.Errorf("record should be the inbound warn, got: %v", recs[0]["msg"])
+	}
+}
+
+func TestWarnEmptyPipelines_OnlyOutboundEmpty(t *testing.T) {
+	cfg := &Config{
+		Mode: ModeEnvoySidecar,
+		Pipeline: PipelineConfig{
+			Inbound: PipelineStageConfig{Plugins: []PluginEntry{{Name: "jwt-validation"}}},
+		},
+	}
+	recs := captureWarns(t, func(l *slog.Logger) { WarnEmptyPipelines(cfg, l) })
+	if len(recs) != 1 {
+		t.Fatalf("expected 1 warn record, got %d", len(recs))
+	}
+	if !strings.Contains(recs[0]["msg"].(string), "outbound pipeline has no plugins") {
+		t.Errorf("record should be the outbound warn, got: %v", recs[0]["msg"])
+	}
+}
+
+func TestWarnEmptyPipelines_NeitherEmpty(t *testing.T) {
+	cfg := &Config{
+		Mode: ModeEnvoySidecar,
+		Pipeline: PipelineConfig{
+			Inbound:  PipelineStageConfig{Plugins: []PluginEntry{{Name: "jwt-validation"}}},
+			Outbound: PipelineStageConfig{Plugins: []PluginEntry{{Name: "token-exchange"}}},
+		},
+	}
+	recs := captureWarns(t, func(l *slog.Logger) { WarnEmptyPipelines(cfg, l) })
+	if len(recs) != 0 {
+		t.Fatalf("expected 0 warn records when both stages are populated, got %d: %#v", len(recs), recs)
+	}
+}
+
+func TestWarnEmptyPipelines_NilLoggerUsesDefault(t *testing.T) {
+	// Smoke test: passing nil should not panic. We don't assert on the
+	// default logger's output here (it goes wherever slog.Default is
+	// pointed).
+	cfg := &Config{Mode: ModeEnvoySidecar}
+	WarnEmptyPipelines(cfg, nil)
+}

--- a/authbridge/cmd/authbridge-envoy/main.go
+++ b/authbridge/cmd/authbridge-envoy/main.go
@@ -148,6 +148,7 @@ func main() {
 		if err := config.Validate(c); err != nil {
 			return nil, nil, nil, err
 		}
+		config.WarnEmptyPipelines(c, slog.Default())
 		in, err := plugins.BuildWithSPIFFE(c.Pipeline.Inbound.Plugins, provider)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("inbound: %w", err)

--- a/authbridge/cmd/authbridge-lite/main.go
+++ b/authbridge/cmd/authbridge-lite/main.go
@@ -136,6 +136,7 @@ func main() {
 		if err := config.Validate(c); err != nil {
 			return nil, nil, nil, err
 		}
+		config.WarnEmptyPipelines(c, slog.Default())
 		in, err := plugins.BuildWithSPIFFE(c.Pipeline.Inbound.Plugins, provider)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("inbound: %w", err)

--- a/authbridge/cmd/authbridge-proxy/main.go
+++ b/authbridge/cmd/authbridge-proxy/main.go
@@ -141,6 +141,7 @@ func main() {
 		if err := config.Validate(c); err != nil {
 			return nil, nil, nil, err
 		}
+		config.WarnEmptyPipelines(c, slog.Default())
 		in, err := plugins.BuildWithSPIFFE(c.Pipeline.Inbound.Plugins, provider)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("inbound: %w", err)


### PR DESCRIPTION
## Summary

- AuthBridge now accepts empty inbound and/or outbound pipelines as a supported pass-through mode. No new config item is introduced — empty list = pass-through.
- A new `config.WarnEmptyPipelines` helper emits one `slog.Warn` per empty stage at startup (and on every hot-reload into an empty config), so the open-proxy condition stays visible in logs.
- All three combined binaries (`authbridge-envoy`, `authbridge-proxy`, `authbridge-lite`) call the helper inside `buildPipelines` immediately after `Validate`.

## Motivation

Operators have hit the previous hard rejection (`pipeline.inbound.plugins is empty; specify at least one plugin (typically jwt-validation)`) when trying to run AuthBridge without inbound token validation — for example, during testing, in asymmetric deployments where only outbound token exchange is needed, or during gradual rollouts.

The original rejection was defensive against a specific schema-migration footgun: operators upgrading from the pre-migration top-level schema (`inbound:`, `outbound:`, `identity:`, `bypass:`, `routes:`) whose ConfigMap hadn't yet been moved under `pipeline.*.plugins[]` would land on a silently-empty `Pipeline` and boot as an open proxy. After this change, that scenario boots successfully but emits a WARN per empty stage. The `on_error: off` plugin kill-switch already let operators reach an effectively-empty pipeline today (registry.go:110), so this widens an existing surface rather than creating a new one.

## Changes

- `authlib/config/validate.go` — drop the two `len(...Plugins) == 0` checks in `validatePipeline`; rewrite the doc comment to describe the new contract.
- `authlib/config/warn.go` (new) — `WarnEmptyPipelines(cfg *Config, logger *slog.Logger)` helper. nil-safe.
- `authlib/config/warn_test.go` (new) — table-style tests covering both-empty / inbound-only / outbound-only / neither / nil-logger.
- `authlib/config/config_test.go` — rename and flip the two `EmptyPipelineRejected` tests to assert the new allowed contract.
- `cmd/authbridge-{envoy,proxy,lite}/main.go` — single-line call to `config.WarnEmptyPipelines(c, slog.Default())` inside `buildPipelines` after `Validate`.

## Test plan

- [x] `go test ./...` passes for `authlib` (33 packages, all green).
- [x] `go vet ./...` clean for `authlib`.
- [x] `go build ./...` succeeds for all three `cmd/authbridge-*` modules.
- [x] New `warn_test.go` covers: both pipelines empty (2 warns), inbound only (1 warn), outbound only (1 warn), neither (0 warns), and nil logger doesn't panic.
- [x] Renamed `TestValidate_EmptyPipelineAllowed` / `TestValidate_EmptyOutboundPipelineAllowed` assert empty pipelines pass `Validate` cleanly.
- [ ] Manual smoke: deploy with an inbound-only or outbound-only config and confirm the WARN line appears in `kubectl logs`.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>