### PR TITLE
fix(ibac): Guard nil Session and bypass MCP housekeeping

### DIFF
--- a/authbridge/authlib/plugins/ibac/plugin.go
+++ b/authbridge/authlib/plugins/ibac/plugin.go
@@ -12,8 +12,10 @@
 //
 // Per-request only — no cross-request session-scoped state. Requires
 // an a2a-parser in the inbound chain (runtime dependency, fail-closed
-// when LastIntent is nil) and works alongside an optional mcp-parser
-// (After ordering hint) for richer action descriptions.
+// when LastIntent is nil or no session has been seeded yet) and works
+// alongside an optional mcp-parser (After ordering hint) for richer
+// action descriptions and to bypass MCP protocol housekeeping
+// (initialize, *list, notifications/*) that carries no intent.
 package ibac
 
 import (
@@ -245,10 +247,40 @@ func (p *IBAC) OnRequest(ctx context.Context, pctx *pipeline.Context) pipeline.A
 		return pipeline.Action{Type: pipeline.Continue}
 	}
 
-	// 5. Pull the user's most recent declared intent. nil here means
-	//    either a2a-parser isn't in the inbound chain, or no user
-	//    message has been received yet — both are operator-error /
-	//    suspicious states. Fail closed.
+	// 5. MCP protocol-housekeeping skip. initialize / notifications /
+	//    *list methods are connection setup and capability discovery —
+	//    they happen before any user request (e.g. agent startup) and
+	//    carry no actionable intent. Same shape as inference_bypass:
+	//    judging them would be a category error, and denying them
+	//    breaks every agent that opens an MCP connection at startup.
+	//    Only methods that invoke side effects (tools/call, prompts/get,
+	//    resources/read) reach the judge.
+	if pctx.Extensions.MCP != nil && isMCPHousekeeping(pctx.Extensions.MCP.Method) {
+		pctx.Skip("mcp_housekeeping")
+		return pipeline.Action{Type: pipeline.Continue}
+	}
+
+	// 6. Pull the user's most recent declared intent. Two distinct
+	//    nil pathways, both fail closed but with different reasons so
+	//    operator dashboards can tell them apart:
+	//      - no_session: no inbound A2A request has populated the
+	//        active session bucket yet (or session tracking is off
+	//        entirely). Common at agent startup before any user turn.
+	//      - no_intent: a session exists but contains no extractable
+	//        user message (a2a-parser missing from inbound chain, or
+	//        events present but none are user-role A2A requests).
+	if pctx.Session == nil {
+		action := describeAction(pctx, p.cfg.JudgeInference)
+		pctx.Record(pipeline.Invocation{
+			Action: pipeline.ActionDeny,
+			Phase:  pipeline.InvocationPhaseRequest,
+			Reason: "no_session",
+			Details: map[string]string{
+				"action": action,
+			},
+		})
+		return pipeline.DenyStatus(403, "ibac.no_session", "no active session for outbound request")
+	}
 	intent := pctx.Session.LastIntent()
 	intentText := extractIntentText(intent)
 	if intentText == "" {
@@ -430,6 +462,32 @@ func formatBodyExcerpt(body []byte, n int) string {
 		}
 	}
 	return fmt.Sprintf("%q", string(body))
+}
+
+// isMCPHousekeeping reports whether an MCP method is connection-setup
+// or capability-discovery traffic that carries no user-actionable
+// intent. These methods fire before any user turn (e.g. an agent's
+// startup `initialize` against its MCP tool server) and judging them
+// would either panic on a nil session or deny on no_intent — both
+// break agents that open MCP connections at startup. Only side-effect
+// methods (tools/call, prompts/get, resources/read) reach the judge.
+//
+// JSON-RPC notifications (any method starting with `notifications/`)
+// are also bypassed: they're one-way protocol signals, never tied to
+// a specific user turn.
+func isMCPHousekeeping(method string) bool {
+	switch method {
+	case "initialize",
+		"ping",
+		"tools/list",
+		"prompts/list",
+		"resources/list",
+		"resources/templates/list",
+		"completion/complete",
+		"logging/setLevel":
+		return true
+	}
+	return strings.HasPrefix(method, "notifications/")
 }
 
 // extractMCPToolName pulls the tool name from a tools/call request's

--- a/authbridge/authlib/plugins/ibac/plugin_test.go
+++ b/authbridge/authlib/plugins/ibac/plugin_test.go
@@ -286,6 +286,93 @@ func TestOnRequest_NoIntent_FailsClosed(t *testing.T) {
 	}
 }
 
