### PR TITLE
feat(authbridge): Add envoy-sidecar mTLS demo

### DIFF
--- a/authbridge/CLAUDE.md
+++ b/authbridge/CLAUDE.md
@@ -265,8 +265,8 @@ preserved.
 
 When the runtime config carries an `mtls:` block, authbridge enables
 transport-level mTLS on the proxy-sidecar listeners (forward + reverse
-proxy). envoy-sidecar mode is unaffected — Envoy handles its own TLS
-via SDS independently.
+proxy). envoy-sidecar mode handles mTLS at the Envoy data-plane level
+instead — see the **envoy-sidecar mTLS** subsection below.
 
 ```yaml
 # authbridge-runtime ConfigMap (top-level)
@@ -293,6 +293,56 @@ per-caller decisions read `pctx.PeerCert` and check the URI SAN.
 **Hot-reload boundary:** mTLS config (`mtls.mode`, cert paths) requires a
 pod restart to apply, matching the existing rule for `listener.*`
 addresses. Plugin-pipeline config keeps its own hot-reload behavior.
+
+### envoy-sidecar mTLS
+
+In envoy-sidecar mode the listeners live in Envoy, not authbridge,
+so the top-level `mtls:` block is a no-op there. Equivalent semantics
+are configured at the Envoy data-plane level by extending the
+`envoy-config` ConfigMap with TLS blocks:
+
+| Mode | Inbound (`:15124`) | Outbound (`:15123`) |
+|---|---|---|
+| `disabled` | plaintext (today's behavior) | plaintext (today's behavior) |
+| `permissive` | `tls_inspector` listener filter + two filter chains: `transport_protocol: tls` chain terminates mTLS, `transport_protocol: raw_buffer` chain accepts plaintext | **plaintext** — no TLS-wrap attempt |
+| `strict` | `tls_inspector` + single TLS filter chain; plaintext drops at filter chain match | `UpstreamTlsContext` on the `original_destination` cluster: TLS-or-fail, blanket |
+
+X.509 SVIDs are read by Envoy directly from `/opt/svid.pem`,
+`/opt/svid_key.pem`, `/opt/svid_bundle.pem` — the same paths
+proxy-sidecar's mTLS uses. The spiffe Provider's file-mirror in
+the `authbridge-envoy` binary keeps these fresh on rotation.
+
+**Inbound parity with proxy-sidecar:** byte-identical observable
+semantics — TLS handshakes terminate against the SPIRE trust bundle,
+plaintext is served (permissive) or rejected (strict). Same outcome
+as proxy-sidecar's `tlssniff.Listener`, just expressed as Envoy
+filter chains. This matches Istio's PERMISSIVE/STRICT inbound exactly.
+
+**Outbound is Istio-shaped, not proxy-sidecar-shaped:** Envoy has
+no native primitive for "try TLS, fall back to plaintext on handshake
+failure" within an `ORIGINAL_DST` cluster (and Istio itself doesn't do
+it — Pilot pre-decides mesh membership). So envoy-sidecar's
+permissive mode keeps outbound plaintext, and strict mode does
+blanket TLS-or-fail to everything the listener sees. This works in
+practice because outbound calls that need plaintext — Keycloak,
+JWKS, external HTTPS — never reach the listener: plugin outbound
+uses Go `net/http` directly, and `proxy-init`'s iptables doesn't
+redirect arbitrary HTTPS egress.
+
+**Behavioral gap to know:** a *permissive* envoy-sidecar caller
+cannot reach a *strict* peer (its outbound is plaintext; the peer's
+strict inbound rejects it). proxy-sidecar permissive can, because
+its outbound dialer tries TLS first per-connection. Mixed-mode
+deployments need both ends compatible — both strict, both permissive,
+or one strict + the other permissive on inbound only.
+
+The kagenti-operator's AgentRuntime CR has an `Spec.MTLSMode` field
+but currently rejects `mtlsMode != disabled` with `envoy-sidecar`
+at admission. The `authbridge/demos/mtls/` envoy-sidecar variant
+(`make demo-mtls-envoy*`) bypasses that gate by swapping the
+namespace `envoy-config` ConfigMap directly; the operator follow-up
+PR will close the gap by rendering per-agent envoy-config from
+`Spec.MTLSMode`.
 
 ## Build and Deploy
 

--- a/authbridge/cmd/authbridge-envoy/main.go
+++ b/authbridge/cmd/authbridge-envoy/main.go
@@ -99,12 +99,15 @@ func main() {
 	}
 
 	// Build the SPIFFE Provider when the spiffe block is configured.
-	// envoy-sidecar mode currently doesn't terminate mTLS at this
-	// process — Envoy does TCP passthrough — so X509Source() is unused
+	// envoy-sidecar mode terminates mTLS in Envoy itself (via the
+	// file-based DownstreamTlsContext / UpstreamTlsContext referencing
+	// /opt/svid*.pem in the rendered envoy-config) — this binary
+	// doesn't see the TLS bytes directly, so X509Source() isn't read
 	// here. The Provider is still needed because token-exchange's
 	// spiffe identity path consumes a JWTSource via DI, and the file
-	// mirror keeps /opt/jwt_svid.token (and the X.509 SVID files)
-	// fresh on disk for Envoy and downstream consumers.
+	// mirror is what keeps /opt/svid.pem, /opt/svid_key.pem,
+	// /opt/svid_bundle.pem, and /opt/jwt_svid.token fresh on disk for
+	// Envoy and other consumers.
 	//
 	// We need cfg first to read the spiffe block, so do a one-shot
 	// Load before buildPipelines runs (buildPipelines re-Loads

--- a/authbridge/demos/mtls/Makefile
+++ b/authbridge/demos/mtls/Makefile
@@ -1,12 +1,14 @@
 .DEFAULT_GOAL := help
 
-NAMESPACE ?= team1
-CALLER    ?= mtls-caller
-CALLEE    ?= mtls-callee
+NAMESPACE      ?= team1
+CALLER         ?= mtls-caller
+CALLEE         ?= mtls-callee
+CALLER_ENVOY   ?= mtls-caller-envoy
+CALLEE_ENVOY   ?= mtls-callee-envoy
 
 .PHONY: help
 help:
-	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[36m%-26s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[36m%-32s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 .PHONY: deploy
 deploy: ## Deploy caller + callee pods (both with mtls.mode: strict)
@@ -39,3 +41,55 @@ demo-mtls-strict-rejects-plain: deploy ## Verify that plain HTTP gets dropped on
 undeploy: ## Tear down the demo's resources
 	kubectl delete -f k8s/caller.yaml --ignore-not-found
 	kubectl delete -f k8s/callee.yaml --ignore-not-found
+
+# ---------------------------------------------------------------------------
+# envoy-sidecar variant
+#
+# Same contract as the proxy-sidecar targets above, but the demo pods
+# are fully hand-crafted (no kagenti.io/inject label — see the demo
+# README's "How the demo wires mTLS" section for why) and mTLS is
+# configured in the Envoy data plane (k8s/envoy-config-mtls.yaml)
+# rather than at the authbridge-runtime layer.
+#
+# These targets manage demo-scoped ConfigMaps
+# (envoy-config-mtls-{permissive,strict,active} and
+# authbridge-runtime-mtls) via scripts/swap-envoy-config.sh.
+# undeploy-envoy clean-deletes them; nothing in the namespace's
+# operator-managed `envoy-config` is touched. Avoid running multiple
+# envoy-sidecar demo variants concurrently in the same namespace —
+# they share the active CM.
+# ---------------------------------------------------------------------------
+
+.PHONY: deploy-envoy-strict
+deploy-envoy-strict: ## Deploy envoy-sidecar variant with strict mTLS (inbound TLS-only, outbound TLS-or-fail)
+	kubectl apply -f k8s/caller-envoy.yaml
+	kubectl apply -f k8s/callee-envoy.yaml
+	./scripts/swap-envoy-config.sh $(NAMESPACE) strict
+	kubectl -n $(NAMESPACE) rollout restart deploy/$(CALLER_ENVOY) deploy/$(CALLEE_ENVOY)
+	kubectl -n $(NAMESPACE) rollout status  deploy/$(CALLER_ENVOY) deploy/$(CALLEE_ENVOY) --timeout=120s
+
+.PHONY: deploy-envoy-permissive
+deploy-envoy-permissive: ## Deploy envoy-sidecar variant with permissive mTLS (inbound peeks, outbound plaintext)
+	kubectl apply -f k8s/caller-envoy.yaml
+	kubectl apply -f k8s/callee-envoy.yaml
+	./scripts/swap-envoy-config.sh $(NAMESPACE) permissive
+	kubectl -n $(NAMESPACE) rollout restart deploy/$(CALLER_ENVOY) deploy/$(CALLEE_ENVOY)
+	kubectl -n $(NAMESPACE) rollout status  deploy/$(CALLER_ENVOY) deploy/$(CALLEE_ENVOY) --timeout=120s
+
+.PHONY: demo-mtls-envoy
+demo-mtls-envoy: deploy-envoy-strict ## Deploy + verify envoy-sidecar mTLS (strict)
+	./scripts/verify-encrypted-envoy.sh $(NAMESPACE) $(CALLER_ENVOY) $(CALLEE_ENVOY)
+
+.PHONY: demo-mtls-envoy-permissive
+demo-mtls-envoy-permissive: deploy-envoy-permissive ## Deploy + verify envoy-sidecar permissive mode (plaintext callers served)
+	./scripts/verify-permissive-envoy.sh $(NAMESPACE) $(CALLEE_ENVOY)
+
+.PHONY: demo-mtls-envoy-strict-rejects-plain
+demo-mtls-envoy-strict-rejects-plain: deploy-envoy-strict ## Verify envoy-sidecar strict mode rejects plaintext callers
+	./scripts/verify-strict-rejects-plain-envoy.sh $(NAMESPACE) $(CALLEE_ENVOY)
+
+.PHONY: undeploy-envoy
+undeploy-envoy: ## Tear down envoy-sidecar variant + clean up demo CMs
+	kubectl delete -f k8s/caller-envoy.yaml --ignore-not-found
+	kubectl delete -f k8s/callee-envoy.yaml --ignore-not-found
+	./scripts/swap-envoy-config.sh $(NAMESPACE) clean || true

--- a/authbridge/demos/mtls/README.md
+++ b/authbridge/demos/mtls/README.md
@@ -1,5 +1,20 @@
 # mTLS demo — agent-to-agent encryption via SPIRE X.509 SVIDs
 
+> **Status (2026-05-27).** The **envoy-sidecar variant**
+> (`make demo-mtls-envoy*`) is verified end-to-end on a kind +
+> kagenti + SPIRE cluster; see the
+> [envoy-sidecar variant](#envoy-sidecar-variant) section below.
+> The **proxy-sidecar variant** (`make demo-mtls`) currently fails
+> at the verification step: the kagenti-operator's controller
+> reconciles per-agent `authbridge-config-*` ConfigMaps and reverts
+> the `mtls:` block that `patch-mtls-config.sh` writes, before the
+> restarted pod can mount it. Both demos are blocked on the same
+> upstream operator bug — see [Operator bugs uncovered](#operator-bugs-uncovered).
+> The Pod manifests in `k8s/{caller,callee}.yaml` were also missing
+> the `kagenti.io/type: agent` label that the operator's
+> mutating-webhook objectSelector requires; both demos' manifests
+> have been updated to include it.
+
 Two pods that talk to each other through their authbridge sidecars,
 configured with `mtls.mode: strict`. Confirms end-to-end:
 
@@ -81,3 +96,184 @@ The `make demo-mtls` target does:
   the cross-pod hop and authbridge's mTLS is redundant. This demo
   doesn't run ambient. Phase 5 will add ambient detection so the
   redundancy is auto-dropped.
+
+## envoy-sidecar variant
+
+The targets above (`make demo-mtls`, `make demo-mtls-permissive`, etc.)
+exercise mTLS in **proxy-sidecar** mode, where authbridge itself is
+the listener and the byte-peek + dial logic lives in Go
+(`authlib/listener/internal/tlssniff` for inbound,
+`authlib/listener/forwardproxy` for outbound).
+
+A parallel set of targets exercises **envoy-sidecar** mode, where
+Envoy is the listener and mTLS is configured at the data-plane level
+via `DownstreamTlsContext` / `UpstreamTlsContext` reading
+`/opt/svid*.pem`:
+
+```sh
+make demo-mtls-envoy                          # strict: deploy + verify
+make demo-mtls-envoy-permissive               # permissive: deploy + verify plaintext callers served
+make demo-mtls-envoy-strict-rejects-plain     # strict: verify plaintext rejected
+make undeploy-envoy                           # tear down + restore namespace envoy-config
+```
+
+### Design
+
+| `mtlsMode` | Inbound (peer-facing :15124) | Outbound (app-egress :15123) |
+| --- | --- | --- |
+| `disabled` (default) | plaintext | plaintext |
+| `permissive` | `tls_inspector` + two filter chains: TLS chain terminates mTLS, raw_buffer chain accepts plaintext | **plaintext** — no TLS-wrap attempt |
+| `strict` | `tls_inspector` + single TLS chain; plaintext rejected at chain match | `UpstreamTlsContext` on the `original_destination` cluster: TLS-or-fail, blanket |
+
+Inbound is byte-identical to proxy-sidecar's `tlssniff.Listener`
+(same protocol semantics, just expressed as Envoy filter chains —
+matches Istio's PERMISSIVE/STRICT inbound exactly).
+
+Outbound is **Istio-shaped**: there is no per-connection
+try-then-fallback (Envoy has no native primitive for it, and Istio
+itself doesn't do it — it relies on Pilot pre-deciding mesh
+membership). Blanket TLS in strict mode is practical for the same
+reason proxy-sidecar's strict mode is: outbound calls that need
+plaintext (Keycloak / JWKS / external HTTPS) never hit the listener:
+
+1. Plugin outbound (token-exchange, jwt-validation talking to
+   Keycloak / JWKS) uses Go's `net/http` directly — bypasses Envoy.
+2. External HTTPS from the app — `proxy-init`'s iptables redirects
+   only plaintext HTTP to the outbound listener; HTTPS bypasses it.
+3. HTTP from the app to peer agents — what gets TLS-wrapped. Peer's
+   inbound listener terminates. Works.
+
+### Behavioral gap vs proxy-sidecar
+
+In proxy-sidecar, a *permissive* caller can reach a *strict* peer
+because its outbound dialer tries TLS first per-connection and the
+handshake succeeds. In envoy-sidecar permissive, outbound is
+plaintext, so a permissive envoy-sidecar caller calling a strict
+peer **fails**. Mixed-mode deployments need both ends compatible
+(both strict, both permissive, or one strict + the other permissive
+on inbound only). The framework documentation in
+[`authbridge/CLAUDE.md`](../../CLAUDE.md#top-level-mtls-configuration)
+calls this out.
+
+### How the demo wires mTLS
+
+The demo is fully **hand-crafted** — no `kagenti.io/inject` label,
+no operator pod injection. This sidesteps both
+[operator bugs](#operator-bugs-uncovered): no RO `/opt` mount because
+we control the volumes, no per-agent CM reconciliation because there
+is no per-agent CM (the demo brings its own `envoy-config-mtls-active`
+and `authbridge-runtime-mtls` CMs that the operator doesn't touch).
+
+The demo pods bring their own:
+
+- ServiceAccount for SPIFFE identity (auto-registered via the
+  cluster's default `ClusterSPIFFEID` template
+  `spiffe://<trust-domain>/ns/<ns>/sa/<sa>`).
+- `authbridge-runtime-mtls` ConfigMap — minimal authbridge config
+  with a no-op pipeline (jwt-validation + token-exchange registered
+  but never invoked, since our Envoy config has no ext_proc filter).
+- `envoy-config-mtls-active` ConfigMap — populated by
+  `swap-envoy-config.sh` from one of the per-mode variants.
+- emptyDir for `/opt` (RW), CSI mount for `/spiffe-workload-api`.
+
+The demo's Envoy config uses **STATIC clusters** with explicit
+upstream addresses (`callee_cluster` points at
+`mtls-callee-envoy.team1.svc.cluster.local:8080`) rather than
+`ORIGINAL_DST` + iptables. That lets the demo skip the proxy-init
+container and HTTP_PROXY-route from the demo-app to the local
+Envoy outbound listener — same pattern the proxy-sidecar mTLS
+demo uses for its forward proxy on `:8081`.
+
+Production traffic uses ORIGINAL_DST + iptables — that's a
+deployment-shape concern, not a mTLS-design concern. Reusing the
+same TLS blocks (`tls_inspector`, `DownstreamTlsContext`, filter
+chain match, `UpstreamTlsContext`) in the operator's
+`envoy.yaml.tmpl` with ORIGINAL_DST is what the kagenti-operator
+follow-up PR does. The follow-up also fixes the RO `/opt` mount
+and per-agent CM rendering; once it lands, the user sets
+`mtlsMode: strict` on the AgentRuntime CR (or in the kagenti UI)
+and the operator wires up the same Envoy YAML this demo ships by
+hand.
+
+## Operator bugs uncovered
+
+Running both variants against a real cluster surfaced three
+kagenti-operator issues. Two of them block the demos today; the
+third is a Pod-spec selector mismatch this PR works around. The
+kagenti-operator follow-up PR is expected to fix #1 and #2; #3 is
+already fixed by the manifest updates in this PR.
+
+### #1 — `/opt` mounted `readOnly:true` on envoy-sidecar's `envoy-proxy` container
+
+Verified empirically:
+- proxy-sidecar `authbridge-proxy` container mounts `svid-output`
+  at `/opt` with `readOnly` defaulted (false → RW).
+- envoy-sidecar `envoy-proxy` container mounts the same volume at
+  `/opt` with `readOnly: true`.
+
+The in-process spiffe Provider mirror writes `/opt/svid.pem`,
+`/opt/svid_key.pem`, `/opt/svid_bundle.pem` on every SPIRE rotation;
+under the RO mount the mirror logs:
+
+```text
+spiffe.mirror: initial x509 write
+  err="write svid.pem: atomicWrite: create temp in /opt: open /opt/.tmp-svid.pem.4183688747: read-only file system"
+```
+
+Envoy then refuses to boot (`Invalid path: /opt/svid_bundle.pem`)
+because the file-based `DownstreamTlsContext` / `UpstreamTlsContext`
+references can't resolve. **Affects: envoy-sidecar mode only.** The
+fix is to flip the readOnly bit on the `svid-output` volumeMount in
+the envoy-sidecar branch of `BuildEnvoyProxyContainerWithSpireOption`
+in `kagenti-operator/internal/webhook/injector/container_builder.go`.
+
+### #2 — Operator controller reconciles per-agent CM, erases user-added fields
+
+`patch-mtls-config.sh` writes `mtls: { mode: strict }` into the
+per-agent `authbridge-config-<name>` ConfigMap. Some operator-side
+component (admission webhook on pod creation, or a reconciler watching
+the CM) re-templates the CM back to its operator-rendered shape
+*before* the pod's kubelet-mounted view picks up the patch:
+
+```console
+$ kubectl -n team1 get cm authbridge-config-mtls-caller \
+    -o jsonpath='{.metadata.annotations.kubectl\.kubernetes\.io/last-applied-configuration}' \
+    | jq -r '.data."config.yaml"' | tail -3
+spiffe: {}
+mtls:
+  mode: strict                 ← what patch-mtls-config.sh wrote
+
+$ kubectl -n team1 get cm authbridge-config-mtls-caller \
+    -o jsonpath='{.data.config\.yaml}' | tail -3
+      name: token-exchange
+spiffe: {}                     ← what the operator left after reconcile
+                                  (NO mtls block)
+
+$ kubectl -n team1 logs deploy/mtls-caller -c authbridge-proxy | grep mtls
+"mTLS disabled (no mtls block in config)"
+```
+
+Same pattern applied to my `spiffe.mirror_dir: /shared` workaround
+during envoy-sidecar testing. **Affects: BOTH proxy-sidecar (`make
+demo-mtls`) and envoy-sidecar variants of this demo.** Either the
+reconciler should preserve user-added fields it doesn't manage, or
+the canonical surface should be `Spec.MTLSMode` on the AgentRuntime
+CR with the operator rendering the resulting `mtls:` block — i.e.,
+the operator follow-up PR's plan.
+
+### #3 — Pod selector mismatch (workaround in this PR)
+
+The kagenti-operator's mutating-webhook `objectSelector` requires
+`kagenti.io/type` in `[agent, tool]`. The demos' Pod templates didn't
+set this label, so no operator injection happened (no authbridge
+sidecar, no per-agent CM created). Either the selector tightened
+recently or the demos haven't been re-run against a current operator.
+
+This PR adds `kagenti.io/type: agent` to all four demo Pod templates
+(`caller.yaml`, `callee.yaml`, `caller-envoy.yaml`, `callee-envoy.yaml`)
+and an explicit `runAsUser: 100` on the `demo-app` container to
+satisfy `runAsNonRoot: true` against the
+`curlimages/curl:latest` image (which now USERs as the non-numeric
+`curl_user`, tripping the kubelet's nonRoot check). With these in
+place the proxy-sidecar demo's Pods at least admit and roll out;
+verification still fails on issue #2 above.

--- a/authbridge/demos/mtls/k8s/authbridge-runtime-mtls.yaml
+++ b/authbridge/demos/mtls/k8s/authbridge-runtime-mtls.yaml
@@ -1,0 +1,29 @@
+# Minimal authbridge-runtime config for the envoy-sidecar mTLS demo.
+#
+# This config is consumed by the authbridge-envoy binary inside the
+# combined image — it does NOT carry an mtls block (envoy-sidecar
+# doesn't have one — mTLS is configured at the Envoy data-plane level
+# via envoy-config-mtls.yaml). Plugin pipelines are empty: this demo
+# tests TLS termination only, no token exchange or JWT validation.
+# The Envoy config has no ext_proc filter, so authbridge-envoy is
+# never invoked anyway.
+#
+# `spiffe: {}` (empty block) starts the in-process spiffe Provider
+# with default settings: socket /spiffe-workload-api/spire-agent.sock,
+# mirror_dir /opt. The demo pods mount /opt as an emptyDir (RW).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authbridge-runtime-mtls
+  namespace: team1
+  labels:
+    app.kubernetes.io/part-of: mtls-demo
+data:
+  config.yaml: |
+    mode: envoy-sidecar
+    pipeline:
+      inbound:
+        plugins: []
+      outbound:
+        plugins: []
+    spiffe: {}

--- a/authbridge/demos/mtls/k8s/callee-envoy.yaml
+++ b/authbridge/demos/mtls/k8s/callee-envoy.yaml
@@ -1,0 +1,124 @@
+# mTLS demo (envoy-sidecar variant) — callee pod. Mirror of
+# caller-envoy.yaml; demo-app listens on :8000 (Envoy inbound on
+# :15124 forwards to it).
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mtls-callee-envoy
+  namespace: team1
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mtls-callee-envoy
+  namespace: team1
+  labels:
+    app.kubernetes.io/name: mtls-callee-envoy
+    app.kubernetes.io/part-of: mtls-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mtls-callee-envoy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mtls-callee-envoy
+        app.kubernetes.io/part-of: mtls-demo
+    spec:
+      serviceAccountName: mtls-callee-envoy
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: demo-app
+          image: hashicorp/http-echo:1.0.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-listen=:8000"
+            - "-text=mtls-callee-envoy ok"
+          ports:
+            - containerPort: 8000
+              name: http
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 65532
+            capabilities: { drop: ["ALL"] }
+          resources:
+            limits:   { cpu: 100m, memory: 64Mi }
+            requests: { cpu:  10m, memory: 32Mi }
+
+        - name: envoy-proxy
+          image: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:latest
+          imagePullPolicy: IfNotPresent
+          args: ["--config", "/etc/authbridge/config.yaml"]
+          ports:
+            - containerPort: 15123
+              name: outbound
+            - containerPort: 15124
+              name: inbound
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsUser: 1337
+            runAsGroup: 1337
+            capabilities: { drop: ["ALL"] }
+          resources:
+            limits:   { cpu: 200m, memory: 128Mi }
+            requests: { cpu:  20m, memory:  64Mi }
+          volumeMounts:
+            - name: envoy-config
+              mountPath: /etc/envoy
+              readOnly: true
+            - name: authbridge-runtime
+              mountPath: /etc/authbridge
+              readOnly: true
+            - name: spire-agent-socket
+              mountPath: /spiffe-workload-api
+              readOnly: true
+            - name: svid-output
+              mountPath: /opt
+            - name: shared-data
+              mountPath: /shared
+
+      volumes:
+        - name: envoy-config
+          configMap:
+            name: envoy-config-mtls-active
+        - name: authbridge-runtime
+          configMap:
+            name: authbridge-runtime-mtls
+        - name: spire-agent-socket
+          csi:
+            driver: csi.spiffe.io
+            readOnly: true
+        - name: svid-output
+          emptyDir: {}
+        - name: shared-data
+          emptyDir: {}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mtls-callee-envoy
+  namespace: team1
+  labels:
+    app.kubernetes.io/name: mtls-callee-envoy
+    app.kubernetes.io/part-of: mtls-demo
+spec:
+  selector:
+    app.kubernetes.io/name: mtls-callee-envoy
+  ports:
+    # Caller dials Service:8080 -> caller's Envoy outbound:15123 ->
+    # callee_cluster (resolved via DNS to this Service) :8080 ->
+    # this Service routes to targetPort 15124 = callee's Envoy
+    # inbound listener.
+    - port: 8080
+      targetPort: 15124
+      protocol: TCP
+      name: http
+  type: ClusterIP

--- a/authbridge/demos/mtls/k8s/callee.yaml
+++ b/authbridge/demos/mtls/k8s/callee.yaml
@@ -33,6 +33,9 @@ spec:
         app.kubernetes.io/part-of: mtls-demo
         kagenti.io/inject: enabled
         kagenti.io/spire: enabled
+        # Required by the kagenti-operator's mutating-webhook
+        # objectSelector ({kagenti.io/type: [agent, tool]}).
+        kagenti.io/type: agent
     spec:
       serviceAccountName: mtls-callee
       securityContext:
@@ -41,7 +44,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: demo-app
-          image: hashicorp/http-echo:latest
+          image: hashicorp/http-echo:1.0.0
           imagePullPolicy: IfNotPresent
           args:
             - "-listen=:8000"

--- a/authbridge/demos/mtls/k8s/caller-envoy.yaml
+++ b/authbridge/demos/mtls/k8s/caller-envoy.yaml
@@ -1,0 +1,139 @@
+# mTLS demo (envoy-sidecar variant) — caller pod.
+#
+# This is hand-crafted (no kagenti.io/inject label) so we control
+# every volume mount. Two operator-side bugs (RO /opt mount in
+# envoy-sidecar mode, runtime CM auto-reconciliation) make the
+# operator-injected path unworkable today; the operator follow-up
+# PR fixes both.
+#
+# SPIRE registration happens automatically via the cluster's default
+# ClusterSPIFFEID (template
+#   spiffe://<trust-domain>/ns/<namespace>/sa/<sa-name>
+# ). Any ServiceAccount-bound pod gets an SVID — no kagenti.io/spire
+# label or operator help required.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mtls-caller-envoy
+  namespace: team1
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mtls-caller-envoy
+  namespace: team1
+  labels:
+    app.kubernetes.io/name: mtls-caller-envoy
+    app.kubernetes.io/part-of: mtls-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mtls-caller-envoy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mtls-caller-envoy
+        app.kubernetes.io/part-of: mtls-demo
+    spec:
+      serviceAccountName: mtls-caller-envoy
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: demo-app
+          image: curlimages/curl:8.11.1
+          imagePullPolicy: IfNotPresent
+          # HTTP_PROXY routes the app's curl through the local Envoy
+          # outbound listener — same pattern the proxy-sidecar demo
+          # uses for its forward proxy on :8081.
+          env:
+            - name: HTTP_PROXY
+              value: "http://127.0.0.1:15123"
+            - name: http_proxy
+              value: "http://127.0.0.1:15123"
+          command: ["sh", "-c", "while true; do sleep 30; done"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 100
+            capabilities: { drop: ["ALL"] }
+          resources:
+            limits:   { cpu: 100m, memory: 64Mi }
+            requests: { cpu:  10m, memory: 32Mi }
+
+        - name: envoy-proxy
+          image: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:latest
+          imagePullPolicy: IfNotPresent
+          # The combined image's entrypoint runs authbridge-envoy
+          # with these args (which it forwards to the binary), then
+          # starts Envoy.
+          args: ["--config", "/etc/authbridge/config.yaml"]
+          ports:
+            - containerPort: 15123
+              name: outbound
+            - containerPort: 15124
+              name: inbound
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsUser: 1337
+            runAsGroup: 1337
+            capabilities: { drop: ["ALL"] }
+          resources:
+            limits:   { cpu: 200m, memory: 128Mi }
+            requests: { cpu:  20m, memory:  64Mi }
+          volumeMounts:
+            - name: envoy-config
+              mountPath: /etc/envoy
+              readOnly: true
+            - name: authbridge-runtime
+              mountPath: /etc/authbridge
+              readOnly: true
+            - name: spire-agent-socket
+              mountPath: /spiffe-workload-api
+              readOnly: true
+            - name: svid-output
+              mountPath: /opt
+              # NOT readOnly — the spiffe Provider mirror writes here.
+            - name: shared-data
+              mountPath: /shared
+
+      volumes:
+        - name: envoy-config
+          configMap:
+            name: envoy-config-mtls-active
+        - name: authbridge-runtime
+          configMap:
+            name: authbridge-runtime-mtls
+        - name: spire-agent-socket
+          csi:
+            driver: csi.spiffe.io
+            readOnly: true
+        - name: svid-output
+          emptyDir: {}
+        - name: shared-data
+          emptyDir: {}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mtls-caller-envoy
+  namespace: team1
+  labels:
+    app.kubernetes.io/name: mtls-caller-envoy
+    app.kubernetes.io/part-of: mtls-demo
+spec:
+  selector:
+    app.kubernetes.io/name: mtls-caller-envoy
+  ports:
+    - port: 8080
+      # No demo-app listener; this Service exists only so the SPIRE
+      # ClusterSPIFFEID auto-populates DNS names. Caller is a client.
+      targetPort: 8000
+      protocol: TCP
+      name: http
+  type: ClusterIP

--- a/authbridge/demos/mtls/k8s/caller.yaml
+++ b/authbridge/demos/mtls/k8s/caller.yaml
@@ -36,6 +36,9 @@ spec:
         app.kubernetes.io/part-of: mtls-demo
         kagenti.io/inject: enabled
         kagenti.io/spire: enabled
+        # Required by the kagenti-operator's mutating-webhook
+        # objectSelector ({kagenti.io/type: [agent, tool]}).
+        kagenti.io/type: agent
     spec:
       serviceAccountName: mtls-caller
       securityContext:
@@ -44,7 +47,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: demo-app
-          image: curlimages/curl:latest
+          image: curlimages/curl:8.11.1
           imagePullPolicy: IfNotPresent
           command: ["sh", "-c", "while true; do sleep 30; done"]
           env:
@@ -55,6 +58,10 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+            # curlimages/curl USERs as the non-numeric `curl_user`;
+            # an explicit numeric runAsUser is required for the
+            # kubelet's runAsNonRoot check to pass.
+            runAsUser: 100
             capabilities:
               drop: ["ALL"]
           resources:

--- a/authbridge/demos/mtls/k8s/envoy-config-mtls.yaml
+++ b/authbridge/demos/mtls/k8s/envoy-config-mtls.yaml
@@ -1,0 +1,320 @@
+# Envoy configs for the envoy-sidecar mTLS demo.
+#
+# These are hand-crafted, self-contained Envoy configs for the demo
+# pods at k8s/{caller,callee}-envoy.yaml. They prove the mTLS design
+# (tls_inspector + filter_chain_match for permissive, single TLS chain
+# for strict, UpstreamTlsContext for outbound origination) at the
+# Envoy data-plane level.
+#
+# Two ConfigMaps below — one per mode. The Makefile creates a third
+# ConfigMap named `envoy-config-mtls-active` populated from one of
+# these variants; the demo deployments mount that.
+#
+# For demo simplicity these configs use STATIC clusters with explicit
+# upstream addresses (caller's outbound dials callee.team1:8080;
+# callee's inbound forwards to 127.0.0.1:8000). Production traffic
+# uses ORIGINAL_DST + iptables redirect — that's a deployment-shape
+# concern, not a mTLS-design concern, and reusing the same TLS blocks
+# in the operator's envoy.yaml.tmpl with ORIGINAL_DST is what the
+# follow-up PR does.
+#
+# X.509 SVID files are written to /opt by the in-process spiffe
+# Provider mirror inside the authbridge-envoy combined image. The
+# pod manifests mount /opt as an emptyDir (RW) — the operator's
+# default RO mount on this path is a separate bug tracked in the
+# operator follow-up.
+#
+# Semantics:
+#
+#   permissive — inbound listener accepts both TLS and plaintext via
+#                tls_inspector + filter_chain_match (transport_protocol).
+#                Outbound stays plaintext. This is byte-identical to
+#                Istio's PERMISSIVE inbound, and equivalent in spirit
+#                to proxy-sidecar's tlssniff byte-peek listener.
+#
+#   strict     — inbound listener accepts only TLS (single TLS chain;
+#                plaintext drops at filter chain match). Outbound
+#                originates TLS to the callee cluster (UpstreamTlsContext).
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: envoy-config-mtls-permissive
+  namespace: team1
+  labels:
+    app.kubernetes.io/part-of: mtls-demo
+    kagenti.io/mtls-mode: permissive
+data:
+  envoy.yaml: |
+    admin:
+      address:
+        socket_address:
+          protocol: TCP
+          address: 127.0.0.1
+          port_value: 9901
+
+    static_resources:
+      listeners:
+      # Outbound: caller's app -> envoy:15123 (via HTTP_PROXY) ->
+      # callee_cluster (which in permissive mode is plaintext).
+      - name: outbound_listener
+        address:
+          socket_address:
+            protocol: TCP
+            address: 0.0.0.0
+            port_value: 15123
+        filter_chains:
+        - filters:
+          - name: envoy.filters.network.http_connection_manager
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              stat_prefix: outbound_http
+              codec_type: AUTO
+              route_config:
+                name: outbound_routes
+                virtual_hosts:
+                - name: catch_all
+                  domains: ["*"]
+                  routes:
+                  - match: { prefix: "/" }
+                    route: { cluster: callee_cluster }
+              http_filters:
+              - name: envoy.filters.http.router
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+      # Inbound: callee receives traffic from caller. tls_inspector
+      # peeks the first bytes; filter_chain_match routes TLS to the
+      # mTLS chain and plaintext to the raw_buffer chain.
+      - name: inbound_listener
+        address:
+          socket_address:
+            protocol: TCP
+            address: 0.0.0.0
+            port_value: 15124
+        listener_filters:
+        - name: envoy.filters.listener.tls_inspector
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+        filter_chains:
+        # TLS chain — terminates mTLS, validates peer cert against
+        # the SPIRE trust bundle, requires a client certificate.
+        - filter_chain_match:
+            transport_protocol: tls
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+              require_client_certificate: true
+              common_tls_context:
+                tls_certificates:
+                - certificate_chain: { filename: /opt/svid.pem }
+                  private_key:       { filename: /opt/svid_key.pem }
+                validation_context:
+                  trusted_ca:        { filename: /opt/svid_bundle.pem }
+          filters:
+          - name: envoy.filters.network.http_connection_manager
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              stat_prefix: inbound_http_tls
+              codec_type: AUTO
+              route_config:
+                name: inbound_routes
+                virtual_hosts:
+                - name: local_app
+                  domains: ["*"]
+                  routes:
+                  - match: { prefix: "/" }
+                    route: { cluster: local_app }
+              http_filters:
+              - name: envoy.filters.http.router
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        # Plaintext chain — accepts non-TLS traffic on the same port.
+        # Strict mode omits this chain entirely so plaintext drops at
+        # filter chain match.
+        - filter_chain_match:
+            transport_protocol: raw_buffer
+          filters:
+          - name: envoy.filters.network.http_connection_manager
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              stat_prefix: inbound_http_plain
+              codec_type: AUTO
+              route_config:
+                name: inbound_routes_plain
+                virtual_hosts:
+                - name: local_app_plain
+                  domains: ["*"]
+                  routes:
+                  - match: { prefix: "/" }
+                    route: { cluster: local_app }
+              http_filters:
+              - name: envoy.filters.http.router
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+      clusters:
+      # callee_cluster — caller's outbound dials callee here.
+      # Permissive: plaintext upstream.
+      - name: callee_cluster
+        connect_timeout: 5s
+        type: STRICT_DNS
+        lb_policy: ROUND_ROBIN
+        load_assignment:
+          cluster_name: callee_cluster
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: mtls-callee-envoy.team1.svc.cluster.local
+                    port_value: 8080
+
+      # local_app — callee's inbound forwards decrypted traffic to
+      # the demo-app container on localhost:8000.
+      - name: local_app
+        connect_timeout: 5s
+        type: STATIC
+        lb_policy: ROUND_ROBIN
+        load_assignment:
+          cluster_name: local_app
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: 127.0.0.1
+                    port_value: 8000
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: envoy-config-mtls-strict
+  namespace: team1
+  labels:
+    app.kubernetes.io/part-of: mtls-demo
+    kagenti.io/mtls-mode: strict
+data:
+  envoy.yaml: |
+    admin:
+      address:
+        socket_address:
+          protocol: TCP
+          address: 127.0.0.1
+          port_value: 9901
+
+    static_resources:
+      listeners:
+      - name: outbound_listener
+        address:
+          socket_address:
+            protocol: TCP
+            address: 0.0.0.0
+            port_value: 15123
+        filter_chains:
+        - filters:
+          - name: envoy.filters.network.http_connection_manager
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              stat_prefix: outbound_http
+              codec_type: AUTO
+              route_config:
+                name: outbound_routes
+                virtual_hosts:
+                - name: catch_all
+                  domains: ["*"]
+                  routes:
+                  - match: { prefix: "/" }
+                    route: { cluster: callee_cluster_tls }
+              http_filters:
+              - name: envoy.filters.http.router
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+      - name: inbound_listener
+        address:
+          socket_address:
+            protocol: TCP
+            address: 0.0.0.0
+            port_value: 15124
+        listener_filters:
+        - name: envoy.filters.listener.tls_inspector
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+        # Strict — only the TLS chain. Plaintext drops at filter
+        # chain match (no chain matches transport_protocol: raw_buffer).
+        filter_chains:
+        - filter_chain_match:
+            transport_protocol: tls
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+              require_client_certificate: true
+              common_tls_context:
+                tls_certificates:
+                - certificate_chain: { filename: /opt/svid.pem }
+                  private_key:       { filename: /opt/svid_key.pem }
+                validation_context:
+                  trusted_ca:        { filename: /opt/svid_bundle.pem }
+          filters:
+          - name: envoy.filters.network.http_connection_manager
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              stat_prefix: inbound_http_tls
+              codec_type: AUTO
+              route_config:
+                name: inbound_routes
+                virtual_hosts:
+                - name: local_app
+                  domains: ["*"]
+                  routes:
+                  - match: { prefix: "/" }
+                    route: { cluster: local_app }
+              http_filters:
+              - name: envoy.filters.http.router
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+      clusters:
+      # callee_cluster_tls — caller's outbound TLS-originates to the
+      # callee using the local SPIRE-issued SVID. Peer must present a
+      # cert validated against the SPIRE trust bundle.
+      - name: callee_cluster_tls
+        connect_timeout: 5s
+        type: STRICT_DNS
+        lb_policy: ROUND_ROBIN
+        load_assignment:
+          cluster_name: callee_cluster_tls
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: mtls-callee-envoy.team1.svc.cluster.local
+                    port_value: 8080
+        transport_socket:
+          name: envoy.transport_sockets.tls
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+            common_tls_context:
+              tls_certificates:
+              - certificate_chain: { filename: /opt/svid.pem }
+                private_key:       { filename: /opt/svid_key.pem }
+              validation_context:
+                trusted_ca:        { filename: /opt/svid_bundle.pem }
+
+      - name: local_app
+        connect_timeout: 5s
+        type: STATIC
+        lb_policy: ROUND_ROBIN
+        load_assignment:
+          cluster_name: local_app
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: 127.0.0.1
+                    port_value: 8000

--- a/authbridge/demos/mtls/scripts/swap-envoy-config.sh
+++ b/authbridge/demos/mtls/scripts/swap-envoy-config.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Populate the demo's `envoy-config-mtls-active` ConfigMap from one of
+# the per-mode variants (envoy-config-mtls-permissive /
+# envoy-config-mtls-strict). The hand-crafted demo deployments mount
+# `envoy-config-mtls-active` directly — there's no shared
+# namespace `envoy-config` to mutate, and no operator reconciliation
+# loop to fight.
+#
+# Usage:
+#   swap-envoy-config.sh <namespace> permissive|strict
+#   swap-envoy-config.sh <namespace> clean      # delete the active CM
+
+set -euo pipefail
+
+NAMESPACE=${1:?usage: swap-envoy-config.sh <namespace> permissive|strict|clean}
+ACTION=${2:?usage: swap-envoy-config.sh <namespace> permissive|strict|clean}
+
+HERE=$(dirname "$0")
+
+case "$ACTION" in
+  permissive|strict)
+    SRC_CM="envoy-config-mtls-${ACTION}"
+
+    # Apply both variant CMs (idempotent) and the runtime CM.
+    kubectl apply -f "$HERE/../k8s/envoy-config-mtls.yaml"
+    kubectl apply -f "$HERE/../k8s/authbridge-runtime-mtls.yaml"
+
+    # Build the active CM from the chosen variant.
+    YAML=$(kubectl -n "$NAMESPACE" get cm "$SRC_CM" -o jsonpath='{.data.envoy\.yaml}')
+    if [[ -z "$YAML" ]]; then
+      echo "ERROR: $SRC_CM has no envoy.yaml entry — did the apply succeed?" >&2
+      exit 1
+    fi
+
+    kubectl -n "$NAMESPACE" create configmap envoy-config-mtls-active \
+      --from-literal=envoy.yaml="$YAML" \
+      --dry-run=client -o yaml | \
+      kubectl -n "$NAMESPACE" apply -f - >/dev/null
+
+    echo "[*] envoy-config-mtls-active populated from $SRC_CM (mode: $ACTION)"
+    ;;
+
+  clean)
+    kubectl -n "$NAMESPACE" delete cm \
+      envoy-config-mtls-active envoy-config-mtls-permissive envoy-config-mtls-strict \
+      authbridge-runtime-mtls --ignore-not-found
+    echo "[*] demo CMs removed"
+    ;;
+
+  *)
+    echo "ERROR: action must be permissive | strict | clean, got: $ACTION" >&2
+    exit 1
+    ;;
+esac

