### PR TITLE
fix(mtls-demo): Patch namespace CM + align permissive across modes

### DIFF
--- a/authbridge/CLAUDE.md
+++ b/authbridge/CLAUDE.md
@@ -279,7 +279,7 @@ mtls:
 | Mode | Inbound (reverse proxy `:8080`) | Outbound (forward proxy) |
 |---|---|---|
 | (no `mtls` block) | Plaintext only. | Plaintext only. |
-| `permissive` (default when block present) | Byte-peek listener: TLS handshakes verified against the SPIRE trust bundle; plaintext callers served on the same port. ⚠️ Plaintext requests carry their full headers and bodies in the clear — including any `Authorization: Bearer ...` token already injected by `token-exchange`. Use only during rollout with cluster-network trust. | Try TLS first; on handshake failure fall back to plain TCP (one-line WARN log). |
+| `permissive` (default when block present) | Byte-peek listener: TLS handshakes verified against the SPIRE trust bundle; plaintext callers served on the same port. ⚠️ Plaintext requests carry their full headers and bodies in the clear — including any `Authorization: Bearer ...` token already injected by `token-exchange`. Use only during rollout with cluster-network trust. | Plaintext — no TLS-wrap attempt. Matches envoy-sidecar's permissive and Istio's PeerAuthentication semantics (permissive is inbound-only). A permissive caller cannot reach a strict peer; mixed-mode deployments need both ends compatible. |
 | `strict` | TLS only — non-TLS callers get the connection closed. | TLS or fail: handshake failure is a hard error, no fallback. |
 
 In both modes, a successful TLS handshake that fails certificate
@@ -318,31 +318,30 @@ plaintext is served (permissive) or rejected (strict). Same outcome
 as proxy-sidecar's `tlssniff.Listener`, just expressed as Envoy
 filter chains. This matches Istio's PERMISSIVE/STRICT inbound exactly.
 
-**Outbound is Istio-shaped, not proxy-sidecar-shaped:** Envoy has
-no native primitive for "try TLS, fall back to plaintext on handshake
-failure" within an `ORIGINAL_DST` cluster (and Istio itself doesn't do
-it — Pilot pre-decides mesh membership). So envoy-sidecar's
-permissive mode keeps outbound plaintext, and strict mode does
-blanket TLS-or-fail to everything the listener sees. This works in
-practice because outbound calls that need plaintext — Keycloak,
-JWKS, external HTTPS — never reach the listener: plugin outbound
-uses Go `net/http` directly, and `proxy-init`'s iptables doesn't
-redirect arbitrary HTTPS egress.
+**Outbound is Istio-shaped:** Envoy has no native primitive for
+"try TLS, fall back to plaintext on handshake failure" within an
+`ORIGINAL_DST` cluster (and Istio itself doesn't do it — Pilot
+pre-decides mesh membership). Permissive keeps outbound plaintext;
+strict does blanket TLS-or-fail to everything the listener sees.
+This works in practice because outbound calls that need plaintext —
+Keycloak, JWKS, external HTTPS — never reach the listener: plugin
+outbound uses Go `net/http` directly, and `proxy-init`'s iptables
+doesn't redirect arbitrary HTTPS egress. **Proxy-sidecar matches
+this**: its forward proxy now also dials plaintext in permissive
+mode, so the two deployment shapes share one outbound semantics.
 
-**Behavioral gap to know:** a *permissive* envoy-sidecar caller
-cannot reach a *strict* peer (its outbound is plaintext; the peer's
-strict inbound rejects it). proxy-sidecar permissive can, because
-its outbound dialer tries TLS first per-connection. Mixed-mode
-deployments need both ends compatible — both strict, both permissive,
-or one strict + the other permissive on inbound only.
+**Behavioral note:** a *permissive* caller cannot reach a *strict*
+peer regardless of mode (its outbound is plaintext; the peer's
+strict inbound rejects it). Mixed-mode deployments need both ends
+compatible — both strict, both permissive, or one strict + the
+other permissive on inbound only.
 
-The kagenti-operator's AgentRuntime CR has an `Spec.MTLSMode` field
-but currently rejects `mtlsMode != disabled` with `envoy-sidecar`
-at admission. The `authbridge/demos/mtls/` envoy-sidecar variant
-(`make demo-mtls-envoy*`) bypasses that gate by swapping the
-namespace `envoy-config` ConfigMap directly; the operator follow-up
-PR will close the gap by rendering per-agent envoy-config from
-`Spec.MTLSMode`.
+The kagenti-operator's AgentRuntime CR's `Spec.MTLSMode` flows
+through to a per-agent rendered envoy-config with the matching TLS
+blocks (operator companion PR). The `authbridge/demos/mtls/`
+envoy-sidecar variant (`make demo-mtls-envoy*`) ships a hand-crafted
+demo that proves the same Envoy YAML design at the data-plane level
+without needing a CR.
 
 ## Build and Deploy
 

--- a/authbridge/authlib/listener/forwardproxy/server.go
+++ b/authbridge/authlib/listener/forwardproxy/server.go
@@ -35,27 +35,32 @@ type Server struct {
 	Client           *http.Client
 }
 
-// MTLSOptions configures outbound mTLS. When non-nil, the forward
-// proxy's HTTP client uses a custom DialContext that:
+// MTLSOptions configures outbound mTLS for the forward proxy. When
+// non-nil, every outbound dial:
 //
 //  1. opens a plain TCP connection to the destination
 //  2. attempts a TLS handshake using the local SVID
 //  3. on handshake success → returns the *tls.Conn
