### PR TITLE
feat(abctl): Picker polish and post-#445 cleanup

### DIFF
--- a/authbridge/cmd/abctl/README.md
+++ b/authbridge/cmd/abctl/README.md
@@ -80,6 +80,7 @@ The UI has three panes. `Enter` drills in; `Esc` backs out.
 | `Enter` | namespaces | open the namespace |
 | `Enter` | pods | port-forward + connect |
 | `Esc` | pods | back to namespaces |
+| `r` | namespaces, pods | reload agent list from cluster |
 | `Enter` / `→` / `l` | sessions, events | drill into selection |
 | `Esc` / `←` / `h` | detail, events | back out |
 | `Esc` | sessions, pipeline | (picker mode) tear down port-forward and back to pods |

--- a/authbridge/cmd/abctl/README.md
+++ b/authbridge/cmd/abctl/README.md
@@ -110,7 +110,6 @@ results; treat the output accordingly.
 ## Deferred to later PRs
 
 - Native clipboard (currently writes to `/tmp`).
-- In-process `kubectl port-forward` (currently manual).
 - Fuzzy search beyond substring match.
 - Per-user filtering (`Identity.Subject == X`).
 - Krew plugin packaging.

--- a/authbridge/cmd/abctl/cluster/cluster.go
+++ b/authbridge/cmd/abctl/cluster/cluster.go
@@ -10,7 +10,6 @@ import (
 	"os/exec"
 	"sort"
 	"strings"
-	"time"
 )
 
 // sidecarContainerNames is the set of container names that mark a pod as
@@ -27,8 +26,7 @@ type Pod struct {
 	Namespace string
 	Name      string
 	Phase     string
-	Ready     bool      // true when every container in containerStatuses is ready
-	StartedAt time.Time // status.startTime; zero if absent
+	Ready     bool // true when every container in containerStatuses is ready
 }
 
 // AgentNamespace is a namespace plus the AuthBridge-bearing pods inside it.
@@ -51,8 +49,7 @@ type kubectlPodList struct {
 			} `json:"containers"`
 		} `json:"spec"`
 		Status struct {
-			Phase             string    `json:"phase"`
-			StartTime         time.Time `json:"startTime"`
+			Phase             string `json:"phase"`
 			ContainerStatuses []struct {
 				Ready bool `json:"ready"`
 			} `json:"containerStatuses"`
@@ -91,7 +88,6 @@ func parseAgentPods(raw []byte) ([]AgentNamespace, error) {
 			Name:      item.Metadata.Name,
 			Phase:     item.Status.Phase,
 			Ready:     ready,
-			StartedAt: item.Status.StartTime,
 		})
 	}
 	out := make([]AgentNamespace, 0, len(byNs))