--- a/authbridge/demos/mtls/scripts/verify-encrypted-envoy.sh
+++ b/authbridge/demos/mtls/scripts/verify-encrypted-envoy.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Verify mTLS is active on the envoy-sidecar variant.
+#
+# We can't grep "mTLS enabled" out of authbridge-proxy logs the way
+# verify-encrypted.sh does — in envoy-sidecar mode mTLS is terminated
+# by Envoy, not by authbridge. Three-pronged check:
+#
+#   1. The active envoy-config CM has tls_inspector + SVID paths
+#      (proves the swap landed).
+#   2. The spiffe Provider mirror has written /opt/svid*.pem on each
+#      pod (proves SPIRE registration is alive).
+#   3. The caller can reach the callee through the sidecars (proves
+#      the wiring works end-to-end).
+#
+# The "encryption on the wire" proof comes from
+# verify-strict-rejects-plain-envoy.sh — a strict listener that
+# rejects plaintext is observably enforcing TLS.
+#
+# Usage: verify-encrypted-envoy.sh <namespace> <caller> <callee>
+
+set -euo pipefail
+
+NAMESPACE=${1:?usage: verify-encrypted-envoy.sh <namespace> <caller> <callee>}
+CALLER=${2:?}
+CALLEE=${3:?}
+
+echo "[*] Confirming the active envoy-config has TLS termination wired in"
+cm=$(kubectl -n "$NAMESPACE" get cm envoy-config-mtls-active -o jsonpath='{.data.envoy\.yaml}' 2>/dev/null || true)
+if [[ -z "$cm" ]]; then
+  echo "  ERROR: envoy-config-mtls-active not found in $NAMESPACE — run swap-envoy-config.sh first" >&2
+  exit 1
+fi
+for pat in 'tls_inspector' 'DownstreamTlsContext' '/opt/svid.pem' '/opt/svid_bundle.pem'; do
+  if ! echo "$cm" | grep -q "$pat"; then
+    echo "  ERROR: envoy-config-mtls-active missing pattern: $pat" >&2
+    exit 1
+  fi
+done
+echo "  envoy-config: tls_inspector + DownstreamTlsContext + SVID paths present"
+
+echo
+echo "[*] Confirming spiffe Provider mirror wrote SVIDs to /opt on each pod"
+for agent in "$CALLER" "$CALLEE"; do
+  # Filter to a Running, fully-Ready pod so we don't accidentally
+  # exec into a Terminating one mid-rollout.
+  pod=$(kubectl -n "$NAMESPACE" get pod \
+          -l app.kubernetes.io/name="$agent" \
+          --field-selector=status.phase=Running \
+          -o 'jsonpath={range .items[?(@.status.containerStatuses[0].ready==true)]}{.metadata.name}{"\n"}{end}' \
+          | head -1)
+  if [[ -z "$pod" ]]; then
+    echo "  ERROR: no Ready pod found for $agent in $NAMESPACE" >&2
+    exit 1
+  fi
+  files=$(kubectl -n "$NAMESPACE" exec "$pod" -c envoy-proxy -- /bin/sh -c \
+            'ls /opt/svid.pem /opt/svid_key.pem /opt/svid_bundle.pem 2>/dev/null | wc -l' 2>/dev/null \
+          || echo 0)
+  if [[ "$files" -lt 3 ]]; then
+    echo "  ERROR: $pod ($agent): only $files of 3 SVID files present in /opt/" >&2
+    echo "         spiffe-helper or in-process Provider didn't fetch from SPIRE." >&2
+    exit 1
+  fi
+  echo "  $agent: 3/3 SVID files present in /opt/"
+done
+
+echo
+echo "[*] Triggering caller → callee request through the sidecars"
+out=$(kubectl -n "$NAMESPACE" exec deploy/"$CALLER" -c demo-app -- \
+        curl -sS --max-time 10 \
+             "http://${CALLEE}.${NAMESPACE}.svc.cluster.local:8080/" 2>&1) || {
+  echo "ERROR: request failed:" >&2
+  echo "$out" >&2
+  exit 1
+}
+echo "  Response: $out"
+
+echo
+echo "============================================="
+echo " mTLS verified — caller → callee through TLS-"
+echo " enabled Envoy listeners on both ends"
+echo "============================================="