-//  4. on handshake failure:
-//     - Strict=false: closes, redials plain TCP, returns the plain conn
-//     (with a one-line WARN log naming the destination)
-//     - Strict=true: closes and returns the handshake error
-//  5. successful handshake with verification failure is always a hard
-//     error in both modes (destination misconfigured its identity)
+//  4. on handshake failure → closes and returns the error (TLS-or-fail)
+//
+// There is no per-connection fallback to plaintext. To match Istio's
+// PeerAuthentication semantics — and to keep proxy-sidecar's outbound
+// behavior consistent with envoy-sidecar's, which has no native
+// "try TLS, fall back" primitive — permissive mode does not pass
+// MTLSOptions to NewServer at all (callers leave it nil so the
+// transport stays plaintext). Strict mode passes MTLSOptions and the
+// dial fails closed when the peer can't terminate.
+//
+// A successful handshake whose peer cert fails verification is always
+// a hard error.
 type MTLSOptions struct {
 	Source  spiffe.X509Source
-	Strict  bool
 	Metrics *authtls.Metrics
 }
 
 // NewServer creates a forward proxy server with a default HTTP client.
-// When mtls is non-nil, every outbound dial first tries TLS using the
-// local SVID; mode-aware fallback is described in MTLSOptions.
+// When mtls is non-nil, every outbound dial does TLS-or-fail using the
+// local SVID; see MTLSOptions for semantics.
 func NewServer(outbound *pipeline.Holder, sessions *session.Store, mtls *MTLSOptions) (*Server, error) {
 	transport := &http.Transport{
 		// Sane Go defaults for everything except DialContext, which we
@@ -74,7 +79,7 @@ func NewServer(outbound *pipeline.Holder, sessions *session.Store, mtls *MTLSOpt
 		if err != nil {
 			return nil, fmt.Errorf("forwardproxy: build client tls config: %w", err)
 		}
-		transport.DialContext = mtlsDialer(tlsCfg, mtls.Strict, mtls.Metrics).DialContext
+		transport.DialContext = mtlsDialer(tlsCfg, mtls.Metrics).DialContext
 	}
 
 	return &Server{
@@ -91,21 +96,18 @@ func NewServer(outbound *pipeline.Holder, sessions *session.Store, mtls *MTLSOpt
 }
 
 // mtlsDialer returns a dialer-shaped object whose DialContext does
-// the try-TLS-fall-back-to-plain dance. We construct it once per
-// Server so the *tls.Config / metrics references are stable across
-// connections.
+// TLS-or-fail. We construct it once per Server so the *tls.Config /
+// metrics references are stable across connections.
 type mtlsDialFunc struct {
 	plain   *net.Dialer
 	tlsCfg  *cryptotls.Config
-	strict  bool
 	metrics *authtls.Metrics
 }
 
-func mtlsDialer(cfg *cryptotls.Config, strict bool, metrics *authtls.Metrics) *mtlsDialFunc {
+func mtlsDialer(cfg *cryptotls.Config, metrics *authtls.Metrics) *mtlsDialFunc {
 	return &mtlsDialFunc{
 		plain:   &net.Dialer{Timeout: 10 * time.Second},
 		tlsCfg:  cfg,
-		strict:  strict,
 		metrics: metrics,
 	}
 }
@@ -113,9 +115,8 @@ func mtlsDialer(cfg *cryptotls.Config, strict bool, metrics *authtls.Metrics) *m
 func (d *mtlsDialFunc) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	plain, err := d.plain.DialContext(ctx, network, addr)
 	if err != nil {
-		// TCP failure — never retry as TLS, and never count as a TLS
-		// fallback. Connection refused / DNS failure is a different
-		// kind of bug from "destination doesn't speak TLS."
+		// TCP failure — separate bug class from "peer doesn't speak TLS".
+		// Returned as-is so callers see the underlying dial error.
 		return nil, err
 	}
 
@@ -132,27 +133,10 @@ func (d *mtlsDialFunc) DialContext(ctx context.Context, network, addr string) (n
 	defer cancel()
 	if err := tlsConn.HandshakeContext(hsCtx); err != nil {
 		_ = tlsConn.Close()
-
-		// Strict mode: handshake failure is terminal. Don't fall back.
-		if d.strict {
-			if d.metrics != nil {
-				d.metrics.OutboundFailed.Add(1)
-			}
-			return nil, fmt.Errorf("forwardproxy mtls strict: handshake to %s failed: %w", addr, err)
-		}
-
-		// Permissive mode: redial plain TCP and return that. Surface
-		// the destination so operators can spot persistent fallbacks
-		// in their logs and either install authbridge on the target
-		// or accept the cost. The mode attribute makes the log easy
-		// to grep across mixed-mode rollouts where some sidecars are
-		// permissive and others are strict.
 		if d.metrics != nil {
-			d.metrics.OutboundFellBack.Add(1)
+			d.metrics.OutboundFailed.Add(1)
 		}
-		slog.Warn("mtls fallback to plaintext",
-			"mode", "permissive", "addr", addr, "reason", err.Error())
-		return d.plain.DialContext(ctx, network, addr)
+		return nil, fmt.Errorf("forwardproxy mtls: handshake to %s failed: %w", addr, err)
 	}
 
 	if d.metrics != nil {

--- a/authbridge/authlib/tls/metrics.go
+++ b/authbridge/authlib/tls/metrics.go
@@ -8,10 +8,11 @@ import (
 // endpoint on :9093. Atomic counters because the listener and the
 // dialer call into them concurrently.
 //
-// Critical for permissive rollouts: an operator promoting from
-// permissive to strict needs OutboundFellBack to reach zero (or only
-// count destinations they know are deliberately plaintext) before
-// flipping. Without these, the rollout is blind.
+// Outbound: only present when the workload is in strict mode (the
+// only mode the forward proxy attempts TLS-or-fail outbound).
+// Permissive mode dials plaintext directly — no TLS attempt, no
+// fallback, no counter — matching envoy-sidecar's permissive
+// semantics.
 type Metrics struct {
 	// Inbound: which path did each accepted connection take?
 	InboundTLSAccepted   atomic.Uint64 // TLS handshake succeeded + verified
@@ -19,10 +20,10 @@ type Metrics struct {
 	InboundPlainRejected atomic.Uint64 // Plain HTTP rejected (strict only)
 	InboundTLSFailed     atomic.Uint64 // TLS handshake / verification failed
 
-	// Outbound: which path did each outbound dial take?
+	// Outbound: only counted in strict mode (TLS-or-fail). Permissive
+	// is plaintext outbound and bypasses these.
 	OutboundTLSSucceeded atomic.Uint64 // TLS handshake succeeded + verified
-	OutboundFellBack     atomic.Uint64 // TLS failed, plain TCP used (permissive only)
-	OutboundFailed       atomic.Uint64 // TLS failed, no fallback (strict) — request errored
+	OutboundFailed       atomic.Uint64 // TLS handshake / verification failed
 }
 
 // Snapshot is a point-in-time copy of the metrics for serialization
@@ -35,7 +36,6 @@ type Snapshot struct {
 	InboundTLSFailed     uint64 `json:"inbound_tls_failed"`
 
 	OutboundTLSSucceeded uint64 `json:"outbound_tls_succeeded"`
-	OutboundFellBack     uint64 `json:"outbound_fell_back"`
 	OutboundFailed       uint64 `json:"outbound_failed"`
 }
 
@@ -49,7 +49,6 @@ func (m *Metrics) Snapshot() Snapshot {
 		InboundPlainRejected: m.InboundPlainRejected.Load(),
 		InboundTLSFailed:     m.InboundTLSFailed.Load(),
 		OutboundTLSSucceeded: m.OutboundTLSSucceeded.Load(),
-		OutboundFellBack:     m.OutboundFellBack.Load(),
 		OutboundFailed:       m.OutboundFailed.Load(),
 	}
 }

--- a/authbridge/cmd/authbridge-lite/main.go
+++ b/authbridge/cmd/authbridge-lite/main.go
@@ -212,8 +212,15 @@ func main() {
 		strict := cfg.MTLS.ResolvedMode() == config.MTLSModeStrict
 		src := provider.X509Source()
 		mtlsMetrics = authtls.NewMetrics()
+		// Inbound permissive peeks-and-routes; strict rejects non-TLS.
 		rpMTLS = &reverseproxy.MTLSOptions{Source: src, Strict: strict, Metrics: mtlsMetrics}
-		fpMTLS = &forwardproxy.MTLSOptions{Source: src, Strict: strict, Metrics: mtlsMetrics}
+		// Outbound: TLS-or-fail in strict only. Permissive is plaintext
+		// outbound — see authbridge-proxy/main.go for the architectural
+		// note on why proxy-sidecar's outbound semantics now match
+		// envoy-sidecar's (no per-connection try-TLS-with-fallback).
+		if strict {
+			fpMTLS = &forwardproxy.MTLSOptions{Source: src, Metrics: mtlsMetrics}
+		}
 		slog.Info("mTLS enabled", "mode", cfg.MTLS.ResolvedMode())
 	} else {
 		slog.Info("mTLS disabled (no mtls block in config)")

--- a/authbridge/cmd/authbridge-proxy/main.go
+++ b/authbridge/cmd/authbridge-proxy/main.go
@@ -221,8 +221,20 @@ func main() {
 		strict := cfg.MTLS.ResolvedMode() == config.MTLSModeStrict
 		src := provider.X509Source()
 		mtlsMetrics = authtls.NewMetrics()
+		// Inbound (reverse proxy): permissive peeks-and-routes, strict
+		// rejects non-TLS. Strict bool toggles between the two.
 		rpMTLS = &reverseproxy.MTLSOptions{Source: src, Strict: strict, Metrics: mtlsMetrics}
-		fpMTLS = &forwardproxy.MTLSOptions{Source: src, Strict: strict, Metrics: mtlsMetrics}
+		// Outbound (forward proxy): only attempt TLS in strict mode.
+		// Permissive is plaintext outbound — matches envoy-sidecar's
+		// permissive (Envoy has no native primitive for "try TLS, fall
+		// back on handshake failure", and Istio's PeerAuthentication
+		// permissive is inbound-only). A permissive caller can no
+		// longer reach a strict peer regardless of mode; mixed-mode
+		// deployments need both ends compatible. See authbridge/CLAUDE.md
+		// "Top-level mtls: configuration".
+		if strict {
+			fpMTLS = &forwardproxy.MTLSOptions{Source: src, Metrics: mtlsMetrics}
+		}
 		slog.Info("mTLS enabled", "mode", cfg.MTLS.ResolvedMode())
 	} else {
 		slog.Info("mTLS disabled (no mtls block in config)")

--- a/authbridge/demos/mtls/Makefile
+++ b/authbridge/demos/mtls/Makefile
@@ -14,8 +14,7 @@ help:
 deploy: ## Deploy caller + callee pods (both with mtls.mode: strict)
 	kubectl apply -f k8s/caller.yaml
 	kubectl apply -f k8s/callee.yaml
-	./scripts/patch-mtls-config.sh $(NAMESPACE) $(CALLER) strict
-	./scripts/patch-mtls-config.sh $(NAMESPACE) $(CALLEE) strict
+	./scripts/patch-mtls-config.sh $(NAMESPACE) strict
 	kubectl -n $(NAMESPACE) rollout restart deploy/$(CALLER) deploy/$(CALLEE)
 	kubectl -n $(NAMESPACE) rollout status deploy/$(CALLER) deploy/$(CALLEE) --timeout=120s
 
@@ -27,8 +26,7 @@ demo-mtls: deploy ## Deploy + run the encryption-on-the-wire check (strict mode)
 demo-mtls-permissive: ## Same shape but with mtls.mode: permissive; verify mixed-mode serving
 	kubectl apply -f k8s/caller.yaml
 	kubectl apply -f k8s/callee.yaml
-	./scripts/patch-mtls-config.sh $(NAMESPACE) $(CALLER) permissive
-	./scripts/patch-mtls-config.sh $(NAMESPACE) $(CALLEE) permissive
+	./scripts/patch-mtls-config.sh $(NAMESPACE) permissive
 	kubectl -n $(NAMESPACE) rollout restart deploy/$(CALLER) deploy/$(CALLEE)
 	kubectl -n $(NAMESPACE) rollout status deploy/$(CALLER) deploy/$(CALLEE) --timeout=120s
 	./scripts/verify-permissive.sh $(NAMESPACE) $(CALLEE)

--- a/authbridge/demos/mtls/README.md
+++ b/authbridge/demos/mtls/README.md
@@ -1,19 +1,18 @@
 # mTLS demo — agent-to-agent encryption via SPIRE X.509 SVIDs
 
-> **Status (2026-05-27).** The **envoy-sidecar variant**
-> (`make demo-mtls-envoy*`) is verified end-to-end on a kind +
-> kagenti + SPIRE cluster; see the
-> [envoy-sidecar variant](#envoy-sidecar-variant) section below.
-> The **proxy-sidecar variant** (`make demo-mtls`) currently fails
-> at the verification step: the kagenti-operator's controller
-> reconciles per-agent `authbridge-config-*` ConfigMaps and reverts
-> the `mtls:` block that `patch-mtls-config.sh` writes, before the
-> restarted pod can mount it. Both demos are blocked on the same
-> upstream operator bug — see [Operator bugs uncovered](#operator-bugs-uncovered).
-> The Pod manifests in `k8s/{caller,callee}.yaml` were also missing
-> the `kagenti.io/type: agent` label that the operator's
-> mutating-webhook objectSelector requires; both demos' manifests
-> have been updated to include it.
+> **Status.** Both variants are verified end-to-end on a kind +
+> kagenti + SPIRE cluster — `make demo-mtls` (proxy-sidecar) and
+> `make demo-mtls-envoy*` (envoy-sidecar; see the
+> [envoy-sidecar variant](#envoy-sidecar-variant) section below).
+> An earlier revision of this README flagged the proxy-sidecar demo
+> as broken because `patch-mtls-config.sh` was patching the per-agent
+> `authbridge-config-<name>` ConfigMap, which the operator's
+> pod-mutating webhook re-renders (and scrubs `mtls:` from) on each
+> pod admission. The script now patches the namespace's
+> `authbridge-runtime-config` ConfigMap instead, where the
+> operator's resolution chain reads `mtls.mode` and propagates it
+> into every per-agent CM at admission time — one patch, all
+> workloads in the namespace pick it up on next pod restart.
 
 Two pods that talk to each other through their authbridge sidecars,
 configured with `mtls.mode: strict`. Confirms end-to-end:
@@ -68,8 +67,11 @@ The `make demo-mtls` target does:
 
 1. Deploys caller + callee Pods to `team1` with operator-injected
    sidecars and SPIRE.
-2. Patches the operator-rendered `authbridge-config-{caller,callee}`
-   ConfigMaps to add `mtls: { mode: strict }`.
+2. Patches the namespace's `authbridge-runtime-config` ConfigMap to
+   add `mtls: { mode: strict }`. The operator's resolution chain
+   reads `mtls.mode` from this CM and bakes it into every per-agent
+   CM in the namespace at the next pod admission — one patch, all
+   workloads pick it up.
 3. Restarts the pods so the new config takes effect (mTLS config
    requires pod restart per the framework hot-reload boundary).
 4. Triggers a request from caller → callee through the kagenti UI
@@ -132,9 +134,9 @@ matches Istio's PERMISSIVE/STRICT inbound exactly).
 Outbound is **Istio-shaped**: there is no per-connection
 try-then-fallback (Envoy has no native primitive for it, and Istio
 itself doesn't do it — it relies on Pilot pre-deciding mesh
-membership). Blanket TLS in strict mode is practical for the same
-reason proxy-sidecar's strict mode is: outbound calls that need
-plaintext (Keycloak / JWKS / external HTTPS) never hit the listener:
+membership). Blanket TLS in strict mode is practical because outbound
+calls that need plaintext (Keycloak / JWKS / external HTTPS) never
+hit the listener:
 
 1. Plugin outbound (token-exchange, jwt-validation talking to
    Keycloak / JWKS) uses Go's `net/http` directly — bypasses Envoy.
@@ -143,23 +145,25 @@ plaintext (Keycloak / JWKS / external HTTPS) never hit the listener:
 3. HTTP from the app to peer agents — what gets TLS-wrapped. Peer's
    inbound listener terminates. Works.
 
-### Behavioral gap vs proxy-sidecar
+**Proxy-sidecar matches the same outbound semantics now**: its
+forward proxy dials plaintext in permissive mode and TLS-or-fail in
+strict, with no per-connection fallback. The two deployment shapes
+share one outbound model. See `authbridge/CLAUDE.md`'s
+"Top-level mtls: configuration" for the full table.
 
-In proxy-sidecar, a *permissive* caller can reach a *strict* peer
-because its outbound dialer tries TLS first per-connection and the
-handshake succeeds. In envoy-sidecar permissive, outbound is
-plaintext, so a permissive envoy-sidecar caller calling a strict
-peer **fails**. Mixed-mode deployments need both ends compatible
-(both strict, both permissive, or one strict + the other permissive
-on inbound only). The framework documentation in
-[`authbridge/CLAUDE.md`](../../CLAUDE.md#top-level-mtls-configuration)
-calls this out.
+### Mixed-mode caveat
+
+A *permissive* caller cannot reach a *strict* peer regardless of
+mode (its outbound is plaintext; the peer's strict inbound rejects
+it). Mixed-mode deployments need both ends compatible — both strict,
+both permissive, or one strict + the other permissive on inbound
+only.
 
 ### How the demo wires mTLS
 
 The demo is fully **hand-crafted** — no `kagenti.io/inject` label,
 no operator pod injection. This sidesteps both
-[operator bugs](#operator-bugs-uncovered): no RO `/opt` mount because
+[operator-side notes](#operator-side-notes): no RO `/opt` mount because
 we control the volumes, no per-agent CM reconciliation because there
 is no per-agent CM (the demo brings its own `envoy-config-mtls-active`
 and `authbridge-runtime-mtls` CMs that the operator doesn't touch).
@@ -195,85 +199,63 @@ and per-agent CM rendering; once it lands, the user sets
 and the operator wires up the same Envoy YAML this demo ships by
 hand.
 
-## Operator bugs uncovered
+## Operator-side notes
 
-Running both variants against a real cluster surfaced three
-kagenti-operator issues. Two of them block the demos today; the
-third is a Pod-spec selector mismatch this PR works around. The
-kagenti-operator follow-up PR is expected to fix #1 and #2; #3 is
-already fixed by the manifest updates in this PR.
+Running both variants against a real cluster surfaced two
+kagenti-operator items worth knowing about. Both are addressed in
+the kagenti-operator companion PR. A third issue (Pod-spec selector
+mismatch) was a demo-side oversight already fixed by the manifest
+updates that landed alongside the envoy-sidecar variant.
 
-### #1 — `/opt` mounted `readOnly:true` on envoy-sidecar's `envoy-proxy` container
+### `/opt` mount asymmetry on envoy-sidecar (operator bug, fixed in companion PR)
 
-Verified empirically:
-- proxy-sidecar `authbridge-proxy` container mounts `svid-output`
-  at `/opt` with `readOnly` defaulted (false → RW).
-- envoy-sidecar `envoy-proxy` container mounts the same volume at
-  `/opt` with `readOnly: true`.
-
+The kagenti-operator's pod mutator was mounting `svid-output` at
+`/opt` with `readOnly: true` on envoy-sidecar's `envoy-proxy`
+container while the proxy-sidecar branch correctly mounted it RW.
 The in-process spiffe Provider mirror writes `/opt/svid.pem`,
-`/opt/svid_key.pem`, `/opt/svid_bundle.pem` on every SPIRE rotation;
-under the RO mount the mirror logs:
+`/opt/svid_key.pem`, `/opt/svid_bundle.pem` there on every SPIRE
+rotation; under the RO mount the mirror failed:
 
 ```text
 spiffe.mirror: initial x509 write
   err="write svid.pem: atomicWrite: create temp in /opt: open /opt/.tmp-svid.pem.4183688747: read-only file system"
 ```
 
-Envoy then refuses to boot (`Invalid path: /opt/svid_bundle.pem`)
+Envoy then refused to boot with `Invalid path: /opt/svid_bundle.pem`
 because the file-based `DownstreamTlsContext` / `UpstreamTlsContext`
-references can't resolve. **Affects: envoy-sidecar mode only.** The
-fix is to flip the readOnly bit on the `svid-output` volumeMount in
-the envoy-sidecar branch of `BuildEnvoyProxyContainerWithSpireOption`
-in `kagenti-operator/internal/webhook/injector/container_builder.go`.
+references couldn't resolve. **Affects: envoy-sidecar mode only.**
+The fix landed in the companion PR — flips the readOnly bit on the
+`svid-output` volumeMount in `BuildEnvoyProxyContainerWithSpireOption`
+(`kagenti-operator/internal/webhook/injector/container_builder.go`).
 
-### #2 — Operator controller reconciles per-agent CM, erases user-added fields
+### Per-agent CMs are operator-owned (by-design; reflected in this PR's script)
 
-`patch-mtls-config.sh` writes `mtls: { mode: strict }` into the
-per-agent `authbridge-config-<name>` ConfigMap. Some operator-side
-component (admission webhook on pod creation, or a reconciler watching
-the CM) re-templates the CM back to its operator-rendered shape
-*before* the pod's kubelet-mounted view picks up the patch:
+The kagenti-operator's pod-mutating webhook builds each per-agent
+`authbridge-config-<name>` ConfigMap by reading the namespace
+`authbridge-runtime-config` as baseYAML and overlaying values
+resolved from the AgentRuntime CR (or defaults when no CR exists).
+The webhook's `ensurePerAgentConfigMap` actively scrubs the `mtls:`
+block when the CR's `Spec.MTLSMode` is unset — that scrub is
+intentional, ensuring the per-agent CM's contents track the
+authoritative source (the resolution chain) rather than picking up
+stale fields. Earlier revisions of this demo's `patch-mtls-config.sh`
+patched the per-agent CM directly, so the patch got reverted on the
+next pod admission. The current script patches the namespace
+`authbridge-runtime-config` CM, which is exactly where the operator's
+resolution chain reads it; one patch propagates to every per-agent
+CM in the namespace.
 
-```console
-$ kubectl -n team1 get cm authbridge-config-mtls-caller \
-    -o jsonpath='{.metadata.annotations.kubectl\.kubernetes\.io/last-applied-configuration}' \
-    | jq -r '.data."config.yaml"' | tail -3
-spiffe: {}
-mtls:
-  mode: strict                 ← what patch-mtls-config.sh wrote
+The longer-term path is to set `Spec.MTLSMode: strict` on an
+AgentRuntime CR — the operator's companion PR makes that work
+cleanly for envoy-sidecar too. The namespace-CM patch this demo uses
+is a lighter-weight knob that avoids requiring a CR for every demo
+pod.
 
-$ kubectl -n team1 get cm authbridge-config-mtls-caller \
-    -o jsonpath='{.data.config\.yaml}' | tail -3
-      name: token-exchange
-spiffe: {}                     ← what the operator left after reconcile
-                                  (NO mtls block)
-
-$ kubectl -n team1 logs deploy/mtls-caller -c authbridge-proxy | grep mtls
-"mTLS disabled (no mtls block in config)"
-```
-
-Same pattern applied to my `spiffe.mirror_dir: /shared` workaround
-during envoy-sidecar testing. **Affects: BOTH proxy-sidecar (`make
-demo-mtls`) and envoy-sidecar variants of this demo.** Either the
-reconciler should preserve user-added fields it doesn't manage, or
-the canonical surface should be `Spec.MTLSMode` on the AgentRuntime
-CR with the operator rendering the resulting `mtls:` block — i.e.,
-the operator follow-up PR's plan.
-
-### #3 — Pod selector mismatch (workaround in this PR)
+### Demo pod manifests need `kagenti.io/type: agent`
 
 The kagenti-operator's mutating-webhook `objectSelector` requires
-`kagenti.io/type` in `[agent, tool]`. The demos' Pod templates didn't
-set this label, so no operator injection happened (no authbridge
-sidecar, no per-agent CM created). Either the selector tightened
-recently or the demos haven't been re-run against a current operator.
-
-This PR adds `kagenti.io/type: agent` to all four demo Pod templates
-(`caller.yaml`, `callee.yaml`, `caller-envoy.yaml`, `callee-envoy.yaml`)
-and an explicit `runAsUser: 100` on the `demo-app` container to
-satisfy `runAsNonRoot: true` against the
-`curlimages/curl:latest` image (which now USERs as the non-numeric
-`curl_user`, tripping the kubelet's nonRoot check). With these in
-place the proxy-sidecar demo's Pods at least admit and roll out;
-verification still fails on issue #2 above.
+`kagenti.io/type` in `[agent, tool]`. The demo Pod templates now set
+this label and an explicit `runAsUser: 100` on the `demo-app`
+container (the `curlimages/curl:latest` image runs as the
+non-numeric `curl_user`, which trips the kubelet's `runAsNonRoot`
+check without an explicit numeric UID).

--- a/authbridge/demos/mtls/scripts/patch-mtls-config.sh
+++ b/authbridge/demos/mtls/scripts/patch-mtls-config.sh
@@ -1,45 +1,57 @@
 #!/bin/bash
-# Patch the operator-rendered authbridge config ConfigMap to add an
-# mtls block at the top level. Idempotent — re-running with the same
-# mode produces no change.
+# Patch the namespace's `authbridge-runtime-config` ConfigMap to add
+# an `mtls:` block at the top level. Idempotent — re-running with the
+# same mode produces no change.
 #
-# Usage: patch-mtls-config.sh <namespace> <agent-name> <mode>
+# Why the namespace CM and not the per-agent CM:
+#
+#   The kagenti-operator's pod-mutating webhook builds each per-agent
+#   `authbridge-config-<name>` CM by reading the namespace
+#   `authbridge-runtime-config` as baseYAML and overlaying values
+#   resolved from the AgentRuntime CR (or defaults when no CR exists).
+#   The webhook's `ensurePerAgentConfigMap` actively scrubs the
+#   `mtls:` block when `Spec.MTLSMode` is unset on the CR — that
+#   scrub is intentional, not a bug, and means a kubectl-patch on the
+#   per-agent CM gets reverted on the next pod admission.
+#
+#   Patching the namespace CM puts the `mtls:` value where the
+#   resolution chain reads it (via the operator's ExtractMTLSMode
+#   helper). The webhook then propagates it into every per-agent CM
+#   in that namespace at admission time. One patch, one CM, all
+#   workloads in the namespace pick it up on next pod restart.
+#
+# Usage: patch-mtls-config.sh <namespace> <mode>
 #   mode is "permissive" or "strict"
 
 set -euo pipefail
 
-NAMESPACE=${1:?usage: patch-mtls-config.sh <namespace> <agent-name> <mode>}
-AGENT=${2:?usage: patch-mtls-config.sh <namespace> <agent-name> <mode>}
-MODE=${3:?usage: patch-mtls-config.sh <namespace> <agent-name> <mode>}
+NAMESPACE=${1:?usage: patch-mtls-config.sh <namespace> <mode>}
+MODE=${2:?usage: patch-mtls-config.sh <namespace> <mode>}
 
 case "$MODE" in
   permissive|strict) ;;
   *) echo "ERROR: mode must be permissive or strict, got: $MODE" >&2; exit 1 ;;
 esac
 
-CM="authbridge-config-${AGENT}"
+CM="authbridge-runtime-config"
 HERE=$(dirname "$0")
 
 echo "[*] Patching $CM in $NAMESPACE with mtls.mode=$MODE"
 
-# Pull the current rendered config, merge in the mtls block, write
-# back. We stream the YAML through the python merger rather than try
-# to do it in shell because the operator's config has nested
-# pipeline / listener blocks that we shouldn't touch.
 ORIG=$(kubectl -n "$NAMESPACE" get cm "$CM" -o jsonpath='{.data.config\.yaml}')
 if [[ -z "$ORIG" ]]; then
-  echo "ERROR: ConfigMap $CM has no config.yaml entry. Operator hasn't rendered it yet?" >&2
+  echo "ERROR: ConfigMap $CM has no config.yaml entry — is the kagenti chart installed in this namespace?" >&2
   exit 1
 fi
 
 MERGED=$(echo "$ORIG" | python3 "$HERE/mtls-merge.py" "$MODE")
 
-# kubectl apply with a fresh ConfigMap manifest (preserves labels /
-# ownership; --dry-run=client + apply is the standard idempotent
-# pattern).
+# kubectl apply with a fresh ConfigMap manifest preserves the
+# operator's ownership labels; the dry-run-then-apply pattern keeps
+# this idempotent.
 kubectl -n "$NAMESPACE" create configmap "$CM" \
   --from-literal=config.yaml="$MERGED" \
   --dry-run=client -o yaml | \
   kubectl -n "$NAMESPACE" apply -f - >/dev/null
 
-echo "[*] Patched."
+echo "[*] Patched. Restart any agent pods in $NAMESPACE to pick up the new mtls posture."

--- a/authbridge/demos/mtls/scripts/verify-encrypted.sh
+++ b/authbridge/demos/mtls/scripts/verify-encrypted.sh
@@ -43,15 +43,13 @@ out=$(kubectl -n "$NAMESPACE" exec deploy/"$CALLER" -c demo-app -- \
 echo "  Response: $out"
 
 echo
-echo "[*] Confirming the wire was encrypted (via outbound forward-proxy logs)"
-if kubectl -n "$NAMESPACE" logs deploy/"$CALLER" -c authbridge-proxy --tail=100 2>/dev/null | \
-   grep -q "mtls fallback to plaintext.*${CALLEE}"; then
-  echo "  ERROR: caller's forward proxy fell back to plaintext for ${CALLEE}." >&2
-  echo "         This means strict mode is NOT actually encrypting the wire." >&2
-  exit 1
-fi
-echo "  No fallback-to-plaintext WARN observed; wire is encrypted."
-
+# No fallback-to-plaintext check anymore. Permissive outbound is now
+# plaintext (matches envoy-sidecar; aligns with Istio's
+# PeerAuthentication semantics) and strict outbound is TLS-or-fail —
+# either way there's no per-connection fallback to grep for. The
+# strict-callee + successful-response combination above is enough
+# evidence that the wire is encrypted: a plaintext outbound from a
+# strict caller would error before reaching the listener.
 echo
 echo "============================================="
 echo " mTLS verified — caller → callee is encrypted"

--- a/authbridge/demos/mtls/scripts/verify-permissive.sh
+++ b/authbridge/demos/mtls/scripts/verify-permissive.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 # Verify that a permissive callee serves both TLS and plaintext on
-# the same port. We hit it with plain HTTP from a curl pod (no
-# authbridge sidecar, no SPIRE) and assert the request succeeds.
+# the same port. Two-pronged check:
+#
+#   1. callee's authbridge log says `mTLS enabled mode=permissive` —
+#      distinguishes "permissive correctly applied" from "mTLS off
+#      entirely" (a disabled callee would also serve the plaintext
+#      request below, so the plaintext-served check alone isn't
+#      enough evidence the permissive mode is on).
+#   2. plain HTTP from a non-mesh client (no authbridge sidecar, no
+#      SPIRE) reaches the demo-app — proves the raw_buffer / byte-peek
+#      path is open in addition to the TLS chain.
 #
 # Usage: verify-permissive.sh <namespace> <callee>
 
@@ -10,6 +18,23 @@ set -euo pipefail
 NAMESPACE=${1:?usage: verify-permissive.sh <namespace> <callee>}
 CALLEE=${2:?}
 
+echo "[*] Confirming $CALLEE has mTLS enabled in permissive mode"
+log_line=$(kubectl -n "$NAMESPACE" logs deploy/"$CALLEE" -c authbridge-proxy --tail=200 2>/dev/null \
+             | grep '"mTLS enabled"' | head -1 || true)
+if [[ -z "$log_line" ]]; then
+  echo "  ERROR: $CALLEE does not show 'mTLS enabled' in its authbridge logs." >&2
+  echo "         The callee is running with mTLS off, so the plaintext-served" >&2
+  echo "         test below would pass even without permissive being applied." >&2
+  exit 1
+fi
+mode=$(echo "$log_line" | sed -n 's/.*mode=\([a-z]*\).*/\1/p')
+if [[ "$mode" != "permissive" ]]; then
+  printf "  ERROR: %s mTLS mode is %q, want permissive.\n" "$CALLEE" "$mode" >&2
+  exit 1
+fi
+echo "  $CALLEE: mTLS enabled, mode=permissive"
+
+echo
 echo "[*] Hitting $CALLEE with plain HTTP from a non-mesh client"
 out=$(kubectl -n "$NAMESPACE" run --rm -i --restart=Never \
         --image=curlimages/curl:latest \
@@ -23,5 +48,6 @@ out=$(kubectl -n "$NAMESPACE" run --rm -i --restart=Never \
 echo "  Response: $out"
 echo
 echo "============================================================"
-echo " Permissive verified — plaintext callers served on same port"
+echo " Permissive verified — mTLS on (mode=permissive), plaintext"
+echo " callers served on the same port"
 echo "============================================================"


### PR DESCRIPTION
## Summary

Two changes for the proxy-sidecar mTLS demo, scoped together because they each unblock a different part of the same flow.

1. **`patch-mtls-config.sh` now patches the namespace `authbridge-runtime-config` CM** (not the per-agent CM the operator owns). Fixes `make demo-mtls`.
2. **Proxy-sidecar permissive outbound is now plaintext, matching envoy-sidecar.** Drops the per-connection try-TLS-with-fallback dialer.

## 1. Namespace CM, not per-agent

The kagenti-operator's pod-mutating webhook owns per-agent `authbridge-config-<name>` ConfigMaps: `ensurePerAgentConfigMap` re-renders them on every pod admission and intentionally scrubs `mtls:` when neither `Spec.MTLSMode` nor the namespace `authbridge-runtime-config` carries it. The earlier flow's patch reverted before the restarted pod could mount it, and authbridge booted with `"mTLS disabled (no mtls block in config)"`.

This PR patches the namespace `authbridge-runtime-config` CM — the layer the operator's resolution chain reads via `ExtractMTLSMode`. The webhook then propagates `mtls.mode` into every per-agent CM at admission time. One patch, all workloads in the namespace pick it up on next pod restart.

`patch-mtls-config.sh` signature drops the `<agent-name>` arg. Makefile's `deploy` + `demo-mtls-permissive` targets call the script once per mode change instead of once per agent.

## 2. Permissive outbound is plaintext for both modes

Previously, proxy-sidecar's permissive outbound attempted TLS first per-connection and fell back to plaintext on handshake failure. Envoy can't do this within an `ORIGINAL_DST` cluster (no native primitive for "try TLS, fall back on handshake failure"), and Istio doesn't either — Pilot pre-decides mesh membership instead. To keep proxy-sidecar's outbound semantics consistent with envoy-sidecar's and aligned with Istio's PeerAuthentication semantics (permissive is inbound-only), drop the per-connection fallback.

| `mtlsMode` | Inbound (both modes) | Outbound (both modes after this PR) |
| --- | --- | --- |
| `disabled` | plaintext | plaintext |
| `permissive` | byte-peek / `tls_inspector` — TLS terminates, plaintext served | **plaintext, no TLS-wrap attempt** |
| `strict` | TLS-only — plaintext rejected | TLS-or-fail, no fallback |

**Behavioral note (now applies to both modes):** a permissive caller cannot reach a strict peer regardless of `authBridgeMode`. Mixed-mode deployments need both ends compatible.

### Code changes

- `authlib/listener/forwardproxy/server.go` — drop the fallback branch in `mtlsDialer`. `MTLSOptions` now implies TLS-or-fail; the `Strict` field is removed since it was always true in the new world.
- `authlib/tls/metrics.go` — drop `OutboundFellBack` (no fallback to count).
- `cmd/authbridge-{proxy,lite}/main.go` — only construct `forwardproxy.MTLSOptions` in strict mode. Permissive leaves it nil so the transport stays plaintext.

### Doc + script updates

- `authbridge/CLAUDE.md` — "Top-level mtls:" table flipped to show plaintext outbound for permissive in both modes; envoy-sidecar subsection no longer claims an asymmetry.
- `demos/mtls/README.md` — updated to match.
- `demos/mtls/scripts/verify-encrypted.sh` — drops the "no fallback-to-plaintext WARN" check since fallback no longer exists.
- `demos/mtls/scripts/verify-permissive.sh` — adds a positive `mTLS enabled mode=permissive` log assertion. Without it, the plaintext-outbound test would also pass against a callee with mTLS off entirely; the new check distinguishes "permissive correctly applied" from "mTLS disabled".

### Compatibility notes (awareness-only)

- **`authlib/tls/metrics.Snapshot`** drops the `outbound_fell_back` JSON field. The `/stats` endpoint is the only consumer; verified via `gh search code` that no external scrapers reference it. No-op in practice.
- **`authlib/listener/forwardproxy.MTLSOptions`** drops the `Strict` field. The struct is exported but only consumed by `cmd/authbridge-proxy` and `cmd/authbridge-lite` in this module; if the library ever gets external consumers, this kind of struct-field removal would become a SemVer break. Internal-only today.

## Test plan

Verified end-to-end on a kind + kagenti + SPIRE cluster (proxy-sidecar variant):

- [x] `bash -n` on the script
- [x] `go build ./...` clean across all four cmds
- [x] `go test -race -count=1 ./authlib/...` passes
- [x] `make demo-mtls` (strict) — both pods log `mTLS enabled mode=strict`; reverse-proxy on `:8000` with `mtls=true`; `verify-encrypted.sh` passes.
- [x] `make demo-mtls-strict-rejects-plain` — plain HTTP from a non-mesh client gets the connection closed.
- [x] `make demo-mtls-permissive` — caller logs `mTLS enabled mode=permissive`, forward-proxy on `:8081` with **no `mtls=` annotation** (plaintext transport, confirming the change took effect); `verify-permissive.sh` serves plain HTTP.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * mTLS demo verified end-to-end for both proxy-sidecar and envoy-sidecar
  * Fixed envoy-sidecar pod boot failures related to SVID mount handling
  * Outbound tightened: when mTLS is active, connections require TLS (no per-connection plaintext fallback)

* **Documentation**
  * Updated mTLS demo verification, operator notes, envoy/proxy outbound semantics, and pod manifest requirements

* **Chores**
  * Simplified mTLS patching to a single namespace-level runtime config; updated CLI and verification flow

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kagenti/kagenti-extensions/pull/441?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->