--- a/authbridge/cmd/abctl/tui/app.go
+++ b/authbridge/cmd/abctl/tui/app.go
@@ -183,6 +183,11 @@ type model struct {
 
 	pickerErr string // single-line picker error shown in footer
 
+	// loading is true while a loadAgentsCmd is in flight. Prevents
+	// concurrent `r` keypresses (or `r` during initial load) from
+	// dispatching parallel ListAgents calls.
+	loading bool
+
 	// activePF is the live port-forward tunnel, if any. Closed on pod-switch
 	// or quit.
 	activePF cluster.PortForward
@@ -273,6 +278,7 @@ func (m *model) backToPodsPane() {
 func (m *model) Init() tea.Cmd {
 	if m.pane == paneNamespaces {
 		// Picker mode — load agents, then idle until user picks a pod.
+		m.loading = true
 		return loadAgentsCmd(m.ctx, m.lister)
 	}
 	return m.initSessionView()
@@ -453,6 +459,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case agentsLoadedMsg:
+		m.loading = false
 		if msg.err != nil {
 			m.pickerErr = msg.err.Error()
 			return m, nil
@@ -460,9 +467,24 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.namespaces = msg.namespaces
 		m.rebuildNamespacesTable()
 		// If the user is on the Pods pane (e.g., reloaded via `r`), refresh
-		// the pods table from the new data so it reflects the cluster state.
+		// the pods table from the new data. If the previously-selected
+		// namespace no longer exists, gracefully back out to the
+		// Namespaces pane so the user isn't stranded looking at an
+		// empty Pods table for a vanished namespace.
 		if m.pane == panePods {
-			m.rebuildPodsTable()
+			found := false
+			for _, ns := range m.namespaces {
+				if ns.Name == m.selectedNamespace {
+					found = true
+					break
+				}
+			}
+			if !found {
+				m.selectedNamespace = ""
+				m.pane = paneNamespaces
+			} else {
+				m.rebuildPodsTable()
+			}
 		}
 		return m, nil
 
@@ -556,12 +578,11 @@ func (m *model) View() string {
 		// m.namespaces == nil → still loading (don't flash the empty-state
 		// hint mid-load); non-nil empty slice → loaded, no agents found.
 		var body string
-		switch {
-		case m.namespaces != nil && len(m.namespaces) == 0 && m.pickerErr == "":
+		if m.namespaces != nil && len(m.namespaces) == 0 && m.pickerErr == "" {
 			body = styleHint.Render(
 				"No AuthBridge agents found in this cluster.\n" +
 					"Use `abctl --endpoint http://...` to connect to a session API directly.")
-		default:
+		} else {
 			body = m.namespacesTbl.View()
 		}
 		footer := "[↑↓/jk] nav  [↵] open  [r] reload  [q] quit"

--- a/authbridge/cmd/abctl/tui/app.go
+++ b/authbridge/cmd/abctl/tui/app.go
@@ -459,6 +459,11 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.namespaces = msg.namespaces
 		m.rebuildNamespacesTable()
+		// If the user is on the Pods pane (e.g., reloaded via `r`), refresh
+		// the pods table from the new data so it reflects the cluster state.
+		if m.pane == panePods {
+			m.rebuildPodsTable()
+		}
 		return m, nil
 
 	case portForwardReadyMsg:
@@ -559,7 +564,7 @@ func (m *model) View() string {
 		default:
 			body = m.namespacesTbl.View()
 		}
-		footer := "[↑↓/jk] nav  [↵] open  [q] quit"
+		footer := "[↑↓/jk] nav  [↵] open  [r] reload  [q] quit"
 		if m.pickerErr != "" {
 			footer = "error: " + m.pickerErr + "    " + footer
 		}
@@ -572,7 +577,7 @@ func (m *model) View() string {
 	if m.pane == panePods {
 		title := "abctl · " + m.selectedNamespace + " · pick pod"
 		body := m.podsTbl.View()
-		footer := "[↑↓/jk] nav  [↵] connect  [Esc] back  [q] quit"
+		footer := "[↑↓/jk] nav  [↵] connect  [Esc] back  [r] reload  [q] quit"
 		if m.pickerErr != "" {
 			footer = "error: " + m.pickerErr + "    " + footer
 		}

--- a/authbridge/cmd/abctl/tui/app.go
+++ b/authbridge/cmd/abctl/tui/app.go
@@ -548,7 +548,17 @@ sortAndRebuild:
 func (m *model) View() string {
 	if m.pane == paneNamespaces {
 		title := "abctl · pick namespace"
-		body := m.namespacesTbl.View()
+		// m.namespaces == nil → still loading (don't flash the empty-state
+		// hint mid-load); non-nil empty slice → loaded, no agents found.
+		var body string
+		switch {
+		case m.namespaces != nil && len(m.namespaces) == 0 && m.pickerErr == "":
+			body = styleHint.Render(
+				"No AuthBridge agents found in this cluster.\n" +
+					"Use `abctl --endpoint http://...` to connect to a session API directly.")
+		default:
+			body = m.namespacesTbl.View()
+		}
 		footer := "[↑↓/jk] nav  [↵] open  [q] quit"
 		if m.pickerErr != "" {
 			footer = "error: " + m.pickerErr + "    " + footer

--- a/authbridge/cmd/abctl/tui/app.go
+++ b/authbridge/cmd/abctl/tui/app.go
@@ -728,7 +728,7 @@ func Run(ctx context.Context, opts RunOptions) error {
 			_ = m.activePF.Close()
 		}
 	}()
-	p := tea.NewProgram(m, tea.WithAltScreen())
+	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithContext(ctx))
 	_, err := p.Run()
 	return err
 }

--- a/authbridge/cmd/abctl/tui/keys.go
+++ b/authbridge/cmd/abctl/tui/keys.go
@@ -21,7 +21,11 @@ func (m *model) handleKey(msg tea.KeyMsg) tea.Cmd {
 			}
 			return nil
 		case "r":
+			if m.loading {
+				return nil
+			}
 			m.pickerErr = ""
+			m.loading = true
 			return loadAgentsCmd(m.ctx, m.lister)
 		case "q", "esc", "ctrl+c":
 			m.cancel()
@@ -52,7 +56,11 @@ func (m *model) handleKey(msg tea.KeyMsg) tea.Cmd {
 			}
 			return nil
 		case "r":
+			if m.loading {
+				return nil
+			}
 			m.pickerErr = ""
+			m.loading = true
 			return loadAgentsCmd(m.ctx, m.lister)
 		case "esc":
 			m.pane = paneNamespaces

--- a/authbridge/cmd/abctl/tui/keys.go
+++ b/authbridge/cmd/abctl/tui/keys.go
@@ -20,6 +20,9 @@ func (m *model) handleKey(msg tea.KeyMsg) tea.Cmd {
 				m.rebuildPodsTable()
 			}
 			return nil
+		case "r":
+			m.pickerErr = ""
+			return loadAgentsCmd(m.ctx, m.lister)
 		case "q", "esc", "ctrl+c":
 			m.cancel()
 			return tea.Quit
@@ -48,6 +51,9 @@ func (m *model) handleKey(msg tea.KeyMsg) tea.Cmd {
 				return startPortForwardCmd(m.ctx, m.portForwarder, m.selectedNamespace, m.selectedPod)
 			}
 			return nil
+		case "r":
+			m.pickerErr = ""
+			return loadAgentsCmd(m.ctx, m.lister)
 		case "esc":
 			m.pane = paneNamespaces
 			m.pickerErr = ""
@@ -284,9 +290,9 @@ func (m *model) helpView() string {
 	}
 	switch m.pane {
 	case paneNamespaces:
-		return "[↑↓/jk] nav  [↵] open  [q] quit"
+		return "[↑↓/jk] nav  [↵] open  [r] reload  [q] quit"
 	case panePods:
-		return "[↑↓/jk] nav  [↵] connect  [Esc] back  [q] quit"
+		return "[↑↓/jk] nav  [↵] connect  [Esc] back  [r] reload  [q] quit"
 	case paneSessions:
 		if m.parentCtx != nil {
 			return "[↑↓] nav  [↵] drill  [tab] pipeline  [/] filter  [esc] pods  [p] pause  [q] quit"

--- a/authbridge/cmd/abctl/tui/picker_test.go
+++ b/authbridge/cmd/abctl/tui/picker_test.go
@@ -134,13 +134,17 @@ func TestRefreshKeybindReloadsAgents(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("`r` on paneNamespaces should produce a Cmd to reload")
 	}
-	_ = cmd() // dispatch the load
+	loaded := cmd() // dispatch the load
 	if lister.calls != 2 {
 		t.Fatalf("after r on paneNamespaces: lister.calls = %d, want 2", lister.calls)
 	}
 	if mm.pickerErr != "" {
 		t.Fatalf("`r` should clear pickerErr, got %q", mm.pickerErr)
 	}
+	// Deliver the agentsLoadedMsg so m.loading flips back to false; otherwise
+	// the next `r` would be gated.
+	updated, _ = mm.Update(loaded)
+	mm = updated.(*model)
 
 	// Drill into team1, press `r` from panePods. Same effect.
 	updated, _ = mm.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -155,6 +159,76 @@ func TestRefreshKeybindReloadsAgents(t *testing.T) {
 	_ = cmd()
 	if lister.calls != 3 {
 		t.Fatalf("after r on panePods: lister.calls = %d, want 3", lister.calls)
+	}
+}
+
+func TestRefreshKeybindIgnoredWhileLoading(t *testing.T) {
+	lister := &fakeLister{namespaces: fixtureNamespaces}
+	m := newPickerModel(context.Background(), lister, nil)
+	// Init dispatches loadAgentsCmd and sets m.loading = true. We don't
+	// execute the Cmd yet — that simulates the load being in flight.
+	initCmd := m.Init()
+	if initCmd == nil {
+		t.Fatal("Init should return a Cmd")
+	}
+	if !m.loading {
+		t.Fatal("Init should set m.loading = true")
+	}
+	// `r` while loading: the gate is purely on m.loading, regardless of
+	// whether the in-flight Cmd has run yet. No new dispatch.
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if cmd != nil {
+		t.Fatal("`r` while loading should return nil Cmd")
+	}
+	// Complete the original load; loading flag clears.
+	_, _ = m.Update(initCmd())
+	if m.loading {
+		t.Fatal("agentsLoadedMsg should clear m.loading")
+	}
+	if lister.calls != 1 {
+		t.Fatalf("only the original load should have run: lister.calls = %d, want 1", lister.calls)
+	}
+	// Now `r` works again.
+	_, cmd = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if cmd == nil {
+		t.Fatal("`r` after load completes should produce a Cmd")
+	}
+	_ = cmd()
+	if lister.calls != 2 {
+		t.Fatalf("after second r: lister.calls = %d, want 2", lister.calls)
+	}
+}
+
+func TestRefreshDropsBackOutWhenSelectedNamespaceVanishes(t *testing.T) {
+	// Drill into team1, then the lister's underlying data shifts to
+	// only-team2. After `r`, the user should land back on paneNamespaces
+	// since team1 no longer exists.
+	lister := &fakeLister{namespaces: fixtureNamespaces}
+	m := newPickerModel(context.Background(), lister, nil)
+	updated, _ := m.Update(m.Init()())
+	mm := updated.(*model)
+	updated, _ = mm.Update(tea.KeyMsg{Type: tea.KeyEnter}) // → panePods on team1
+	mm = updated.(*model)
+	if mm.pane != panePods {
+		t.Fatalf("setup: not on panePods, got %v", mm.pane)
+	}
+
+	// Cluster state changes — only team2 remains.
+	lister.namespaces = []cluster.AgentNamespace{
+		{Name: "team2", Pods: []cluster.Pod{
+			{Namespace: "team2", Name: "billing-agent-1", Phase: "Pending", Ready: false},
+		}},
+	}
+	// Press `r`, deliver the new agentsLoadedMsg.
+	_, cmd := mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	updated, _ = mm.Update(cmd())
+	mm = updated.(*model)
+
+	if mm.pane != paneNamespaces {
+		t.Fatalf("after vanished-namespace reload, pane should be paneNamespaces, got %v", mm.pane)
+	}
+	if mm.selectedNamespace != "" {
+		t.Fatalf("selectedNamespace should be cleared, got %q", mm.selectedNamespace)
 	}
 }
 

--- a/authbridge/cmd/abctl/tui/picker_test.go
+++ b/authbridge/cmd/abctl/tui/picker_test.go
@@ -13,10 +13,14 @@ import (
 	"github.com/kagenti/kagenti-extensions/authbridge/cmd/abctl/cluster"
 )
 
-// fakeLister returns a fixed []AgentNamespace.
-type fakeLister struct{ namespaces []cluster.AgentNamespace }
+// fakeLister returns a fixed []AgentNamespace and counts ListAgents calls.
+type fakeLister struct {
+	namespaces []cluster.AgentNamespace
+	calls      int
+}
 
 func (f *fakeLister) ListAgents(ctx context.Context) ([]cluster.AgentNamespace, error) {
+	f.calls++
 	return f.namespaces, nil
 }
 
@@ -111,6 +115,46 @@ func TestPodsPaneEscBacksOut(t *testing.T) {
 	mm = updated.(*model)
 	if mm.pane != paneNamespaces {
 		t.Fatalf("Esc should back out to Namespaces, got pane %v", mm.pane)
+	}
+}
+
+func TestRefreshKeybindReloadsAgents(t *testing.T) {
+	lister := &fakeLister{namespaces: fixtureNamespaces}
+	m := newPickerModel(context.Background(), lister, nil)
+	// Initial load: 1 call.
+	updated, _ := m.Update(m.Init()())
+	mm := updated.(*model)
+	if lister.calls != 1 {
+		t.Fatalf("after Init: lister.calls = %d, want 1", lister.calls)
+	}
+	mm.pickerErr = "stale error from earlier"
+
+	// `r` from paneNamespaces should re-run loadAgentsCmd and clear the error.
+	_, cmd := mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if cmd == nil {
+		t.Fatal("`r` on paneNamespaces should produce a Cmd to reload")
+	}
+	_ = cmd() // dispatch the load
+	if lister.calls != 2 {
+		t.Fatalf("after r on paneNamespaces: lister.calls = %d, want 2", lister.calls)
+	}
+	if mm.pickerErr != "" {
+		t.Fatalf("`r` should clear pickerErr, got %q", mm.pickerErr)
+	}
+
+	// Drill into team1, press `r` from panePods. Same effect.
+	updated, _ = mm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	mm = updated.(*model)
+	if mm.pane != panePods {
+		t.Fatalf("setup: not on panePods, got %v", mm.pane)
+	}
+	_, cmd = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if cmd == nil {
+		t.Fatal("`r` on panePods should produce a Cmd to reload")
+	}
+	_ = cmd()
+	if lister.calls != 3 {
+		t.Fatalf("after r on panePods: lister.calls = %d, want 3", lister.calls)
 	}
 }
 

--- a/authbridge/cmd/abctl/tui/picker_test.go
+++ b/authbridge/cmd/abctl/tui/picker_test.go
@@ -134,17 +134,19 @@ func TestRefreshKeybindReloadsAgents(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("`r` on paneNamespaces should produce a Cmd to reload")
 	}
-	loaded := cmd() // dispatch the load
-	if lister.calls != 2 {
-		t.Fatalf("after r on paneNamespaces: lister.calls = %d, want 2", lister.calls)
-	}
 	if mm.pickerErr != "" {
 		t.Fatalf("`r` should clear pickerErr, got %q", mm.pickerErr)
 	}
-	// Deliver the agentsLoadedMsg so m.loading flips back to false; otherwise
-	// the next `r` would be gated.
-	updated, _ = mm.Update(loaded)
+	// Run the Cmd and feed its message through Update so the post-reload
+	// transition (clear m.loading, rebuild table) actually runs.
+	updated, _ = mm.Update(cmd())
 	mm = updated.(*model)
+	if lister.calls != 2 {
+		t.Fatalf("after r on paneNamespaces: lister.calls = %d, want 2", lister.calls)
+	}
+	if mm.loading {
+		t.Fatal("agentsLoadedMsg should clear m.loading")
+	}
 
 	// Drill into team1, press `r` from panePods. Same effect.
 	updated, _ = mm.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -156,9 +158,14 @@ func TestRefreshKeybindReloadsAgents(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("`r` on panePods should produce a Cmd to reload")
 	}
-	_ = cmd()
+	updated, _ = mm.Update(cmd())
+	mm = updated.(*model)
 	if lister.calls != 3 {
 		t.Fatalf("after r on panePods: lister.calls = %d, want 3", lister.calls)
+	}
+	// Pane stays on panePods (selectedNamespace still exists in the new data).
+	if mm.pane != panePods {
+		t.Fatalf("after r on panePods with stable data: pane = %v, want panePods", mm.pane)
 	}
 }
 

--- a/authbridge/cmd/abctl/tui/picker_test.go
+++ b/authbridge/cmd/abctl/tui/picker_test.go
@@ -53,6 +53,22 @@ func TestNamespacesPaneLoadsAndRenders(t *testing.T) {
 	}
 }
 
+func TestNamespacesPaneEmptyState(t *testing.T) {
+	// Lister returns no agents — the pane should render an actionable hint
+	// instead of an empty table.
+	m := newPickerModel(context.Background(), &fakeLister{namespaces: []cluster.AgentNamespace{}}, nil)
+	loaded := m.Init()()
+	updated, _ := m.Update(loaded)
+	mm := updated.(*model)
+	view := mm.View()
+	if !strings.Contains(view, "No AuthBridge agents found") {
+		t.Fatalf("empty-state hint missing from view:\n%s", view)
+	}
+	if !strings.Contains(view, "--endpoint") {
+		t.Fatalf("empty-state hint should mention --endpoint:\n%s", view)
+	}
+}
+
 func TestNamespacesPaneDrillsIntoPods(t *testing.T) {
 	m := newPickerModel(context.Background(), &fakeLister{namespaces: fixtureNamespaces}, nil)
 	loaded := m.Init()()

--- a/authbridge/demos/ibac/scripts/launch-abctl.sh
+++ b/authbridge/demos/ibac/scripts/launch-abctl.sh
@@ -6,7 +6,7 @@
 # that just verifies prerequisites and runs the binary. The picker
 # discovers the agent automatically; the user picks team1/email-agent.
 
-set -uo pipefail
+set -euo pipefail
 
 NAMESPACE=${1:-team1}
 AGENT_NAME=${2:-email-agent}

--- a/authbridge/demos/ibac/scripts/launch-abctl.sh
+++ b/authbridge/demos/ibac/scripts/launch-abctl.sh
@@ -1,16 +1,10 @@
 #!/bin/bash
 # Launch abctl against the IBAC agent's authbridge sidecar.
 #
-# Handles the boring orchestration so `make show-result` is one
-# step:
-#
-#   1. Build abctl if it isn't already cached (~5s first run, instant
-#      after).
-#   2. Detect whether something is already listening on :9094 (the
-#      session API port). If not, start `kubectl port-forward` in the
-#      background and tear it down when abctl exits.
-#   3. Run abctl in the foreground. User quits with `q` or Ctrl-C;
-#      the trap cleans up the port-forward.
+# Since abctl now ships with a built-in Namespaces → Pods picker that
+# spawns its own kubectl port-forward, this script is a thin wrapper
+# that just verifies prerequisites and runs the binary. The picker
+# discovers the agent automatically; the user picks team1/email-agent.
 
 set -uo pipefail
 
@@ -20,9 +14,7 @@ ABCTL_BIN=${ABCTL_BIN:-/tmp/abctl-ibac-demo}
 
 # 1. The Makefile's build-abctl target builds the binary on demand.
 #    If it's still missing, the user invoked the script directly —
-#    point them at the right entry point instead of trying to build
-#    in here (which would couple this script to the go toolchain
-#    layout in their dev environment).
+#    point them at the right entry point.
 if [[ ! -x "$ABCTL_BIN" ]]; then
   echo "ERROR: abctl binary not found at $ABCTL_BIN." >&2
   echo "       Run \`make show-result\` (which depends on build-abctl)" >&2
@@ -30,61 +22,13 @@ if [[ ! -x "$ABCTL_BIN" ]]; then
   exit 1
 fi
 
-# 2. Verify the agent pod is up before any port-forward attempt.
+# 2. Verify the agent pod is up — friendlier failure than dropping the
+#    user into an empty picker.
 if ! kubectl -n "$NAMESPACE" get deploy "$AGENT_NAME" >/dev/null 2>&1; then
   echo "ERROR: deployment $NAMESPACE/$AGENT_NAME not found." >&2
   echo "       Run 'make demo-ibac' first." >&2
   exit 1
 fi
 
-# 3. Port-forward orchestration.
-#    - If something is already listening on :9094, assume the user
-#      set up the forward themselves and use it.
-#    - Otherwise start one we own and clean up on exit.
-PF_PID=""
-cleanup() {
-  if [[ -n "$PF_PID" ]]; then
-    kill "$PF_PID" 2>/dev/null || true
-    wait 2>/dev/null || true
-  fi
-}
-trap cleanup EXIT INT TERM
-
-PORT_IN_USE=0
-if command -v lsof >/dev/null 2>&1; then
-  if lsof -nP -iTCP:9094 -sTCP:LISTEN >/dev/null 2>&1; then
-    PORT_IN_USE=1
-  fi
-elif command -v ss >/dev/null 2>&1; then
-  if ss -ltn '( sport = :9094 )' 2>/dev/null | grep -q ':9094'; then
-    PORT_IN_USE=1
-  fi
-fi
-
-if [[ "$PORT_IN_USE" == "1" ]]; then
-  echo "[*] Reusing existing listener on :9094 (assumed your port-forward)."
-else
-  echo "[*] Starting port-forward to deploy/$AGENT_NAME on :9094 ..."
-  kubectl -n "$NAMESPACE" port-forward deploy/"$AGENT_NAME" 9094:9094 >/dev/null 2>&1 &
-  PF_PID=$!
-  # Wait for the listener to come up before launching the TUI.
-  for _ in 1 2 3 4 5 6 7 8; do
-    if curl -sf http://localhost:9094/healthz >/dev/null 2>&1; then
-      break
-    fi
-    sleep 0.5
-  done
-  if ! curl -sf http://localhost:9094/healthz >/dev/null 2>&1; then
-    echo "ERROR: port-forward never came up. Last kubectl output:" >&2
-    kubectl -n "$NAMESPACE" port-forward deploy/"$AGENT_NAME" 9094:9094 2>&1 | head -5 >&2 || true
-    exit 1
-  fi
-fi
-
-# 4. Run abctl in the foreground. Important: do NOT use `exec` — it
-#    replaces the shell process, which would kill our cleanup trap
-#    and leak the kubectl port-forward we just started. Run as a
-#    child so the trap fires on abctl's exit.
+# 3. Run abctl. The picker handles port-forward setup + teardown.
 "$ABCTL_BIN"
-exit_code=$?
-exit "$exit_code"


### PR DESCRIPTION
## Summary

Polish + cleanup follow-ups to #445 (the abctl Namespaces → Pods picker). Six small, focused commits, each independently reviewable.

## Commits

1. **`feat(abctl): Empty-state hint when no AuthBridge agents found`** — replaces the empty namespaces table with an actionable hint pointing at `--endpoint` when the cluster has no agents.
2. **`feat(abctl): r reloads picker from cluster`** — `r` keybind on both picker panes re-runs `loadAgentsCmd` and refreshes the pods table if currently shown. Helps when a long-running abctl session has gone stale.
3. **`feat(abctl): Propagate ctx into bubbletea program`** — `tea.NewProgram` now takes `tea.WithContext(ctx)` so SIGTERM (translated to ctx cancel by `main.go`'s signal handler) cleanly exits the TUI loop without requiring `q`.
4. **`refactor(abctl): Drop unused Pod.StartedAt`** — symmetric with `PortForward.Wait()` / `LocalPort()` we already trimmed in #445; the field was set in `parseAgentPods` but read nowhere. Easy to add back when a future picker column needs it.
5. **`chore(ibac-demo): Slim launch-abctl.sh; drop manual port-forward`** — abctl now does its own port-forward. Drops the `:9094`-detection lsof/ss probe, the `kubectl port-forward` subprocess + cleanup trap, and the `curl /healthz` readiness loop. 72 lines → 34. Preflights for the abctl binary + agent deployment stay (friendlier failure than an empty picker).
6. **`docs(abctl): Drop stale "in-process port-forward" deferred entry`** — #445 implemented this; the README's "Deferred to later PRs" list still advertised it as not-done.

## User-visible changes

| Change | Before | After |
|---|---|---|
| Empty cluster | empty Namespaces table (looks broken) | "No AuthBridge agents found. Use `--endpoint http://...` to connect manually." |
| Stale picker | quit + relaunch to refresh | press `r` |
| SIGTERM | TUI ignores it; user must press `q` | program exits cleanly |
| `make show-result` | spawns its own `kubectl port-forward` | abctl's picker handles it |

Footer hints + README keybindings table updated for the new `r` row.

## Test plan

- [x] All `cmd/abctl` tests pass under `-race`.
- [x] `go vet` clean across all three subpackages.
- [x] `go test -tags=e2e ./cluster/ -run TestE2ESmoke` passes against the live IBAC cluster.
- [x] `bash authbridge/demos/ibac/scripts/launch-abctl.sh` runs preflights and launches the binary; no orphaned `kubectl port-forward` subprocesses.
- [x] `make demo-ibac && make show-result` exercises the full flow.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reload shortcut (press r) in Namespaces and Pods panes to refresh agents.

* **Improvements**
  * Prevents concurrent reloads and auto-refreshes pods after a successful reload.
  * UI distinguishes loading vs loaded-empty states and shows a clearer empty-state hint.
  * Help/footer now shows the [r] reload key.

* **Tests**
  * Added tests for empty-state messaging and reload key behavior.

* **Chores**
  * Demo launch script simplified to invoke the picker directly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kagenti/kagenti-extensions/pull/446?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->