--- a/authbridge/demos/mtls/scripts/verify-permissive-envoy.sh
+++ b/authbridge/demos/mtls/scripts/verify-permissive-envoy.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Verify a permissive envoy-sidecar callee serves plaintext on the
+# same port. Same contract as verify-permissive.sh, just hits the
+# envoy-variant callee.
+#
+# Usage: verify-permissive-envoy.sh <namespace> <callee>
+
+set -euo pipefail
+
+NAMESPACE=${1:?usage: verify-permissive-envoy.sh <namespace> <callee>}
+CALLEE=${2:?}
+
+echo "[*] Hitting $CALLEE with plain HTTP from a non-mesh client"
+out=$(kubectl -n "$NAMESPACE" run --rm -i --restart=Never \
+        --image=curlimages/curl:latest \
+        --command "verify-permissive-envoy-$$" -- \
+        curl -sS --max-time 10 \
+             "http://${CALLEE}.${NAMESPACE}.svc.cluster.local:8080/" 2>&1) || {
+  echo "ERROR: plaintext request to permissive callee failed:" >&2
+  echo "$out" >&2
+  exit 1
+}
+echo "  Response: $out"
+echo
+echo "==================================================================="
+echo " Permissive (envoy) verified — raw_buffer chain serves plaintext"
+echo "==================================================================="