+// Nil Session must not panic. The forward-proxy listener leaves
+// pctx.Session nil whenever no inbound A2A request has seeded the
+// active session bucket yet — common at agent startup. Treat it as
+// a distinct fail-closed reason (no_session) so dashboards can tell
+// "no inbound has happened yet" apart from "session exists but
+// contains no intent" (no_intent).
+func TestOnRequest_NilSession_FailsClosed(t *testing.T) {
+	fj := &fakeJudge{}
+	p := newConfiguredIBAC(t, fj)
+
+	pctx := makePCtx(t)
+	pctx.Session = nil // before any inbound A2A
+	action := invokeOnRequest(p, pctx)
+
+	if action.Type != pipeline.Reject {
+		t.Errorf("got %v, want Reject when Session is nil", action.Type)
+	}
+	if fj.calls != 0 {
+		t.Errorf("judge should not be called when there's no session")
+	}
+	inv := lastInvocation(t, pctx)
+	if inv.Reason != "no_session" {
+		t.Errorf("Invocation reason = %q, want 'no_session'", inv.Reason)
+	}
+}
+
+// MCP protocol-housekeeping methods carry no user-actionable intent
+// (they're connection setup or capability discovery, not side
+// effects). IBAC must skip them; otherwise every agent that opens an
+// MCP connection at startup gets blocked before any user turn.
+func TestOnRequest_MCPHousekeepingBypass(t *testing.T) {
+	cases := []string{
+		"initialize",
+		"ping",
+		"tools/list",
+		"prompts/list",
+		"resources/list",
+		"resources/templates/list",
+		"completion/complete",
+		"logging/setLevel",
+		"notifications/initialized",
+		"notifications/cancelled",
+	}
+	for _, method := range cases {
+		t.Run(method, func(t *testing.T) {
+			fj := &fakeJudge{}
+			p := newConfiguredIBAC(t, fj)
+
+			pctx := makePCtx(t)
+			pctx.Session = nil // housekeeping must bypass before the session check
+			pctx.Method = "POST"
+			pctx.Host = "some-mcp-server"
+			pctx.Path = "/mcp"
+			pctx.Extensions.MCP = &pipeline.MCPExtension{Method: method}
+			action := invokeOnRequest(p, pctx)
+
+			if action.Type != pipeline.Continue {
+				t.Errorf("got %v, want Continue for housekeeping method %q", action.Type, method)
+			}
+			if fj.calls != 0 {
+				t.Errorf("judge should not be called for housekeeping method %q", method)
+			}
+		})
+	}
+}
+
+// MCP tools/call must NOT be treated as housekeeping — it's the
+// canonical side-effect method IBAC exists to judge.
+func TestOnRequest_MCPToolsCallIsNotHousekeeping(t *testing.T) {
+	fj := &fakeJudge{verdict: "allow"}
+	p := newConfiguredIBAC(t, fj)
+
+	pctx := makePCtx(t)
+	pctx.Method = "POST"
+	pctx.Host = "user-tool"
+	pctx.Path = "/mcp"
+	pctx.Extensions.MCP = &pipeline.MCPExtension{
+		Method: "tools/call",
+		Params: map[string]any{"name": "delete_user"},
+	}
+	_ = invokeOnRequest(p, pctx)
+
+	if fj.calls != 1 {
+		t.Errorf("judge calls = %d, want 1 (tools/call must be judged)", fj.calls)
+	}
+}
+
 // Email-poison parity: this is the canonical case the plugin exists
 // for. Raw HTTP exfiltration to an unknown server, no MCP/Inference
 // extensions, judge denies → 403. This test is the contract that


### PR DESCRIPTION
## Summary

Fixes #442. Two related bugs in `authlib/plugins/ibac` that combine to
break any agent whose first action is an outbound MCP call (e.g. an
`initialize` against its tool server at startup):

1. **Nil-pointer panic.** `IBAC.OnRequest` dereferenced `pctx.Session`
   at `plugin.go:252` without a nil check. The forward-proxy listener
   leaves `Session` nil whenever no inbound A2A request has seeded the
   active session bucket yet (`forwardproxy/server.go:205-209`) — the
   normal state at agent startup.

2. **No concept of MCP protocol housekeeping.** Even with the nil
   guard, MCP `initialize` / `tools/list` / `notifications/*` would be
   denied as `no_intent`, which is a category error: these methods are
   connection setup and capability discovery, not user-actionable side
   effects.

## Changes

### Bug 1 — nil-Session guard

Before `LastIntent()`, check `Session != nil` explicitly and fail
closed with a distinct `no_session` reason. Kept separate from
`no_intent` so operator dashboards can tell "no inbound has happened
yet" apart from "session exists but contains no user intent". Both
still 403 — neither state is safe to allow.

### Bug 2 — MCP housekeeping bypass (option a from #442)

New step #5 in `OnRequest`, mirroring the existing `inference_bypass`
shape: when `mcp-parser` populated `pctx.Extensions.MCP` and the
method is in the housekeeping set, emit `pctx.Skip("mcp_housekeeping")`
and continue. Bypassed methods:

- Connection setup: `initialize`, `ping`
- Capability discovery: `tools/list`, `prompts/list`, `resources/list`, `resources/templates/list`
- Housekeeping: `completion/complete`, `logging/setLevel`
- Any `notifications/*` (one-way protocol signals)

Side-effect methods (`tools/call`, `prompts/get`, `resources/read`)
are unchanged — they still reach the judge.

## Test plan

- [x] `go test ./plugins/ibac/...` passes (17 tests, 10 sub-tests)
- [x] Full authlib suite passes (`go test ./...`, 29 packages)
- [x] `gofmt` and `go vet` clean
- [x] New tests:
  - `TestOnRequest_NilSession_FailsClosed` — covers bug 1
  - `TestOnRequest_MCPHousekeepingBypass` — table-driven over all 10 bypassed methods, with `Session=nil` to prove housekeeping bypasses *before* the session check
  - `TestOnRequest_MCPToolsCallIsNotHousekeeping` — guard against accidentally letting `tools/call` slip through

## Reproducer (no longer panics)

Pipeline:

```yaml
inbound:  [a2a-parser, jwt-validation]
outbound: [token-exchange, inference-parser, mcp-parser, ibac]
```

Agent does an MCP `initialize` to its tool server at startup. With
this PR, IBAC bypasses cleanly (`mcp_housekeeping`); the agent's MCP
transport opens and subsequent `tools/call`s still get judged once an
inbound A2A request seeds the session.

Closes #442

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Optimized authorization checks for Model Context Protocol (MCP) setup and housekeeping operations, improving initialization speed.

* **Bug Fixes**
  * Improved error handling and distinction between authorization failures caused by missing session information versus missing user intent, with clearer logging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kagenti/kagenti-extensions/pull/443?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->