--- a/authbridge/demos/mtls/scripts/verify-strict-rejects-plain-envoy.sh
+++ b/authbridge/demos/mtls/scripts/verify-strict-rejects-plain-envoy.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Verify a strict envoy-sidecar callee closes plain HTTP connections.
+# Same contract as verify-strict-rejects-plain.sh, just hits the
+# envoy-variant callee.
+#
+# Usage: verify-strict-rejects-plain-envoy.sh <namespace> <callee>
+
+set -euo pipefail
+
+NAMESPACE=${1:?usage: verify-strict-rejects-plain-envoy.sh <namespace> <callee>}
+CALLEE=${2:?}
+
+echo "[*] Hitting $CALLEE with plain HTTP from a non-mesh client — expect rejection"
+if kubectl -n "$NAMESPACE" run --rm -i --restart=Never \
+     --image=curlimages/curl:latest \
+     --command "verify-strict-envoy-$$" -- \
+     curl -sS --max-time 10 \
+          "http://${CALLEE}.${NAMESPACE}.svc.cluster.local:8080/" >/dev/null 2>&1; then
+  echo "ERROR: strict envoy-sidecar callee unexpectedly served plaintext." >&2
+  echo "       Either tls_inspector isn't routing the connection to the" >&2
+  echo "       TLS chain, or a raw_buffer chain is still present." >&2
+  exit 1
+fi
+echo "  Connection rejected as expected."
+echo
+echo "================================================================"
+echo " Strict (envoy) verified — plaintext rejected at filter chain match"
+echo "================================================================"


### PR DESCRIPTION
## Summary

- Adds an envoy-sidecar mTLS demo (`make demo-mtls-envoy*`) — proves the Envoy data-plane mTLS design (`tls_inspector` + filter chain match for inbound, `UpstreamTlsContext` for strict outbound) works end-to-end with SPIRE X.509 SVIDs.
- Fixes the existing proxy-sidecar demo's Pod manifests (`kagenti.io/type: agent` label + explicit `runAsUser: 100`) so they at least admit and roll out under the current operator's tightened webhook selectors.
- Documents three operator bugs uncovered during e2e testing — two of which are blockers the kagenti-operator follow-up PR needs to fix.

## Design

| `mtlsMode` | Inbound (peer-facing :15124) | Outbound (app-egress :15123) |
| --- | --- | --- |
| `disabled` (default) | plaintext | plaintext |
| `permissive` | `tls_inspector` + two filter chains: TLS chain terminates mTLS, raw_buffer chain accepts plaintext | **plaintext** — no TLS-wrap attempt |
| `strict` | `tls_inspector` + single TLS chain; plaintext rejected at chain match | `UpstreamTlsContext`: TLS-or-fail, blanket |

Inbound is byte-identical to proxy-sidecar's `tlssniff.Listener` semantics, expressed as Envoy filter chains — matches Istio's PERMISSIVE/STRICT inbound exactly.

Outbound is Istio-shaped: no per-connection try-then-fallback. Blanket TLS in strict mode is practical because outbound calls that need plaintext (Keycloak / JWKS / external HTTPS) never reach the listener — plugin outbound uses Go `net/http` directly, and `proxy-init`'s iptables redirects only plaintext HTTP to the outbound listener.

**Behavioral gap to know:** a *permissive* envoy-sidecar caller cannot reach a *strict* peer (its outbound is plaintext; the peer's strict inbound rejects it). proxy-sidecar permissive can, because its outbound dialer tries TLS first per-connection. Documented in `authbridge/CLAUDE.md` and the demo README.

## Why hand-crafted (not operator-injected)

The demo uses its own pod manifests with no `kagenti.io/inject` label. SPIFFE identity auto-registers via the cluster's default `ClusterSPIFFEID` template (`spiffe://<trust-domain>/ns/<ns>/sa/<sa>`). This sidesteps two operator bugs that would otherwise block the demo entirely — see "Operator bugs uncovered" in the demo README.

## Operator bugs uncovered

Verified empirically during e2e testing. The kagenti-operator follow-up PR needs to address #1 and #2 in addition to its originally-planned scope.

1. **`/opt` mounted `readOnly:true` on envoy-sidecar's `envoy-proxy` container** (asymmetric with proxy-sidecar's RW). The in-process spiffe Provider mirror can't write SVID files; Envoy refuses to boot.
2. **Operator's controller reconciles per-agent `authbridge-config-<name>` ConfigMaps and erases user-added fields** (`mtls:`, `spiffe.mirror_dir`, etc.) before the pod can mount them. Affects both the existing proxy-sidecar `make demo-mtls` and the envoy-sidecar variant. Either preserve user fields in reconcile, or make `Spec.MTLSMode` on the AgentRuntime CR the canonical source.
3. **Pod selector mismatch** — webhook's `objectSelector` requires `kagenti.io/type` in `[agent, tool]`. Demo manifests didn't have it. Fixed in this PR.

## Test plan

Verified e2e on a kind + kagenti + SPIRE cluster (kagenti chart `0.3.0-alpha.1`, authbridge-envoy `:latest`):

- [x] `make demo-mtls-envoy` — strict mode caller→callee succeeds; SVIDs mirrored to `/opt`; Envoy admin `/config_dump` shows `tls_inspector` + `DownstreamTlsContext`.
- [x] `make demo-mtls-envoy-strict-rejects-plain` — external plaintext call rejected at filter chain match.
- [x] `make demo-mtls-envoy-permissive` — external plaintext call served by the `raw_buffer` chain.
- [x] `make undeploy-envoy` — clean teardown.
- [x] Proxy-sidecar `make demo-mtls` admits + rolls out (was failing on selector + curl runAsUser before this PR). Verification still fails on operator bug 2 — documented.
- [x] Lint: `kubectl apply --dry-run=client` on all 6 manifests, `bash -n` on all 8 scripts, `go vet ./cmd/authbridge-envoy/...`.

**Follow-up (separate PR, not blocking this one):** re-run on a fresh cluster after the kagenti-operator follow-up PR lands and confirm the operator-injected path produces the same Envoy YAML this demo ships by hand.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Envoy-sidecar mTLS demo variant with permissive/strict modes, new make targets, demo manifests, mode-switching helper, and verification scripts.

* **Documentation**
  * Expanded docs describing Envoy-sidecar mTLS semantics, configuration variants, SVID file usage/paths, and known interoperability gap (permissive→strict).

* **Bug Fixes**
  * Demo manifest fixes (labels, image pinning, non-root user) and a status note documenting operator issues uncovered.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kagenti/kagenti-extensions/pull/440?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->