### PR TITLE
feat(abctl): Surface plugin runtime config in plugin-detail pane

### DIFF
--- a/authbridge/authlib/pipeline/configured.go
+++ b/authbridge/authlib/pipeline/configured.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"context"
 	"encoding/json"
 )
 
@@ -30,3 +31,44 @@ func wrapConfigured(p Plugin, raw json.RawMessage) Plugin {
 // with. Used by sessionapi describePipeline to populate /v1/pipeline's
 // Config field.
 func (c *configuredPlugin) RawConfig() json.RawMessage { return c.raw }
+
+// Init forwards to the wrapped plugin if it implements Initializer; otherwise
+// returns nil (no deferred initialization). Required because Initializer is
+// not declared on the Plugin interface, so the embedded Plugin's Init method
+// (if any) is NOT promoted to *configuredPlugin's method set — only methods
+// declared on Plugin are. Without this explicit forwarding, the framework's
+// Init dispatcher would silently skip wrapped plugins.
+func (c *configuredPlugin) Init(ctx context.Context) error {
+	if init, ok := c.Plugin.(Initializer); ok {
+		return init.Init(ctx)
+	}
+	return nil
+}
+
+// Shutdown forwards to the wrapped plugin if it implements Shutdowner; otherwise
+// returns nil (no resources to release).
+func (c *configuredPlugin) Shutdown(ctx context.Context) error {
+	if sh, ok := c.Plugin.(Shutdowner); ok {
+		return sh.Shutdown(ctx)
+	}
+	return nil
+}
+
+// OnFinish forwards to the wrapped plugin if it implements Finisher; otherwise
+// no-ops. The framework's OnFinish dispatcher type-asserts against Finisher,
+// so wrapped plugins must implement it explicitly to participate.
+func (c *configuredPlugin) OnFinish(ctx context.Context, pctx *Context) {
+	if fin, ok := c.Plugin.(Finisher); ok {
+		fin.OnFinish(ctx, pctx)
+	}
+}
+
+// Ready forwards to the wrapped plugin if it implements Readier; otherwise
+// returns true. This matches the existing semantics in Pipeline.Ready
+// (pipeline.go:287-289): plugins without Readier are considered always-ready.
+func (c *configuredPlugin) Ready() bool {
+	if r, ok := c.Plugin.(Readier); ok {
+		return r.Ready()
+	}
+	return true
+}

--- a/authbridge/authlib/pipeline/configured.go
+++ b/authbridge/authlib/pipeline/configured.go
@@ -1,0 +1,32 @@
+package pipeline
+
+import (
+	"encoding/json"
+)
+
+// configuredPlugin wraps a plugin built via Configurable.Configure with the
+// raw config bytes it was constructed from, so the session API can surface
+// them on /v1/pipeline. All Plugin interface methods forward to the embedded
+// plugin — zero observable behavior change at the request hot path.
+//
+// Optional plugin interfaces (Initializer, Shutdowner, Finisher, Readier)
+// are NOT promoted through the embedded Plugin interface — Go does not
+// promote method-set membership through an embedded interface. The wrapper
+// implements each of those four interfaces explicitly and forwards
+// conditionally; see the methods below (added in a follow-up commit).
+type configuredPlugin struct {
+	Plugin
+	raw json.RawMessage
+}
+
+// wrapConfigured returns a Plugin whose dynamic type is *configuredPlugin.
+// Callers (registry.Build) invoke this only after Configurable.Configure
+// returns nil; non-Configurable plugins pass through unwrapped.
+func wrapConfigured(p Plugin, raw json.RawMessage) Plugin {
+	return &configuredPlugin{Plugin: p, raw: raw}
+}
+
+// RawConfig returns the raw config bytes the wrapped plugin was configured
+// with. Used by sessionapi describePipeline to populate /v1/pipeline's
+// Config field.
+func (c *configuredPlugin) RawConfig() json.RawMessage { return c.raw }

--- a/authbridge/authlib/pipeline/configured.go
+++ b/authbridge/authlib/pipeline/configured.go
@@ -5,6 +5,18 @@ import (
 	"encoding/json"
 )
 
+// RawConfigProvider is implemented by plugins (or wrappers around them)
+// that can surface the raw runtime config bytes the plugin was built
+// from. The session API uses this interface in describePipeline to
+// populate /v1/pipeline's Config field. Naming it explicitly (rather
+// than asserting an inline interface literal at the call site) gives
+// callers a greppable contract and turns any future signature drift
+// into a compile-time error rather than a silently-failing
+// type-assertion.
+type RawConfigProvider interface {
+	RawConfig() json.RawMessage
+}
+
 // configuredPlugin wraps a plugin built via Configurable.Configure with the
 // raw config bytes it was constructed from, so the session API can surface
 // them on /v1/pipeline. All Plugin interface methods forward to the embedded
@@ -14,7 +26,16 @@ import (
 // are NOT promoted through the embedded Plugin interface — Go does not
 // promote method-set membership through an embedded interface. The wrapper
 // implements each of those four interfaces explicitly and forwards
-// conditionally; see the methods below (added in a follow-up commit).
+// conditionally; see the methods below.
+//
+// Side effect of unconditional forwarding: every wrapped (i.e., every
+// Configurable) plugin satisfies all four optional interfaces regardless
+// of what the inner plugin actually implements. Callers that distinguish
+// "implements Initializer" from "doesn't" via type-assertion will treat
+// every wrapped plugin as an Initializer (and Shutdowner, Finisher,
+// Readier). Behavior at the dispatcher hot path is preserved by the
+// no-op fallbacks; callers that need to discriminate must rely on
+// inner behavior rather than type-assertions.
 type configuredPlugin struct {
 	Plugin
 	raw json.RawMessage
@@ -25,14 +46,24 @@ type configuredPlugin struct {
 // surface them on /v1/pipeline. Callers (plugins.Build) invoke this
 // only after Configurable.Configure returns nil; non-Configurable
 // plugins pass through unwrapped.
+//
+// The raw bytes are defensively copied before being stored, so a
+// caller that holds onto its reference and mutates it (or whose
+// surrounding decoder reuses the underlying buffer) cannot perturb
+// what RawConfig() later returns. The cost is one allocation per
+// Configurable plugin per pipeline build — negligible at startup
+// and on the rare hot-reload path.
 func WrapConfigured(p Plugin, raw json.RawMessage) Plugin {
-	return &configuredPlugin{Plugin: p, raw: raw}
+	cp := append(json.RawMessage(nil), raw...)
+	return &configuredPlugin{Plugin: p, raw: cp}
 }
 
-// RawConfig returns the raw config bytes the wrapped plugin was configured
-// with. Used by sessionapi describePipeline to populate /v1/pipeline's
-// Config field.
-func (c *configuredPlugin) RawConfig() json.RawMessage { return c.raw }
+// RawConfig returns a defensive copy of the raw config bytes the
+// wrapped plugin was configured with. Returning a copy means callers
+// cannot mutate what subsequent calls return.
+func (c *configuredPlugin) RawConfig() json.RawMessage {
+	return append(json.RawMessage(nil), c.raw...)
+}
 
 // Init forwards to the wrapped plugin if it implements Initializer; otherwise
 // returns nil (no deferred initialization). Required because Initializer is

--- a/authbridge/authlib/pipeline/configured.go
+++ b/authbridge/authlib/pipeline/configured.go
@@ -20,10 +20,12 @@ type configuredPlugin struct {
 	raw json.RawMessage
 }
 
-// wrapConfigured returns a Plugin whose dynamic type is *configuredPlugin.
-// Callers (registry.Build) invoke this only after Configurable.Configure
-// returns nil; non-Configurable plugins pass through unwrapped.
-func wrapConfigured(p Plugin, raw json.RawMessage) Plugin {
+// WrapConfigured returns a Plugin whose dynamic type retains the raw
+// config bytes the plugin was built from, so the session API can
+// surface them on /v1/pipeline. Callers (plugins.Build) invoke this
+// only after Configurable.Configure returns nil; non-Configurable
+// plugins pass through unwrapped.
+func WrapConfigured(p Plugin, raw json.RawMessage) Plugin {
 	return &configuredPlugin{Plugin: p, raw: raw}
 }
 

--- a/authbridge/authlib/pipeline/configured_test.go
+++ b/authbridge/authlib/pipeline/configured_test.go
@@ -63,3 +63,150 @@ func TestConfiguredPluginPassesThroughPluginMethods(t *testing.T) {
 			fake.requests, fake.responses)
 	}
 }
+
+// fakeInitializer extends fakePlugin with Initializer.
+type fakeInitializer struct {
+	fakePlugin
+	initCalls int
+	initErr   error
+}
+
+func (f *fakeInitializer) Init(ctx context.Context) error {
+	f.initCalls++
+	return f.initErr
+}
+
+// fakeShutdowner extends fakePlugin with Shutdowner.
+type fakeShutdowner struct {
+	fakePlugin
+	shutdownCalls int
+}
+
+func (f *fakeShutdowner) Shutdown(ctx context.Context) error {
+	f.shutdownCalls++
+	return nil
+}
+
+// fakeFinisher extends fakePlugin with Finisher.
+type fakeFinisher struct {
+	fakePlugin
+	finishCalls int
+}
+
+func (f *fakeFinisher) OnFinish(ctx context.Context, pctx *Context) {
+	f.finishCalls++
+}
+
+// fakeReadier extends fakePlugin with Readier.
+type fakeReadier struct {
+	fakePlugin
+	ready bool
+}
+
+func (f *fakeReadier) Ready() bool { return f.ready }
+
+func TestConfiguredPluginForwardsInit(t *testing.T) {
+	fake := &fakeInitializer{fakePlugin: fakePlugin{name: "x"}}
+	cp := wrapConfigured(fake, nil)
+	init, ok := cp.(Initializer)
+	if !ok {
+		t.Fatal("wrapper should implement Initializer (unconditional forwarding)")
+	}
+	if err := init.Init(context.Background()); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if fake.initCalls != 1 {
+		t.Fatalf("Init not forwarded: calls=%d want 1", fake.initCalls)
+	}
+}
+
+func TestConfiguredPluginInitNoOpForNonInitializer(t *testing.T) {
+	cp := wrapConfigured(&fakePlugin{name: "x"}, nil)
+	init, ok := cp.(Initializer)
+	if !ok {
+		t.Fatal("wrapper always implements Initializer")
+	}
+	if err := init.Init(context.Background()); err != nil {
+		t.Fatalf("no-op Init should return nil, got %v", err)
+	}
+}
+
+func TestConfiguredPluginForwardsShutdown(t *testing.T) {
+	fake := &fakeShutdowner{fakePlugin: fakePlugin{name: "x"}}
+	cp := wrapConfigured(fake, nil)
+	sh, ok := cp.(Shutdowner)
+	if !ok {
+		t.Fatal("wrapper should implement Shutdowner")
+	}
+	if err := sh.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	if fake.shutdownCalls != 1 {
+		t.Fatalf("Shutdown not forwarded: calls=%d want 1", fake.shutdownCalls)
+	}
+}
+
+func TestConfiguredPluginShutdownNoOpForNonShutdowner(t *testing.T) {
+	cp := wrapConfigured(&fakePlugin{name: "x"}, nil)
+	sh, ok := cp.(Shutdowner)
+	if !ok {
+		t.Fatal("wrapper always implements Shutdowner")
+	}
+	if err := sh.Shutdown(context.Background()); err != nil {
+		t.Fatalf("no-op Shutdown should return nil, got %v", err)
+	}
+}
+
+func TestConfiguredPluginForwardsFinish(t *testing.T) {
+	fake := &fakeFinisher{fakePlugin: fakePlugin{name: "x"}}
+	cp := wrapConfigured(fake, nil)
+	fin, ok := cp.(Finisher)
+	if !ok {
+		t.Fatal("wrapper should implement Finisher")
+	}
+	fin.OnFinish(context.Background(), nil)
+	if fake.finishCalls != 1 {
+		t.Fatalf("OnFinish not forwarded: calls=%d want 1", fake.finishCalls)
+	}
+}
+
+func TestConfiguredPluginFinishNoOpForNonFinisher(t *testing.T) {
+	cp := wrapConfigured(&fakePlugin{name: "x"}, nil)
+	fin, ok := cp.(Finisher)
+	if !ok {
+		t.Fatal("wrapper always implements Finisher")
+	}
+	// Should not panic.
+	fin.OnFinish(context.Background(), nil)
+}
+
+func TestConfiguredPluginForwardsReady(t *testing.T) {
+	// Plugin that reports not-ready: wrapper must report not-ready too.
+	fake := &fakeReadier{fakePlugin: fakePlugin{name: "x"}, ready: false}
+	cp := wrapConfigured(fake, nil)
+	r, ok := cp.(Readier)
+	if !ok {
+		t.Fatal("wrapper should implement Readier")
+	}
+	if r.Ready() {
+		t.Fatal("Ready should forward false from underlying plugin")
+	}
+	// Now set ready=true; wrapper reflects.
+	fake.ready = true
+	if !r.Ready() {
+		t.Fatal("Ready should forward true from underlying plugin")
+	}
+}
+
+func TestConfiguredPluginReadyDefaultsTrueForNonReadier(t *testing.T) {
+	// Matches the existing Pipeline.Ready() semantics: plugins without
+	// Readier are considered always-ready (pipeline.go:287-289).
+	cp := wrapConfigured(&fakePlugin{name: "x"}, nil)
+	r, ok := cp.(Readier)
+	if !ok {
+		t.Fatal("wrapper always implements Readier")
+	}
+	if !r.Ready() {
+		t.Fatal("non-Readier wrapped plugin should default to ready=true")
+	}
+}

--- a/authbridge/authlib/pipeline/configured_test.go
+++ b/authbridge/authlib/pipeline/configured_test.go
@@ -29,7 +29,7 @@ func (f *fakePlugin) OnResponse(ctx context.Context, pctx *Context) Action {
 func TestConfiguredPluginRawConfig(t *testing.T) {
 	raw := json.RawMessage(`{"issuer":"http://idp"}`)
 	cp := WrapConfigured(&fakePlugin{name: "jwt-validation"}, raw)
-	rc, ok := cp.(interface{ RawConfig() json.RawMessage })
+	rc, ok := cp.(RawConfigProvider)
 	if !ok {
 		t.Fatal("wrapper should expose RawConfig() via type-assertion")
 	}

--- a/authbridge/authlib/pipeline/configured_test.go
+++ b/authbridge/authlib/pipeline/configured_test.go
@@ -1,0 +1,65 @@
+package pipeline
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// fakePlugin is a minimal Plugin implementation for testing the wrapper.
+// It records call counts so pass-through can be asserted.
+type fakePlugin struct {
+	name      string
+	caps      PluginCapabilities
+	requests  int
+	responses int
+}
+
+func (f *fakePlugin) Name() string                  { return f.name }
+func (f *fakePlugin) Capabilities() PluginCapabilities { return f.caps }
+func (f *fakePlugin) OnRequest(ctx context.Context, pctx *Context) Action {
+	f.requests++
+	return Action{}
+}
+func (f *fakePlugin) OnResponse(ctx context.Context, pctx *Context) Action {
+	f.responses++
+	return Action{}
+}
+
+func TestConfiguredPluginRawConfig(t *testing.T) {
+	raw := json.RawMessage(`{"issuer":"http://idp"}`)
+	cp := wrapConfigured(&fakePlugin{name: "jwt-validation"}, raw)
+	rc, ok := cp.(interface{ RawConfig() json.RawMessage })
+	if !ok {
+		t.Fatal("wrapper should expose RawConfig() via type-assertion")
+	}
+	got := string(rc.RawConfig())
+	if got != `{"issuer":"http://idp"}` {
+		t.Fatalf("RawConfig: %q want %q", got, `{"issuer":"http://idp"}`)
+	}
+}
+
+func TestConfiguredPluginPassesThroughPluginMethods(t *testing.T) {
+	fake := &fakePlugin{
+		name: "jwt-validation",
+		caps: PluginCapabilities{Reads: []string{"a"}, Writes: []string{"security"}},
+	}
+	cp := wrapConfigured(fake, json.RawMessage(`{}`))
+
+	if cp.Name() != "jwt-validation" {
+		t.Fatalf("Name pass-through broken: %q", cp.Name())
+	}
+	caps := cp.Capabilities()
+	if len(caps.Reads) != 1 || caps.Reads[0] != "a" {
+		t.Fatalf("Capabilities pass-through broken: %+v", caps)
+	}
+	if len(caps.Writes) != 1 || caps.Writes[0] != "security" {
+		t.Fatalf("Capabilities pass-through broken: %+v", caps)
+	}
+	cp.OnRequest(context.Background(), nil)
+	cp.OnResponse(context.Background(), nil)
+	if fake.requests != 1 || fake.responses != 1 {
+		t.Fatalf("OnRequest/OnResponse pass-through broken: req=%d resp=%d",
+			fake.requests, fake.responses)
+	}
+}

--- a/authbridge/authlib/pipeline/configured_test.go
+++ b/authbridge/authlib/pipeline/configured_test.go
@@ -28,7 +28,7 @@ func (f *fakePlugin) OnResponse(ctx context.Context, pctx *Context) Action {
 
 func TestConfiguredPluginRawConfig(t *testing.T) {
 	raw := json.RawMessage(`{"issuer":"http://idp"}`)
-	cp := wrapConfigured(&fakePlugin{name: "jwt-validation"}, raw)
+	cp := WrapConfigured(&fakePlugin{name: "jwt-validation"}, raw)
 	rc, ok := cp.(interface{ RawConfig() json.RawMessage })
 	if !ok {
 		t.Fatal("wrapper should expose RawConfig() via type-assertion")
@@ -44,7 +44,7 @@ func TestConfiguredPluginPassesThroughPluginMethods(t *testing.T) {
 		name: "jwt-validation",
 		caps: PluginCapabilities{Reads: []string{"a"}, Writes: []string{"security"}},
 	}
-	cp := wrapConfigured(fake, json.RawMessage(`{}`))
+	cp := WrapConfigured(fake, json.RawMessage(`{}`))
 
 	if cp.Name() != "jwt-validation" {
 		t.Fatalf("Name pass-through broken: %q", cp.Name())
@@ -107,7 +107,7 @@ func (f *fakeReadier) Ready() bool { return f.ready }
 
 func TestConfiguredPluginForwardsInit(t *testing.T) {
 	fake := &fakeInitializer{fakePlugin: fakePlugin{name: "x"}}
-	cp := wrapConfigured(fake, nil)
+	cp := WrapConfigured(fake, nil)
 	init, ok := cp.(Initializer)
 	if !ok {
 		t.Fatal("wrapper should implement Initializer (unconditional forwarding)")
@@ -121,7 +121,7 @@ func TestConfiguredPluginForwardsInit(t *testing.T) {
 }
 
 func TestConfiguredPluginInitNoOpForNonInitializer(t *testing.T) {
-	cp := wrapConfigured(&fakePlugin{name: "x"}, nil)
+	cp := WrapConfigured(&fakePlugin{name: "x"}, nil)
 	init, ok := cp.(Initializer)
 	if !ok {
 		t.Fatal("wrapper always implements Initializer")
@@ -133,7 +133,7 @@ func TestConfiguredPluginInitNoOpForNonInitializer(t *testing.T) {
 
 func TestConfiguredPluginForwardsShutdown(t *testing.T) {
 	fake := &fakeShutdowner{fakePlugin: fakePlugin{name: "x"}}
-	cp := wrapConfigured(fake, nil)
+	cp := WrapConfigured(fake, nil)
 	sh, ok := cp.(Shutdowner)
 	if !ok {
 		t.Fatal("wrapper should implement Shutdowner")
@@ -147,7 +147,7 @@ func TestConfiguredPluginForwardsShutdown(t *testing.T) {
 }
 
 func TestConfiguredPluginShutdownNoOpForNonShutdowner(t *testing.T) {
-	cp := wrapConfigured(&fakePlugin{name: "x"}, nil)
+	cp := WrapConfigured(&fakePlugin{name: "x"}, nil)
 	sh, ok := cp.(Shutdowner)
 	if !ok {
 		t.Fatal("wrapper always implements Shutdowner")
@@ -159,7 +159,7 @@ func TestConfiguredPluginShutdownNoOpForNonShutdowner(t *testing.T) {
 
 func TestConfiguredPluginForwardsFinish(t *testing.T) {
 	fake := &fakeFinisher{fakePlugin: fakePlugin{name: "x"}}
-	cp := wrapConfigured(fake, nil)
+	cp := WrapConfigured(fake, nil)
 	fin, ok := cp.(Finisher)
 	if !ok {
 		t.Fatal("wrapper should implement Finisher")
@@ -171,7 +171,7 @@ func TestConfiguredPluginForwardsFinish(t *testing.T) {
 }
 
 func TestConfiguredPluginFinishNoOpForNonFinisher(t *testing.T) {
-	cp := wrapConfigured(&fakePlugin{name: "x"}, nil)
+	cp := WrapConfigured(&fakePlugin{name: "x"}, nil)
 	fin, ok := cp.(Finisher)
 	if !ok {
 		t.Fatal("wrapper always implements Finisher")
@@ -183,7 +183,7 @@ func TestConfiguredPluginFinishNoOpForNonFinisher(t *testing.T) {
 func TestConfiguredPluginForwardsReady(t *testing.T) {
 	// Plugin that reports not-ready: wrapper must report not-ready too.
 	fake := &fakeReadier{fakePlugin: fakePlugin{name: "x"}, ready: false}
-	cp := wrapConfigured(fake, nil)
+	cp := WrapConfigured(fake, nil)
 	r, ok := cp.(Readier)
 	if !ok {
 		t.Fatal("wrapper should implement Readier")
@@ -201,7 +201,7 @@ func TestConfiguredPluginForwardsReady(t *testing.T) {
 func TestConfiguredPluginReadyDefaultsTrueForNonReadier(t *testing.T) {
 	// Matches the existing Pipeline.Ready() semantics: plugins without
 	// Readier are considered always-ready (pipeline.go:287-289).
-	cp := wrapConfigured(&fakePlugin{name: "x"}, nil)
+	cp := WrapConfigured(&fakePlugin{name: "x"}, nil)
 	r, ok := cp.(Readier)
 	if !ok {
 		t.Fatal("wrapper always implements Readier")

--- a/authbridge/authlib/plugins/registry.go
+++ b/authbridge/authlib/plugins/registry.go
@@ -119,6 +119,8 @@ func Build(entries []config.PluginEntry, opts ...pipeline.Option) (*pipeline.Pip
 			if err := c.Configure(e.Config); err != nil {
 				return nil, fmt.Errorf("configure %q: %w", e.Name, err)
 			}
+			// Wrap so the session API can surface the raw config on /v1/pipeline.
+			p = pipeline.WrapConfigured(p, e.Config)
 		} else if len(e.Config) > 0 {
 			return nil, fmt.Errorf("plugin %q does not accept configuration", e.Name)
 		}
@@ -167,6 +169,8 @@ func BuildWithSPIFFE(entries []config.PluginEntry, p *spiffe.Provider, opts ...p
 			if err := c.Configure(e.Config); err != nil {
 				return nil, fmt.Errorf("configure %q: %w", e.Name, err)
 			}
+			// Wrap so the session API can surface the raw config on /v1/pipeline.
+			plugin = pipeline.WrapConfigured(plugin, e.Config)
 		} else if len(e.Config) > 0 {
 			return nil, fmt.Errorf("plugin %q does not accept configuration", e.Name)
 		}

--- a/authbridge/authlib/plugins/registry_test.go
+++ b/authbridge/authlib/plugins/registry_test.go
@@ -566,3 +566,50 @@ func TestRegistryWrapsConfigurablePluginsForRawConfig(t *testing.T) {
 		t.Fatal("non-Configurable plugin should NOT be wrapped")
 	}
 }
+
+// TestBuildWithSPIFFEWrapsConfigurablePluginsForRawConfig is the parity test
+// for BuildWithSPIFFE — the second registry entry point shares the wrap site
+// with Build. Lock both paths so the wrapping invariant doesn't drift.
+func TestBuildWithSPIFFEWrapsConfigurablePluginsForRawConfig(t *testing.T) {
+	cfgName := "rawcfg-spiffe-test-configurable"
+	relName := "rawcfg-spiffe-test-relational"
+	RegisterPlugin(cfgName, func() pipeline.Plugin {
+		return &cfgPlugin{relPlugin: relPlugin{name: cfgName}}
+	})
+	defer UnregisterPlugin(cfgName)
+	RegisterPlugin(relName, func() pipeline.Plugin {
+		return &relPlugin{name: relName}
+	})
+	defer UnregisterPlugin(relName)
+
+	configRaw := json.RawMessage(`{"hello":"world"}`)
+	// nil provider is valid for plugins that don't implement
+	// spiffe.ProviderConsumer (BuildWithSPIFFE skips SetSPIFFEProvider in
+	// that case).
+	pipe, err := BuildWithSPIFFE([]config.PluginEntry{
+		{Name: cfgName, Config: configRaw},
+		{Name: relName},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BuildWithSPIFFE: %v", err)
+	}
+	plugins := pipe.Plugins()
+	if len(plugins) != 2 {
+		t.Fatalf("want 2 plugins, got %d", len(plugins))
+	}
+
+	rc, ok := plugins[0].(interface{ RawConfig() json.RawMessage })
+	if !ok {
+		t.Fatal("Configurable plugin should be wrapped (RawConfig type-assert)")
+	}
+	if string(rc.RawConfig()) != `{"hello":"world"}` {
+		t.Fatalf("RawConfig: got %q want %q", string(rc.RawConfig()), `{"hello":"world"}`)
+	}
+	if plugins[0].Name() != cfgName {
+		t.Fatalf("Name through wrapper: %q", plugins[0].Name())
+	}
+	_, ok = plugins[1].(interface{ RawConfig() json.RawMessage })
+	if ok {
+		t.Fatal("non-Configurable plugin should NOT be wrapped")
+	}
+}

--- a/authbridge/authlib/plugins/registry_test.go
+++ b/authbridge/authlib/plugins/registry_test.go
@@ -518,7 +518,7 @@ func (c *cfgPlugin) Configure(raw json.RawMessage) error {
 
 // TestRegistryWrapsConfigurablePluginsForRawConfig verifies that plugins
 // built through Build expose their raw config bytes via type-assertion
-// to interface{ RawConfig() json.RawMessage }. This is the contract
+// to pipeline.RawConfigProvider. This is the contract
 // /v1/pipeline relies on.
 func TestRegistryWrapsConfigurablePluginsForRawConfig(t *testing.T) {
 	// Register a Configurable plugin and a non-Configurable plugin under
@@ -548,7 +548,7 @@ func TestRegistryWrapsConfigurablePluginsForRawConfig(t *testing.T) {
 	}
 
 	// First plugin (Configurable) should expose RawConfig().
-	rc, ok := plugins[0].(interface{ RawConfig() json.RawMessage })
+	rc, ok := plugins[0].(pipeline.RawConfigProvider)
 	if !ok {
 		t.Fatal("Configurable plugin should be wrapped (RawConfig type-assert)")
 	}
@@ -561,7 +561,7 @@ func TestRegistryWrapsConfigurablePluginsForRawConfig(t *testing.T) {
 	}
 
 	// Second plugin (non-Configurable) must NOT be wrapped.
-	_, ok = plugins[1].(interface{ RawConfig() json.RawMessage })
+	_, ok = plugins[1].(pipeline.RawConfigProvider)
 	if ok {
 		t.Fatal("non-Configurable plugin should NOT be wrapped")
 	}
@@ -598,7 +598,7 @@ func TestBuildWithSPIFFEWrapsConfigurablePluginsForRawConfig(t *testing.T) {
 		t.Fatalf("want 2 plugins, got %d", len(plugins))
 	}
 
-	rc, ok := plugins[0].(interface{ RawConfig() json.RawMessage })
+	rc, ok := plugins[0].(pipeline.RawConfigProvider)
 	if !ok {
 		t.Fatal("Configurable plugin should be wrapped (RawConfig type-assert)")
 	}
@@ -608,7 +608,7 @@ func TestBuildWithSPIFFEWrapsConfigurablePluginsForRawConfig(t *testing.T) {
 	if plugins[0].Name() != cfgName {
 		t.Fatalf("Name through wrapper: %q", plugins[0].Name())
 	}
-	_, ok = plugins[1].(interface{ RawConfig() json.RawMessage })
+	_, ok = plugins[1].(pipeline.RawConfigProvider)
 	if ok {
 		t.Fatal("non-Configurable plugin should NOT be wrapped")
 	}

--- a/authbridge/authlib/plugins/registry_test.go
+++ b/authbridge/authlib/plugins/registry_test.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/config"
@@ -499,5 +500,69 @@ func TestBuildWithSPIFFE_NonConsumerPlugin_Unaffected(t *testing.T) {
 	_, err := BuildWithSPIFFE([]config.PluginEntry{{Name: "test-non-consumer"}}, prov)
 	if err != nil {
 		t.Fatalf("BuildWithSPIFFE: %v", err)
+	}
+}
+
+// cfgPlugin is a Configurable wrapper around relPlugin used to verify
+// that the registry wraps Configurable plugins in pipeline.WrapConfigured
+// and that non-Configurable plugins (relPlugin alone) are NOT wrapped.
+type cfgPlugin struct {
+	relPlugin
+	configured json.RawMessage
+}
+
+func (c *cfgPlugin) Configure(raw json.RawMessage) error {
+	c.configured = raw
+	return nil
+}
+
+// TestRegistryWrapsConfigurablePluginsForRawConfig verifies that plugins
+// built through Build expose their raw config bytes via type-assertion
+// to interface{ RawConfig() json.RawMessage }. This is the contract
+// /v1/pipeline relies on.
+func TestRegistryWrapsConfigurablePluginsForRawConfig(t *testing.T) {
+	// Register a Configurable plugin and a non-Configurable plugin under
+	// throwaway names so this test doesn't fight the global registry.
+	cfgName := "rawcfg-test-configurable"
+	relName := "rawcfg-test-relational"
+	RegisterPlugin(cfgName, func() pipeline.Plugin {
+		return &cfgPlugin{relPlugin: relPlugin{name: cfgName}}
+	})
+	defer UnregisterPlugin(cfgName)
+	RegisterPlugin(relName, func() pipeline.Plugin {
+		return &relPlugin{name: relName}
+	})
+	defer UnregisterPlugin(relName)
+
+	configRaw := json.RawMessage(`{"hello":"world"}`)
+	pipe, err := Build([]config.PluginEntry{
+		{Name: cfgName, Config: configRaw},
+		{Name: relName},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	plugins := pipe.Plugins()
+	if len(plugins) != 2 {
+		t.Fatalf("want 2 plugins, got %d", len(plugins))
+	}
+
+	// First plugin (Configurable) should expose RawConfig().
+	rc, ok := plugins[0].(interface{ RawConfig() json.RawMessage })
+	if !ok {
+		t.Fatal("Configurable plugin should be wrapped (RawConfig type-assert)")
+	}
+	if string(rc.RawConfig()) != `{"hello":"world"}` {
+		t.Fatalf("RawConfig: got %q want %q", string(rc.RawConfig()), `{"hello":"world"}`)
+	}
+	// Plugin's Name() still works through the wrapper.
+	if plugins[0].Name() != cfgName {
+		t.Fatalf("Name through wrapper: %q", plugins[0].Name())
+	}
+
+	// Second plugin (non-Configurable) must NOT be wrapped.
+	_, ok = plugins[1].(interface{ RawConfig() json.RawMessage })
+	if ok {
+		t.Fatal("non-Configurable plugin should NOT be wrapped")
 	}
 }

--- a/authbridge/authlib/sessionapi/server.go
+++ b/authbridge/authlib/sessionapi/server.go
@@ -104,12 +104,13 @@ func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
 
 // pipelinePluginView is the wire shape for one plugin in /v1/pipeline.
 type pipelinePluginView struct {
-	Name       string   `json:"name"`
-	Direction  string   `json:"direction"`
-	Position   int      `json:"position"` // 1-based order within its direction
-	BodyAccess bool     `json:"bodyAccess"`
-	Writes     []string `json:"writes,omitempty"`
-	Reads      []string `json:"reads,omitempty"`
+	Name       string          `json:"name"`
+	Direction  string          `json:"direction"`
+	Position   int             `json:"position"` // 1-based order within its direction
+	BodyAccess bool            `json:"bodyAccess"`
+	Writes     []string        `json:"writes,omitempty"`
+	Reads      []string        `json:"reads,omitempty"`
+	Config     json.RawMessage `json:"config,omitempty"`
 }
 
 // handlePipeline returns the composition of the inbound and outbound
@@ -139,7 +140,7 @@ func describePipeline(h *pipeline.Holder, direction string) []pipelinePluginView
 	out := make([]pipelinePluginView, len(plugins))
 	for i, pl := range plugins {
 		caps := pl.Capabilities()
-		out[i] = pipelinePluginView{
+		view := pipelinePluginView{
 			Name:       pl.Name(),
 			Direction:  direction,
 			Position:   i + 1,
@@ -147,6 +148,13 @@ func describePipeline(h *pipeline.Holder, direction string) []pipelinePluginView
 			Writes:     caps.Writes,
 			Reads:      caps.Reads,
 		}
+		// Surface raw config when the plugin was wrapped by the registry.
+		// Non-Configurable plugins type-assert false; Config stays nil and
+		// json.Marshal omits it via omitempty.
+		if rc, ok := pl.(interface{ RawConfig() json.RawMessage }); ok {
+			view.Config = rc.RawConfig()
+		}
+		out[i] = view
 	}
 	return out
 }

--- a/authbridge/authlib/sessionapi/server.go
+++ b/authbridge/authlib/sessionapi/server.go
@@ -149,9 +149,16 @@ func describePipeline(h *pipeline.Holder, direction string) []pipelinePluginView
 			Reads:      caps.Reads,
 		}
 		// Surface raw config when the plugin was wrapped by the registry.
-		// Non-Configurable plugins type-assert false; Config stays nil and
-		// json.Marshal omits it via omitempty.
-		if rc, ok := pl.(interface{ RawConfig() json.RawMessage }); ok {
+		// Non-Configurable plugins don't satisfy RawConfigProvider; Config
+		// stays nil and json.Marshal omits it via omitempty.
+		//
+		// Trust note: bytes are emitted verbatim. The framework convention
+		// is that secrets live behind *_file paths, never inline (mirrors
+		// the policy at :9093/config). This endpoint is in-cluster only;
+		// a regex-based redaction layer would be illusory given how many
+		// secret-like field names exist in practice. Enforce no-inline-
+		// secrets at config-review time instead.
+		if rc, ok := pl.(pipeline.RawConfigProvider); ok {
 			view.Config = rc.RawConfig()
 		}
 		out[i] = view

--- a/authbridge/authlib/sessionapi/server_test.go
+++ b/authbridge/authlib/sessionapi/server_test.go
@@ -366,6 +366,65 @@ func TestHandlePipeline_NilPipelines(t *testing.T) {
 	}
 }
 
+// TestHandlePipelineSurfacesConfig verifies that the Config field on
+// /v1/pipeline carries each Configurable plugin's raw config bytes
+// (when wrapped by the registry's WrapConfigured), and that
+// non-Configurable plugins emit no Config field.
+func TestHandlePipelineSurfacesConfig(t *testing.T) {
+	configRaw := json.RawMessage(`{"hello":"world"}`)
+	wrapped := pipeline.WrapConfigured(&fakePlugin{name: "with-config"}, configRaw)
+	plain := &fakePlugin{name: "without-config"}
+
+	inbound, err := pipeline.New([]pipeline.Plugin{wrapped, plain})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store := session.New(5*time.Minute, 100, 0)
+	defer store.Close()
+	srv := New(":0", store, WithPipelines(pipeline.NewHolder(inbound), nil))
+	ts := httptest.NewServer(srv.server.Handler)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/v1/pipeline")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var body struct {
+		Inbound []struct {
+			Name   string          `json:"name"`
+			Config json.RawMessage `json:"config,omitempty"`
+		} `json:"inbound"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Inbound) != 2 {
+		t.Fatalf("want 2 plugins, got %d", len(body.Inbound))
+	}
+	for _, p := range body.Inbound {
+		switch p.Name {
+		case "with-config":
+			if string(p.Config) != `{"hello":"world"}` {
+				t.Fatalf("with-config Config: got %q want %q",
+					string(p.Config), `{"hello":"world"}`)
+			}
+		case "without-config":
+			if len(p.Config) != 0 {
+				t.Fatalf("without-config should emit no Config, got %q",
+					string(p.Config))
+			}
+		default:
+			t.Fatalf("unexpected plugin name: %q", p.Name)
+		}
+	}
+}
+
 func TestHandleHealthz(t *testing.T) {
 	ts, _ := newTestServer(t)
 	resp, err := http.Get(ts.URL + "/healthz")

--- a/authbridge/cmd/abctl/apiclient/client.go
+++ b/authbridge/cmd/abctl/apiclient/client.go
@@ -83,12 +83,13 @@ type PipelineView struct {
 // PipelinePlugin describes one plugin's position, direction, and
 // capabilities. Mirrors the server's pipelinePluginView exactly.
 type PipelinePlugin struct {
-	Name       string   `json:"name"`
-	Direction  string   `json:"direction"`
-	Position   int      `json:"position"`
-	BodyAccess bool     `json:"bodyAccess"`
-	Writes     []string `json:"writes"`
-	Reads      []string `json:"reads"`
+	Name       string          `json:"name"`
+	Direction  string          `json:"direction"`
+	Position   int             `json:"position"`
+	BodyAccess bool            `json:"bodyAccess"`
+	Writes     []string        `json:"writes"`
+	Reads      []string        `json:"reads"`
+	Config     json.RawMessage `json:"config,omitempty"`
 }
 
 // GetPipeline fetches /v1/pipeline.

--- a/authbridge/cmd/abctl/apiclient/client_test.go
+++ b/authbridge/cmd/abctl/apiclient/client_test.go
@@ -107,3 +107,42 @@ func TestGetPipeline(t *testing.T) {
 		t.Errorf("inbound[1].Writes = %v, want [a2a]", got.Inbound[1].Writes)
 	}
 }
+
+// TestPipelinePluginDecodesConfig verifies the new Config field on
+// /v1/pipeline survives JSON round-trip through PipelinePlugin.
+func TestPipelinePluginDecodesConfig(t *testing.T) {
+	body := `{"inbound":[
+	  {"name":"with-config","direction":"inbound","position":1,"bodyAccess":false,
+	   "config":{"hello":"world"}},
+	  {"name":"without-config","direction":"inbound","position":2,"bodyAccess":false}
+	],"outbound":[]}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/pipeline" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL)
+	view, err := c.GetPipeline(context.Background())
+	if err != nil {
+		t.Fatalf("GetPipeline: %v", err)
+	}
+	if len(view.Inbound) != 2 {
+		t.Fatalf("want 2 inbound, got %d", len(view.Inbound))
+	}
+	// First plugin: Config decoded.
+	if string(view.Inbound[0].Config) != `{"hello":"world"}` {
+		t.Fatalf("with-config Config: got %q want %q",
+			string(view.Inbound[0].Config), `{"hello":"world"}`)
+	}
+	// Second plugin: Config absent → empty/nil.
+	if len(view.Inbound[1].Config) != 0 {
+		t.Fatalf("without-config Config should be empty, got %q",
+			string(view.Inbound[1].Config))
+	}
+}

--- a/authbridge/cmd/abctl/tui/plugin_detail_pane.go
+++ b/authbridge/cmd/abctl/tui/plugin_detail_pane.go
@@ -31,11 +31,15 @@ func (m *model) showPluginDetail(p *apiclient.PipelinePlugin) {
 	fmt.Fprintf(&b, "%s %s\n", styleMuted.Render("Body:     "), body)
 	fmt.Fprintf(&b, "%s %d events in cached sessions\n", styleMuted.Render("Activity: "), counts[p.Name])
 	fmt.Fprintln(&b)
-	b.WriteString(styleMuted.Render("Config:    "))
+	// Always-newline format keeps the visual layout consistent whether
+	// the plugin is Configurable (JSON body, multi-line) or not ("(none)",
+	// single line). Earlier inline-(none) variant caused jitter when
+	// navigating between plugins with and without config.
+	b.WriteString(styleMuted.Render("Config:"))
+	b.WriteString("\n")
 	if len(p.Config) == 0 {
-		b.WriteString(" (none)\n")
+		b.WriteString("  (none)\n")
 	} else {
-		b.WriteString("\n")
 		b.WriteString(ColorizeJSONBytes(p.Config))
 		b.WriteString("\n")
 	}

--- a/authbridge/cmd/abctl/tui/plugin_detail_pane.go
+++ b/authbridge/cmd/abctl/tui/plugin_detail_pane.go
@@ -31,7 +31,14 @@ func (m *model) showPluginDetail(p *apiclient.PipelinePlugin) {
 	fmt.Fprintf(&b, "%s %s\n", styleMuted.Render("Body:     "), body)
 	fmt.Fprintf(&b, "%s %d events in cached sessions\n", styleMuted.Render("Activity: "), counts[p.Name])
 	fmt.Fprintln(&b)
-	b.WriteString(styleHint.Render("(per-plugin runtime config will be added when the Plugin interface\nexposes a Config() method — tracked as a follow-up.)"))
+	b.WriteString(styleMuted.Render("Config:    "))
+	if len(p.Config) == 0 {
+		b.WriteString(" (none)\n")
+	} else {
+		b.WriteString("\n")
+		b.WriteString(ColorizeJSONBytes(p.Config))
+		b.WriteString("\n")
+	}
 
 	m.detailVp.SetContent(b.String())
 	m.detailVp.GotoTop()

--- a/authbridge/cmd/abctl/tui/plugin_detail_pane_test.go
+++ b/authbridge/cmd/abctl/tui/plugin_detail_pane_test.go
@@ -1,0 +1,56 @@
+package tui
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/kagenti/kagenti-extensions/authbridge/cmd/abctl/apiclient"
+)
+
+func TestShowPluginDetailRendersConfig(t *testing.T) {
+	m := newPickerModel(context.Background(), nil, nil)
+	// The viewport defaults to 0×0 (sized by layout() on WindowSizeMsg);
+	// in unit tests we set it manually so View() returns content.
+	m.detailVp.Width = 80
+	m.detailVp.Height = 20
+	plugin := &apiclient.PipelinePlugin{
+		Name:      "jwt-validation",
+		Direction: "inbound",
+		Position:  1,
+		Writes:    []string{"security"},
+		Config:    json.RawMessage(`{"issuer":"http://idp"}`),
+	}
+	m.showPluginDetail(plugin)
+	view := m.detailVp.View()
+	if !strings.Contains(view, "Config:") {
+		t.Fatalf("rendered view missing Config section:\n%s", view)
+	}
+	if !strings.Contains(view, "issuer") {
+		t.Fatalf("rendered view missing config key:\n%s", view)
+	}
+	if !strings.Contains(view, "http://idp") {
+		t.Fatalf("rendered view missing config value:\n%s", view)
+	}
+}
+
+func TestShowPluginDetailRendersNoneForEmptyConfig(t *testing.T) {
+	m := newPickerModel(context.Background(), nil, nil)
+	m.detailVp.Width = 80
+	m.detailVp.Height = 20
+	plugin := &apiclient.PipelinePlugin{
+		Name:      "non-configurable",
+		Direction: "inbound",
+		Position:  1,
+		Config:    nil,
+	}
+	m.showPluginDetail(plugin)
+	view := m.detailVp.View()
+	if !strings.Contains(view, "Config:") {
+		t.Fatalf("rendered view missing Config section:\n%s", view)
+	}
+	if !strings.Contains(view, "(none)") {
+		t.Fatalf("rendered view should say (none) for empty Config:\n%s", view)
+	}
+}

--- a/authbridge/cmd/abctl/tui/plugin_detail_pane_test.go
+++ b/authbridge/cmd/abctl/tui/plugin_detail_pane_test.go
@@ -54,3 +54,36 @@ func TestShowPluginDetailRendersNoneForEmptyConfig(t *testing.T) {
 		t.Fatalf("rendered view should say (none) for empty Config:\n%s", view)
 	}
 }
+
+// TestShowPluginDetailHandlesMalformedConfig verifies the TUI degrades
+// gracefully when Config bytes are not valid JSON. The server should
+// never produce malformed bytes (Configure() validates), but corruption
+// in transit isn't impossible — we lock the contract that the renderer
+// writes *something* without panicking.
+func TestShowPluginDetailHandlesMalformedConfig(t *testing.T) {
+	m := newPickerModel(context.Background(), nil, nil)
+	m.detailVp.Width = 80
+	m.detailVp.Height = 20
+	plugin := &apiclient.PipelinePlugin{
+		Name:      "broken",
+		Direction: "inbound",
+		Position:  1,
+		Config:    json.RawMessage(`{not valid`),
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("showPluginDetail panicked on malformed JSON: %v", r)
+		}
+	}()
+	m.showPluginDetail(plugin)
+	view := m.detailVp.View()
+	if !strings.Contains(view, "Config:") {
+		t.Fatalf("rendered view missing Config section:\n%s", view)
+	}
+	// ColorizeJSONBytes' fallback is to render the raw bytes as a muted
+	// string. We don't assert exact escape-code output (style-dependent),
+	// but the literal "{not" should appear somewhere.
+	if !strings.Contains(view, "{not") {
+		t.Fatalf("rendered view missing raw config fallback:\n%s", view)
+	}
+}

--- a/authbridge/docs/superpowers/plans/2026-05-28-abctl-plugin-config.md
+++ b/authbridge/docs/superpowers/plans/2026-05-28-abctl-plugin-config.md
@@ -120,7 +120,7 @@ func TestConfiguredPluginPassesThroughPluginMethods(t *testing.T) {
 
 Run:
 ```bash
-cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions/authbridge
+cd authbridge
 go test ./authlib/pipeline/ -run TestConfiguredPlugin -v
 ```
 Expected: build failure — `wrapConfigured` undefined.
@@ -171,7 +171,7 @@ Note: the `context` import isn't used yet — Go will reject unused imports. Dro
 
 Run:
 ```bash
-cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions/authbridge
+cd authbridge
 go test ./authlib/pipeline/ -run TestConfiguredPlugin -v
 go vet ./authlib/pipeline/
 ```
@@ -180,7 +180,7 @@ Expected: both tests PASS, vet clean.
 - [ ] **Step 5: Commit**
 
 ```bash
-cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions
+# (run from repo root)
 git add authbridge/authlib/pipeline/configured.go authbridge/authlib/pipeline/configured_test.go
 git commit -s -m "feat(authlib): Add configuredPlugin wrapper retaining raw config
 
@@ -360,7 +360,7 @@ func TestConfiguredPluginReadyDefaultsTrueForNonReadier(t *testing.T) {
 
 Run:
 ```bash
-cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions/authbridge
+cd authbridge
 go test ./authlib/pipeline/ -run TestConfiguredPlugin -v
 ```
 Expected: existing two tests still PASS, eight new tests FAIL with "wrapper should implement X" errors.
@@ -425,7 +425,7 @@ import (
 
 Run:
 ```bash
-cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions/authbridge
+cd authbridge
 go test ./authlib/pipeline/ -run TestConfiguredPlugin -v
 go vet ./authlib/pipeline/
 ```
@@ -440,7 +440,7 @@ Expected: all tests PASS.
 - [ ] **Step 5: Commit**
 
 ```bash
-cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions
+# (run from repo root)
 git add authbridge/authlib/pipeline/configured.go authbridge/authlib/pipeline/configured_test.go
 git commit -s -m "feat(authlib): Forward optional plugin interfaces in configuredPlugin
 
@@ -549,7 +549,7 @@ If `encoding/json` isn't yet imported in `registry_test.go`, add it. The other i
 
 Run:
 ```bash
-cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions/authbridge
+cd authbridge
 go test ./authlib/plugins/ -run TestRegistryWrapsConfigurablePluginsForRawConfig -v
 ```
 Expected: FAIL — the test asserts `RawConfig` type-assertion succeeds for the Configurable plugin, but Build doesn't wrap yet, so the assertion fails on the first plugin.
@@ -581,8 +581,8 @@ In `authbridge/authlib/pipeline/configured_test.go`, find/replace every `wrapCon
 
 ```bash
 sed -i.bak 's/wrapConfigured(/WrapConfigured(/g' \
-  /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions/authbridge/authlib/pipeline/configured_test.go
-rm /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions/authbridge/authlib/pipeline/configured_test.go.bak
+  authbridge/authlib/pipeline/configured_test.go
+rm authbridge/authlib/pipeline/configured_test.go.bak
 ```
 
 - [ ] **Step 4: Implement — wrap in Build and BuildWithSPIFFE**
@@ -649,7 +649,7 @@ Becomes:
 
 Run:
 ```bash
-cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions/authbridge
+cd authbridge
 go test ./authlib/...
 go vet ./authlib/...
 ```
@@ -662,7 +662,7 @@ If the new test fails because the non-Configurable plugin's type-assert succeeds
 - [ ] **Step 6: Commit**
 
 ```bash
-cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions
+# (run from repo root)
 git add authbridge/authlib/pipeline/configured.go authbridge/authlib/pipeline/configured_test.go authbridge/authlib/plugins/registry.go authbridge/authlib/plugins/registry_test.go
 git commit -s -m "feat(authlib): Wrap Configurable plugins in the registry
 
@@ -759,7 +759,7 @@ func TestHandlePipelineSurfacesConfig(t *testing.T) {
 
 Run:
 ```bash
-cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions/authbridge
+cd authbridge
 go test ./authlib/sessionapi/ -run TestHandlePipelineSurfacesConfig -v
 ```
 Expected: FAIL — the response body has no `config` field, so the assertion `string(p.Config) != ""` fires for the Configurable plugin.
@@ -815,7 +815,7 @@ func describePipeline(h *pipeline.Holder, direction string) []pipelinePluginView
 
 Run:
 ```bash
-cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions/authbridge
+cd authbridge
 go test ./authlib/sessionapi/ -v
 go vet ./authlib/sessionapi/
 ```
@@ -824,7 +824,7 @@ Expected: all tests PASS including `TestHandlePipelineSurfacesConfig` and the ex
 - [ ] **Step 5: Commit**
 
 ```bash
-cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions
+# (run from repo root)
 git add authbridge/authlib/sessionapi/server.go authbridge/authlib/sessionapi/server_test.go
 git commit -s -m "feat(sessionapi): Surface plugin runtime config on /v1/pipeline
 
@@ -897,7 +897,7 @@ func TestPipelinePluginDecodesConfig(t *testing.T) {
 
 Run:
 ```bash
-cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions/authbridge/cmd/abctl
+cd authbridge/cmd/abctl
 go test ./apiclient/ -run TestPipelinePluginDecodesConfig -v
 ```
 Expected: build failure — `view.Inbound[0].Config` is undefined on `PipelinePlugin`.
@@ -924,7 +924,7 @@ If `encoding/json` isn't imported in `client.go` yet (it likely is, but verify),
 
 Run:
 ```bash
-cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions/authbridge/cmd/abctl
+cd authbridge/cmd/abctl
 go test ./apiclient/ -v
 go vet ./apiclient/
 ```
@@ -933,7 +933,7 @@ Expected: all tests PASS including the new one, vet clean.
 - [ ] **Step 5: Commit**
 
 ```bash
-cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions
+# (run from repo root)
 git add authbridge/cmd/abctl/apiclient/client.go authbridge/cmd/abctl/apiclient/client_test.go
 git commit -s -m "feat(abctl): Decode Config field on PipelinePlugin
 
@@ -957,7 +957,7 @@ Replace the placeholder text in `plugin_detail_pane.go` with `ColorizeJSONBytes`
 
 Run:
 ```bash
-grep -l "showPluginDetail" /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions/authbridge/cmd/abctl/tui/*_test.go
+grep -l "showPluginDetail" authbridge/cmd/abctl/tui/*_test.go
 ```
 
 There may not be a dedicated test for `showPluginDetail` yet — `detail_pane_test.go` is the closest neighbor. If neither tests `showPluginDetail`, create `plugin_detail_pane_test.go`. The plan below assumes a new test file.
@@ -1030,7 +1030,7 @@ Add `"context"` to the imports if not already present.
 
 Run:
 ```bash
-cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions/authbridge/cmd/abctl
+cd authbridge/cmd/abctl
 go test ./tui/ -run TestShowPluginDetail -v
 ```
 Expected: tests FAIL — current `showPluginDetail` renders the placeholder text "(per-plugin runtime config will be added when..." instead of "Config: ...".
@@ -1064,7 +1064,7 @@ if len(p.Config) == 0 {
 
 Run:
 ```bash
-cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions/authbridge/cmd/abctl
+cd authbridge/cmd/abctl
 go test ./tui/
 go vet ./tui/
 go build ./...
@@ -1085,7 +1085,7 @@ go build -o ./abctl .
 - [ ] **Step 6: Commit**
 
 ```bash
-cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions
+# (run from repo root)
 git add authbridge/cmd/abctl/tui/plugin_detail_pane.go authbridge/cmd/abctl/tui/plugin_detail_pane_test.go
 git commit -s -m "feat(abctl): Render plugin runtime config in plugin-detail pane
 

--- a/authbridge/docs/superpowers/plans/2026-05-28-abctl-plugin-config.md
+++ b/authbridge/docs/superpowers/plans/2026-05-28-abctl-plugin-config.md
@@ -1,0 +1,1132 @@
+# Plugin Config in abctl Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the placeholder text in abctl's plugin-detail pane with each plugin's actual runtime config (post-`${VAR}` expansion), surfaced via a new optional field on `/v1/pipeline`.
+
+**Architecture:** The `pipeline` package gains a `configuredPlugin` wrapper that retains the raw JSON config bytes used to build a plugin. The wrapper forwards all five required + four optional Plugin interface methods so existing dispatchers continue to work unchanged. The `plugins` registry constructs the wrapper after a successful `Configure()`. `sessionapi/server.go` adds a `Config json.RawMessage` field to its pipeline view, populated via type-assertion. `abctl`'s apiclient mirrors the wire field; `plugin_detail_pane.go` renders it through the existing `ColorizeJSONBytes` helper.
+
+**Tech Stack:** Go 1.24, `encoding/json`, existing authlib pipeline + sessionapi infrastructure, existing abctl bubbletea TUI + JSON colorizer.
+
+**Spec:** [`docs/superpowers/specs/2026-05-28-abctl-plugin-config-design.md`](../specs/2026-05-28-abctl-plugin-config-design.md)
+
+---
+
+## File Structure
+
+**New files:**
+- `authbridge/authlib/pipeline/configured.go` — `configuredPlugin` wrapper struct, `RawConfig()` method, four optional-interface forwarding methods, package-level `wrapConfigured` constructor.
+- `authbridge/authlib/pipeline/configured_test.go` — wrapper tests: `RawConfig`, `Plugin` pass-through, forwarding for each of `Initializer`/`Shutdowner`/`Finisher`/`Readier`, no-op fallback for plugins that don't implement those.
+
+**Modified files:**
+- `authbridge/authlib/plugins/registry.go` — wrap Configurable plugins after successful `Configure()` at the two existing call sites.
+- `authbridge/authlib/plugins/registry_test.go` — verify a Configurable plugin built via the registry exposes `RawConfig()`; a non-Configurable one does not.
+- `authbridge/authlib/sessionapi/server.go` — add `Config json.RawMessage` to `pipelinePluginView`; populate via type-assertion in `describePipeline`.
+- `authbridge/authlib/sessionapi/server_test.go` — extend `TestHandlePipeline` to assert the `config` field round-trips for a Configurable plugin and is omitted for a non-Configurable one.
+- `authbridge/cmd/abctl/apiclient/client.go` — add `Config json.RawMessage` to `PipelinePlugin`.
+- `authbridge/cmd/abctl/apiclient/client_test.go` — extend the pipeline-decode test to assert `Config` round-trips.
+- `authbridge/cmd/abctl/tui/plugin_detail_pane.go` — replace the placeholder text with `ColorizeJSONBytes`-rendered config (or `(none)`).
+- `authbridge/cmd/abctl/tui/plugin_detail_pane_test.go` — extend the rendering test with both Config-set and Config-empty cases.
+
+**Convention notes:**
+- The `pipeline` package is a separate Go module (`authbridge/authlib/`); use `cd authbridge && go test ./authlib/...` for tests.
+- The `cmd/abctl/` package is a separate Go module; use `cd authbridge/cmd/abctl && go test ./...`.
+- Repo policy: DCO sign-off (`-s`), `Assisted-By` (NOT `Co-Authored-By`), conventional commit format.
+- Branch: work proceeds on a fresh branch off `upstream/main`. The branch already exists (`feat/abctl-plugin-config-spec`) with the design doc already committed (`ec24f3f`).
+
+---
+
+## Task 1: Wrapper struct + RawConfig + Plugin pass-through
+
+Build the wrapper with only the required `Plugin` interface methods + `RawConfig()`. The four optional interfaces come in Task 2.
+
+**Files:**
+- Create: `authbridge/authlib/pipeline/configured.go`
+- Create: `authbridge/authlib/pipeline/configured_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `authbridge/authlib/pipeline/configured_test.go`:
+
+```go
+package pipeline
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// fakePlugin is a minimal Plugin implementation for testing the wrapper.
+// It records call counts so pass-through can be asserted.
+type fakePlugin struct {
+	name      string
+	caps      PluginCapabilities
+	requests  int
+	responses int
+}
+
+func (f *fakePlugin) Name() string                  { return f.name }
+func (f *fakePlugin) Capabilities() PluginCapabilities { return f.caps }
+func (f *fakePlugin) OnRequest(ctx context.Context, pctx *Context) Action {
+	f.requests++
+	return Action{}
+}
+func (f *fakePlugin) OnResponse(ctx context.Context, pctx *Context) Action {
+	f.responses++
+	return Action{}
+}
+
+func TestConfiguredPluginRawConfig(t *testing.T) {
+	raw := json.RawMessage(`{"issuer":"http://idp"}`)
+	cp := wrapConfigured(&fakePlugin{name: "jwt-validation"}, raw)
+	rc, ok := cp.(interface{ RawConfig() json.RawMessage })
+	if !ok {
+		t.Fatal("wrapper should expose RawConfig() via type-assertion")
+	}
+	got := string(rc.RawConfig())
+	if got != `{"issuer":"http://idp"}` {
+		t.Fatalf("RawConfig: %q want %q", got, `{"issuer":"http://idp"}`)
+	}
+}
+
+func TestConfiguredPluginPassesThroughPluginMethods(t *testing.T) {
+	fake := &fakePlugin{
+		name: "jwt-validation",
+		caps: PluginCapabilities{Reads: []string{"a"}, Writes: []string{"security"}},
+	}
+	cp := wrapConfigured(fake, json.RawMessage(`{}`))
+
+	if cp.Name() != "jwt-validation" {
+		t.Fatalf("Name pass-through broken: %q", cp.Name())
+	}
+	caps := cp.Capabilities()
+	if len(caps.Reads) != 1 || caps.Reads[0] != "a" {
+		t.Fatalf("Capabilities pass-through broken: %+v", caps)
+	}
+	if len(caps.Writes) != 1 || caps.Writes[0] != "security" {
+		t.Fatalf("Capabilities pass-through broken: %+v", caps)
+	}
+	cp.OnRequest(context.Background(), nil)
+	cp.OnResponse(context.Background(), nil)
+	if fake.requests != 1 || fake.responses != 1 {
+		t.Fatalf("OnRequest/OnResponse pass-through broken: req=%d resp=%d",
+			fake.requests, fake.responses)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail (compile error)**
+
+Run:
+```bash
+cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions/authbridge
+go test ./authlib/pipeline/ -run TestConfiguredPlugin -v
+```
+Expected: build failure — `wrapConfigured` undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `authbridge/authlib/pipeline/configured.go`:
+
+```go
+package pipeline
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// configuredPlugin wraps a plugin built via Configurable.Configure with the
+// raw config bytes it was constructed from, so the session API can surface
+// them on /v1/pipeline. All Plugin interface methods forward to the embedded
+// plugin — zero observable behavior change at the request hot path.
+//
+// Optional plugin interfaces (Initializer, Shutdowner, Finisher, Readier)
+// are NOT promoted through the embedded Plugin interface — Go does not
+// promote method-set membership through an embedded interface. The wrapper
+// implements each of those four interfaces explicitly and forwards
+// conditionally; see the methods below.
+type configuredPlugin struct {
+	Plugin
+	raw json.RawMessage
+}
+
+// wrapConfigured returns a Plugin whose dynamic type is *configuredPlugin.
+// Callers (registry.Build) invoke this only after Configurable.Configure
+// returns nil; non-Configurable plugins pass through unwrapped.
+func wrapConfigured(p Plugin, raw json.RawMessage) Plugin {
+	return &configuredPlugin{Plugin: p, raw: raw}
+}
+
+// RawConfig returns the raw config bytes the wrapped plugin was configured
+// with. Used by sessionapi describePipeline to populate /v1/pipeline's
+// Config field.
+func (c *configuredPlugin) RawConfig() json.RawMessage { return c.raw }
+```
+
+Note: the `context` import isn't used yet — Go will reject unused imports. Drop it for now and re-add in Task 2 when forwarding methods need it. Or simply omit it from the import block until Task 2.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions/authbridge
+go test ./authlib/pipeline/ -run TestConfiguredPlugin -v
+go vet ./authlib/pipeline/
+```
+Expected: both tests PASS, vet clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions
+git add authbridge/authlib/pipeline/configured.go authbridge/authlib/pipeline/configured_test.go
+git commit -s -m "feat(authlib): Add configuredPlugin wrapper retaining raw config
+
+The wrapper holds a json.RawMessage alongside an embedded Plugin so the
+session API can surface per-plugin runtime config on /v1/pipeline.
+Plugin interface methods (Name, Capabilities, OnRequest, OnResponse)
+pass through via embedding. The four optional interfaces are added in
+the next commit.
+
+Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Optional interface forwarding
+
+Add explicit forwarding for `Initializer`, `Shutdowner`, `Finisher`, `Readier` so the framework dispatchers (which type-assert against these) continue to work for wrapped plugins.
+
+**Files:**
+- Modify: `authbridge/authlib/pipeline/configured.go` — append four forwarding methods.
+- Modify: `authbridge/authlib/pipeline/configured_test.go` — append forwarding + no-op tests.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `authbridge/authlib/pipeline/configured_test.go`:
+
+```go
+// fakeInitializer extends fakePlugin with Initializer.
+type fakeInitializer struct {
+	fakePlugin
+	initCalls int
+	initErr   error
+}
+
+func (f *fakeInitializer) Init(ctx context.Context) error {
+	f.initCalls++
+	return f.initErr
+}
+
+// fakeShutdowner extends fakePlugin with Shutdowner.
+type fakeShutdowner struct {
+	fakePlugin
+	shutdownCalls int
+}
+
+func (f *fakeShutdowner) Shutdown(ctx context.Context) error {
+	f.shutdownCalls++
+	return nil
+}
+
+// fakeFinisher extends fakePlugin with Finisher.
+type fakeFinisher struct {
+	fakePlugin
+	finishCalls int
+}
+
+func (f *fakeFinisher) OnFinish(ctx context.Context, pctx *Context) {
+	f.finishCalls++
+}
+
+// fakeReadier extends fakePlugin with Readier.
+type fakeReadier struct {
+	fakePlugin
+	ready bool
+}
+
+func (f *fakeReadier) Ready() bool { return f.ready }
+
+func TestConfiguredPluginForwardsInit(t *testing.T) {
+	fake := &fakeInitializer{fakePlugin: fakePlugin{name: "x"}}
+	cp := wrapConfigured(fake, nil)
+	init, ok := cp.(Initializer)
+	if !ok {
+		t.Fatal("wrapper should implement Initializer (unconditional forwarding)")
+	}
+	if err := init.Init(context.Background()); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if fake.initCalls != 1 {
+		t.Fatalf("Init not forwarded: calls=%d want 1", fake.initCalls)
+	}
+}
+
+func TestConfiguredPluginInitNoOpForNonInitializer(t *testing.T) {
+	cp := wrapConfigured(&fakePlugin{name: "x"}, nil)
+	init, ok := cp.(Initializer)
+	if !ok {
+		t.Fatal("wrapper always implements Initializer")
+	}
+	if err := init.Init(context.Background()); err != nil {
+		t.Fatalf("no-op Init should return nil, got %v", err)
+	}
+}
+
+func TestConfiguredPluginForwardsShutdown(t *testing.T) {
+	fake := &fakeShutdowner{fakePlugin: fakePlugin{name: "x"}}
+	cp := wrapConfigured(fake, nil)
+	sh, ok := cp.(Shutdowner)
+	if !ok {
+		t.Fatal("wrapper should implement Shutdowner")
+	}
+	if err := sh.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	if fake.shutdownCalls != 1 {
+		t.Fatalf("Shutdown not forwarded: calls=%d want 1", fake.shutdownCalls)
+	}
+}
+
+func TestConfiguredPluginShutdownNoOpForNonShutdowner(t *testing.T) {
+	cp := wrapConfigured(&fakePlugin{name: "x"}, nil)
+	sh, ok := cp.(Shutdowner)
+	if !ok {
+		t.Fatal("wrapper always implements Shutdowner")
+	}
+	if err := sh.Shutdown(context.Background()); err != nil {
+		t.Fatalf("no-op Shutdown should return nil, got %v", err)
+	}
+}
+
+func TestConfiguredPluginForwardsFinish(t *testing.T) {
+	fake := &fakeFinisher{fakePlugin: fakePlugin{name: "x"}}
+	cp := wrapConfigured(fake, nil)
+	fin, ok := cp.(Finisher)
+	if !ok {
+		t.Fatal("wrapper should implement Finisher")
+	}
+	fin.OnFinish(context.Background(), nil)
+	if fake.finishCalls != 1 {
+		t.Fatalf("OnFinish not forwarded: calls=%d want 1", fake.finishCalls)
+	}
+}
+
+func TestConfiguredPluginFinishNoOpForNonFinisher(t *testing.T) {
+	cp := wrapConfigured(&fakePlugin{name: "x"}, nil)
+	fin, ok := cp.(Finisher)
+	if !ok {
+		t.Fatal("wrapper always implements Finisher")
+	}
+	// Should not panic.
+	fin.OnFinish(context.Background(), nil)
+}
+
+func TestConfiguredPluginForwardsReady(t *testing.T) {
+	// Plugin that reports not-ready: wrapper must report not-ready too.
+	fake := &fakeReadier{fakePlugin: fakePlugin{name: "x"}, ready: false}
+	cp := wrapConfigured(fake, nil)
+	r, ok := cp.(Readier)
+	if !ok {
+		t.Fatal("wrapper should implement Readier")
+	}
+	if r.Ready() {
+		t.Fatal("Ready should forward false from underlying plugin")
+	}
+	// Now set ready=true; wrapper reflects.
+	fake.ready = true
+	if !r.Ready() {
+		t.Fatal("Ready should forward true from underlying plugin")
+	}
+}
+
+func TestConfiguredPluginReadyDefaultsTrueForNonReadier(t *testing.T) {
+	// Matches the existing Pipeline.Ready() semantics: plugins without
+	// Readier are considered always-ready (pipeline.go:287-289).
+	cp := wrapConfigured(&fakePlugin{name: "x"}, nil)
+	r, ok := cp.(Readier)
+	if !ok {
+		t.Fatal("wrapper always implements Readier")
+	}
+	if !r.Ready() {
+		t.Fatal("non-Readier wrapped plugin should default to ready=true")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+```bash
+cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions/authbridge
+go test ./authlib/pipeline/ -run TestConfiguredPlugin -v
+```
+Expected: existing two tests still PASS, eight new tests FAIL with "wrapper should implement X" errors.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `authbridge/authlib/pipeline/configured.go` (and update the import block to include `"context"`):
+
+```go
+// Init forwards to the wrapped plugin if it implements Initializer; otherwise
+// returns nil (no deferred initialization). Required because Initializer is
+// not declared on the Plugin interface, so the embedded Plugin's Init method
+// (if any) is NOT promoted to *configuredPlugin's method set — only methods
+// declared on Plugin are. Without this explicit forwarding, the framework's
+// Init dispatcher would silently skip wrapped plugins.
+func (c *configuredPlugin) Init(ctx context.Context) error {
+	if init, ok := c.Plugin.(Initializer); ok {
+		return init.Init(ctx)
+	}
+	return nil
+}
+
+// Shutdown forwards to the wrapped plugin if it implements Shutdowner; otherwise
+// returns nil (no resources to release).
+func (c *configuredPlugin) Shutdown(ctx context.Context) error {
+	if sh, ok := c.Plugin.(Shutdowner); ok {
+		return sh.Shutdown(ctx)
+	}
+	return nil
+}
+
+// OnFinish forwards to the wrapped plugin if it implements Finisher; otherwise
+// no-ops. The framework's OnFinish dispatcher type-asserts against Finisher,
+// so wrapped plugins must implement it explicitly to participate.
+func (c *configuredPlugin) OnFinish(ctx context.Context, pctx *Context) {
+	if fin, ok := c.Plugin.(Finisher); ok {
+		fin.OnFinish(ctx, pctx)
+	}
+}
+
+// Ready forwards to the wrapped plugin if it implements Readier; otherwise
+// returns true. This matches the existing semantics in Pipeline.Ready
+// (pipeline.go:287-289): plugins without Readier are considered always-ready.
+func (c *configuredPlugin) Ready() bool {
+	if r, ok := c.Plugin.(Readier); ok {
+		return r.Ready()
+	}
+	return true
+}
+```
+
+The import block at the top of `configured.go` becomes:
+
+```go
+import (
+	"context"
+	"encoding/json"
+)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions/authbridge
+go test ./authlib/pipeline/ -run TestConfiguredPlugin -v
+go vet ./authlib/pipeline/
+```
+Expected: all 10 wrapper tests PASS, vet clean.
+
+Also run the full pipeline package to verify no regression:
+```bash
+go test ./authlib/pipeline/
+```
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions
+git add authbridge/authlib/pipeline/configured.go authbridge/authlib/pipeline/configured_test.go
+git commit -s -m "feat(authlib): Forward optional plugin interfaces in configuredPlugin
+
+Initializer/Shutdowner/Finisher/Readier are not declared on the Plugin
+interface, so methods on the embedded Plugin's concrete type aren't
+promoted to *configuredPlugin's method set — Go only promotes methods
+declared on the embedded interface. The framework's dispatchers
+type-assert against these four interfaces, so without explicit
+forwarding they would silently skip every wrapped plugin.
+
+Each forwarding method conditionally invokes the wrapped plugin's
+implementation if it has one, else no-ops with the documented default
+(nil error / no-op call / Ready=true). End-to-end behavior is identical
+to the pre-wrap world; only the dispatch chain grows by one frame.
+
+Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Registry wraps Configurable plugins
+
+Hook the wrapper into the two existing `Configure()` call sites in `plugins/registry.go` so every Configurable plugin built via the registry gets wrapped. Promote `wrapConfigured` → `WrapConfigured` so the cross-package call works.
+
+**Files:**
+- Modify: `authbridge/authlib/pipeline/configured.go` — rename `wrapConfigured` to `WrapConfigured` (export).
+- Modify: `authbridge/authlib/pipeline/configured_test.go` — update test references.
+- Modify: `authbridge/authlib/plugins/registry.go` — wrap after Configure success at the two call sites in `Build` (line 119) and `BuildWithSPIFFE` (line 167).
+- Modify: `authbridge/authlib/plugins/registry_test.go` — append `TestRegistryWrapsConfigurablePluginsForRawConfig`.
+
+- [ ] **Step 1: Write the failing test**
+
+The existing `registry_test.go` registers test plugins via `RegisterPlugin(name, factory)` and builds via `Build([]config.PluginEntry{...})`. It defines a non-Configurable test plugin `relPlugin` (lines 109-128). We extend it with a Configurable variant.
+
+Append to `authbridge/authlib/plugins/registry_test.go`:
+
+```go
+// cfgPlugin is a Configurable wrapper around relPlugin used to verify
+// that the registry wraps Configurable plugins in pipeline.WrapConfigured
+// and that non-Configurable plugins (relPlugin alone) are NOT wrapped.
+type cfgPlugin struct {
+	relPlugin
+	configured json.RawMessage
+}
+
+func (c *cfgPlugin) Configure(raw json.RawMessage) error {
+	c.configured = raw
+	return nil
+}
+
+// TestRegistryWrapsConfigurablePluginsForRawConfig verifies that plugins
+// built through Build expose their raw config bytes via type-assertion
+// to interface{ RawConfig() json.RawMessage }. This is the contract
+// /v1/pipeline relies on.
+func TestRegistryWrapsConfigurablePluginsForRawConfig(t *testing.T) {
+	// Register a Configurable plugin and a non-Configurable plugin under
+	// throwaway names so this test doesn't fight the global registry.
+	cfgName := "rawcfg-test-configurable"
+	relName := "rawcfg-test-relational"
+	RegisterPlugin(cfgName, func() pipeline.Plugin {
+		return &cfgPlugin{relPlugin: relPlugin{name: cfgName}}
+	})
+	defer UnregisterPlugin(cfgName)
+	RegisterPlugin(relName, func() pipeline.Plugin {
+		return &relPlugin{name: relName}
+	})
+	defer UnregisterPlugin(relName)
+
+	configRaw := json.RawMessage(`{"hello":"world"}`)
+	pipe, err := Build([]config.PluginEntry{
+		{Name: cfgName, Config: configRaw},
+		{Name: relName},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	plugins := pipe.Plugins()
+	if len(plugins) != 2 {
+		t.Fatalf("want 2 plugins, got %d", len(plugins))
+	}
+
+	// First plugin (Configurable) should expose RawConfig().
+	rc, ok := plugins[0].(interface{ RawConfig() json.RawMessage })
+	if !ok {
+		t.Fatal("Configurable plugin should be wrapped (RawConfig type-assert)")
+	}
+	if string(rc.RawConfig()) != `{"hello":"world"}` {
+		t.Fatalf("RawConfig: got %q want %q", string(rc.RawConfig()), `{"hello":"world"}`)
+	}
+	// Plugin's Name() still works through the wrapper.
+	if plugins[0].Name() != cfgName {
+		t.Fatalf("Name through wrapper: %q", plugins[0].Name())
+	}
+
+	// Second plugin (non-Configurable) must NOT be wrapped.
+	_, ok = plugins[1].(interface{ RawConfig() json.RawMessage })
+	if ok {
+		t.Fatal("non-Configurable plugin should NOT be wrapped")
+	}
+}
+```
+
+If `encoding/json` isn't yet imported in `registry_test.go`, add it. The other imports (`config`, `pipeline`, `testing`) are already there.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions/authbridge
+go test ./authlib/plugins/ -run TestRegistryWrapsConfigurablePluginsForRawConfig -v
+```
+Expected: FAIL — the test asserts `RawConfig` type-assertion succeeds for the Configurable plugin, but Build doesn't wrap yet, so the assertion fails on the first plugin.
+
+It may also fail to compile if `pipeline.WrapConfigured` is referenced (it isn't in this test, since we type-assert through an interface literal). Should compile cleanly and just fail at the assertion.
+
+- [ ] **Step 3: Implement — promote `wrapConfigured` to `WrapConfigured`**
+
+In `authbridge/authlib/pipeline/configured.go`, rename the function:
+
+```go
+// Before:
+func wrapConfigured(p Plugin, raw json.RawMessage) Plugin {
+	return &configuredPlugin{Plugin: p, raw: raw}
+}
+
+// After:
+// WrapConfigured returns a Plugin whose dynamic type retains the raw
+// config bytes the plugin was built from, so the session API can
+// surface them on /v1/pipeline. Callers (plugins.Build) invoke this
+// only after Configurable.Configure returns nil; non-Configurable
+// plugins pass through unwrapped.
+func WrapConfigured(p Plugin, raw json.RawMessage) Plugin {
+	return &configuredPlugin{Plugin: p, raw: raw}
+}
+```
+
+In `authbridge/authlib/pipeline/configured_test.go`, find/replace every `wrapConfigured(` with `WrapConfigured(`:
+
+```bash
+sed -i.bak 's/wrapConfigured(/WrapConfigured(/g' \
+  /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions/authbridge/authlib/pipeline/configured_test.go
+rm /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions/authbridge/authlib/pipeline/configured_test.go.bak
+```
+
+- [ ] **Step 4: Implement — wrap in Build and BuildWithSPIFFE**
+
+In `authbridge/authlib/plugins/registry.go`, modify `Build` (around line 117-122). The current code:
+
+```go
+		p := factory()
+		if c, ok := p.(pipeline.Configurable); ok {
+			if err := c.Configure(e.Config); err != nil {
+				return nil, fmt.Errorf("configure %q: %w", e.Name, err)
+			}
+		} else if len(e.Config) > 0 {
+			return nil, fmt.Errorf("plugin %q does not accept configuration", e.Name)
+		}
+		ps = append(ps, p)
+```
+
+Becomes:
+
+```go
+		p := factory()
+		if c, ok := p.(pipeline.Configurable); ok {
+			if err := c.Configure(e.Config); err != nil {
+				return nil, fmt.Errorf("configure %q: %w", e.Name, err)
+			}
+			// Wrap so the session API can surface the raw config on /v1/pipeline.
+			p = pipeline.WrapConfigured(p, e.Config)
+		} else if len(e.Config) > 0 {
+			return nil, fmt.Errorf("plugin %q does not accept configuration", e.Name)
+		}
+		ps = append(ps, p)
+```
+
+In the same file, modify `BuildWithSPIFFE` (around line 165-172). The local var there is named `plugin`, not `p`. The current code:
+
+```go
+		if c, ok := plugin.(pipeline.Configurable); ok {
+			if err := c.Configure(e.Config); err != nil {
+				return nil, fmt.Errorf("configure %q: %w", e.Name, err)
+			}
+		} else if len(e.Config) > 0 {
+			return nil, fmt.Errorf("plugin %q does not accept configuration", e.Name)
+		}
+		ps = append(ps, plugin)
+```
+
+Becomes:
+
+```go
+		if c, ok := plugin.(pipeline.Configurable); ok {
+			if err := c.Configure(e.Config); err != nil {
+				return nil, fmt.Errorf("configure %q: %w", e.Name, err)
+			}
+			// Wrap so the session API can surface the raw config on /v1/pipeline.
+			plugin = pipeline.WrapConfigured(plugin, e.Config)
+		} else if len(e.Config) > 0 {
+			return nil, fmt.Errorf("plugin %q does not accept configuration", e.Name)
+		}
+		ps = append(ps, plugin)
+```
+
+- [ ] **Step 5: Run tests to verify everything passes**
+
+Run:
+```bash
+cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions/authbridge
+go test ./authlib/...
+go vet ./authlib/...
+```
+Expected: all tests PASS (existing + new), vet clean.
+
+If the new test fails because `RawConfig` type-asserts as nil bytes for the Configurable plugin: verify that `pipeline.WrapConfigured(plugin, e.Config)` is being passed `e.Config` (the raw bytes), not a re-encoded form.
+
+If the new test fails because the non-Configurable plugin's type-assert succeeds: check that the wrap line is INSIDE the `if c, ok := plugin.(pipeline.Configurable); ok { ... }` block, not outside.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions
+git add authbridge/authlib/pipeline/configured.go authbridge/authlib/pipeline/configured_test.go authbridge/authlib/plugins/registry.go authbridge/authlib/plugins/registry_test.go
+git commit -s -m "feat(authlib): Wrap Configurable plugins in the registry
+
+Registry now wraps each Configurable plugin in pipeline.WrapConfigured
+after a successful Configure(), retaining the raw config bytes the
+plugin was built from. Non-Configurable plugins pass through unwrapped.
+
+Promoted wrapConfigured to WrapConfigured so the registry can call it
+across packages.
+
+Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: sessionapi exposes Config on /v1/pipeline
+
+Add a `Config json.RawMessage` field to the wire shape and populate it via type-assertion. `omitempty` ensures non-Configurable plugins emit unchanged JSON.
+
+**Files:**
+- Modify: `authbridge/authlib/sessionapi/server.go` — add field to `pipelinePluginView`, populate in `describePipeline`.
+- Modify: `authbridge/authlib/sessionapi/server_test.go` — extend `TestHandlePipeline`.
+
+- [ ] **Step 1: Write the failing test**
+
+The existing `TestHandlePipeline` (around line 288) already builds two pipelines with `&fakePlugin{...}` instances, wraps them in `pipeline.NewHolder`, constructs the server with `New(":0", store, WithPipelines(...))`, and `httptest.NewServer(srv.server.Handler)`. We mirror that shape for the new test.
+
+Append to `authbridge/authlib/sessionapi/server_test.go` (next to `TestHandlePipeline`):
+
+```go
+// TestHandlePipelineSurfacesConfig verifies that the Config field on
+// /v1/pipeline carries each Configurable plugin's raw config bytes
+// (when wrapped by the registry's WrapConfigured), and that
+// non-Configurable plugins emit no Config field.
+func TestHandlePipelineSurfacesConfig(t *testing.T) {
+	configRaw := json.RawMessage(`{"hello":"world"}`)
+	wrapped := pipeline.WrapConfigured(&fakePlugin{name: "with-config"}, configRaw)
+	plain := &fakePlugin{name: "without-config"}
+
+	inbound, err := pipeline.New([]pipeline.Plugin{wrapped, plain})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store := session.New(5*time.Minute, 100, 0)
+	defer store.Close()
+	srv := New(":0", store, WithPipelines(pipeline.NewHolder(inbound), nil))
+	ts := httptest.NewServer(srv.server.Handler)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/v1/pipeline")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var body struct {
+		Inbound []struct {
+			Name   string          `json:"name"`
+			Config json.RawMessage `json:"config,omitempty"`
+		} `json:"inbound"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Inbound) != 2 {
+		t.Fatalf("want 2 plugins, got %d", len(body.Inbound))
+	}
+	for _, p := range body.Inbound {
+		switch p.Name {
+		case "with-config":
+			if string(p.Config) != `{"hello":"world"}` {
+				t.Fatalf("with-config Config: got %q want %q",
+					string(p.Config), `{"hello":"world"}`)
+			}
+		case "without-config":
+			if len(p.Config) != 0 {
+				t.Fatalf("without-config should emit no Config, got %q",
+					string(p.Config))
+			}
+		default:
+			t.Fatalf("unexpected plugin name: %q", p.Name)
+		}
+	}
+}
+```
+
+`fakePlugin` is already defined in `server_test.go` at the top of the file (the existing `TestHandlePipeline` uses it). `json` and `http` and `httptest` and `time` and `session` and `pipeline` are already in the test file's imports.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions/authbridge
+go test ./authlib/sessionapi/ -run TestHandlePipelineSurfacesConfig -v
+```
+Expected: FAIL — the response body has no `config` field, so the assertion `string(p.Config) != ""` fires for the Configurable plugin.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `authbridge/authlib/sessionapi/server.go`, locate the `pipelinePluginView` struct (around line 105) and add the new field:
+
+```go
+type pipelinePluginView struct {
+	Name       string          `json:"name"`
+	Direction  string          `json:"direction"`
+	Position   int             `json:"position"`
+	BodyAccess bool            `json:"bodyAccess"`
+	Writes     []string        `json:"writes,omitempty"`
+	Reads      []string        `json:"reads,omitempty"`
+	Config     json.RawMessage `json:"config,omitempty"` // NEW
+}
+```
+
+Locate `describePipeline` (around line 134) and modify the loop body that builds each `pipelinePluginView`:
+
+```go
+func describePipeline(h *pipeline.Holder, direction string) []pipelinePluginView {
+	if h == nil {
+		return []pipelinePluginView{}
+	}
+	plugins := h.Plugins()
+	out := make([]pipelinePluginView, len(plugins))
+	for i, pl := range plugins {
+		caps := pl.Capabilities()
+		view := pipelinePluginView{
+			Name:       pl.Name(),
+			Direction:  direction,
+			Position:   i + 1,
+			BodyAccess: caps.BodyAccess,
+			Writes:     caps.Writes,
+			Reads:      caps.Reads,
+		}
+		// Surface raw config when the plugin was wrapped by the registry.
+		// Non-Configurable plugins type-assert false; Config stays nil and
+		// json.Marshal omits it via omitempty.
+		if rc, ok := pl.(interface{ RawConfig() json.RawMessage }); ok {
+			view.Config = rc.RawConfig()
+		}
+		out[i] = view
+	}
+	return out
+}
+```
+
+- [ ] **Step 4: Run tests to verify everything passes**
+
+Run:
+```bash
+cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions/authbridge
+go test ./authlib/sessionapi/ -v
+go vet ./authlib/sessionapi/
+```
+Expected: all tests PASS including `TestHandlePipelineSurfacesConfig` and the existing `TestHandlePipeline`, vet clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions
+git add authbridge/authlib/sessionapi/server.go authbridge/authlib/sessionapi/server_test.go
+git commit -s -m "feat(sessionapi): Surface plugin runtime config on /v1/pipeline
+
+pipelinePluginView gains a Config json.RawMessage field. describePipeline
+type-asserts each plugin against interface{ RawConfig() json.RawMessage }
+— populated by the registry's configuredPlugin wrapper for Configurable
+plugins. Non-Configurable plugins return no RawConfig method, so the
+field stays nil and omitempty drops it from the JSON. Wire shape for
+existing consumers is unchanged.
+
+Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: apiclient mirrors Config field
+
+Decode the new wire field on the abctl side.
+
+**Files:**
+- Modify: `authbridge/cmd/abctl/apiclient/client.go` — add field to `PipelinePlugin`.
+- Modify: `authbridge/cmd/abctl/apiclient/client_test.go` — extend the pipeline-decode test.
+
+- [ ] **Step 1: Write the failing test**
+
+Find the existing pipeline-related test in `authbridge/cmd/abctl/apiclient/client_test.go` (look for `GetPipeline` or `TestPipeline` patterns). If one exists, extend it. If not, add a new test that exercises the JSON decode path:
+
+```go
+// TestPipelinePluginDecodesConfig verifies the new Config field on
+// /v1/pipeline survives JSON round-trip through PipelinePlugin.
+func TestPipelinePluginDecodesConfig(t *testing.T) {
+	body := `{"inbound":[
+	  {"name":"with-config","direction":"inbound","position":1,"bodyAccess":false,
+	   "config":{"hello":"world"}},
+	  {"name":"without-config","direction":"inbound","position":2,"bodyAccess":false}
+	],"outbound":[]}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/pipeline" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL)
+	view, err := c.GetPipeline(context.Background())
+	if err != nil {
+		t.Fatalf("GetPipeline: %v", err)
+	}
+	if len(view.Inbound) != 2 {
+		t.Fatalf("want 2 inbound, got %d", len(view.Inbound))
+	}
+	// First plugin: Config decoded.
+	if string(view.Inbound[0].Config) != `{"hello":"world"}` {
+		t.Fatalf("with-config Config: got %q want %q",
+			string(view.Inbound[0].Config), `{"hello":"world"}`)
+	}
+	// Second plugin: Config absent → empty/nil.
+	if len(view.Inbound[1].Config) != 0 {
+		t.Fatalf("without-config Config should be empty, got %q",
+			string(view.Inbound[1].Config))
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions/authbridge/cmd/abctl
+go test ./apiclient/ -run TestPipelinePluginDecodesConfig -v
+```
+Expected: build failure — `view.Inbound[0].Config` is undefined on `PipelinePlugin`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `authbridge/cmd/abctl/apiclient/client.go`, locate the `PipelinePlugin` struct (around line 85) and add the new field:
+
+```go
+type PipelinePlugin struct {
+	Name       string          `json:"name"`
+	Direction  string          `json:"direction"`
+	Position   int             `json:"position"`
+	BodyAccess bool            `json:"bodyAccess"`
+	Writes     []string        `json:"writes"`
+	Reads      []string        `json:"reads"`
+	Config     json.RawMessage `json:"config,omitempty"` // NEW
+}
+```
+
+If `encoding/json` isn't imported in `client.go` yet (it likely is, but verify), add it.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions/authbridge/cmd/abctl
+go test ./apiclient/ -v
+go vet ./apiclient/
+```
+Expected: all tests PASS including the new one, vet clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions
+git add authbridge/cmd/abctl/apiclient/client.go authbridge/cmd/abctl/apiclient/client_test.go
+git commit -s -m "feat(abctl): Decode Config field on PipelinePlugin
+
+Mirrors the new wire field added to /v1/pipeline server-side. Field is
+omitempty so non-Configurable plugins stay backward-compatible.
+
+Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: TUI renders the config
+
+Replace the placeholder text in `plugin_detail_pane.go` with `ColorizeJSONBytes`-rendered config (or `(none)` for non-Configurable plugins).
+
+**Files:**
+- Modify: `authbridge/cmd/abctl/tui/plugin_detail_pane.go` — replace placeholder with rendered config.
+- Modify: `authbridge/cmd/abctl/tui/detail_pane_test.go` (or wherever `showPluginDetail` is tested) — extend.
+
+- [ ] **Step 1: Identify the existing detail-pane test file**
+
+Run:
+```bash
+grep -l "showPluginDetail" /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions/authbridge/cmd/abctl/tui/*_test.go
+```
+
+There may not be a dedicated test for `showPluginDetail` yet — `detail_pane_test.go` is the closest neighbor. If neither tests `showPluginDetail`, create `plugin_detail_pane_test.go`. The plan below assumes a new test file.
+
+- [ ] **Step 2: Write the failing tests**
+
+Create (or extend) `authbridge/cmd/abctl/tui/plugin_detail_pane_test.go`:
+
+```go
+package tui
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/kagenti/kagenti-extensions/authbridge/cmd/abctl/apiclient"
+)
+
+func TestShowPluginDetailRendersConfig(t *testing.T) {
+	m := newPickerModel(context.Background(), nil, nil)
+	// The viewport defaults to 0×0 (sized by layout() on WindowSizeMsg);
+	// in unit tests we set it manually so View() returns content.
+	m.detailVp.Width = 80
+	m.detailVp.Height = 20
+	plugin := &apiclient.PipelinePlugin{
+		Name:      "jwt-validation",
+		Direction: "inbound",
+		Position:  1,
+		Writes:    []string{"security"},
+		Config:    json.RawMessage(`{"issuer":"http://idp"}`),
+	}
+	m.showPluginDetail(plugin)
+	view := m.detailVp.View()
+	if !strings.Contains(view, "Config:") {
+		t.Fatalf("rendered view missing Config section:\n%s", view)
+	}
+	if !strings.Contains(view, "issuer") {
+		t.Fatalf("rendered view missing config key:\n%s", view)
+	}
+	if !strings.Contains(view, "http://idp") {
+		t.Fatalf("rendered view missing config value:\n%s", view)
+	}
+}
+
+func TestShowPluginDetailRendersNoneForEmptyConfig(t *testing.T) {
+	m := newPickerModel(context.Background(), nil, nil)
+	m.detailVp.Width = 80
+	m.detailVp.Height = 20
+	plugin := &apiclient.PipelinePlugin{
+		Name:      "non-configurable",
+		Direction: "inbound",
+		Position:  1,
+		Config:    nil,
+	}
+	m.showPluginDetail(plugin)
+	view := m.detailVp.View()
+	if !strings.Contains(view, "Config:") {
+		t.Fatalf("rendered view missing Config section:\n%s", view)
+	}
+	if !strings.Contains(view, "(none)") {
+		t.Fatalf("rendered view should say (none) for empty Config:\n%s", view)
+	}
+}
+```
+
+Add `"context"` to the imports if not already present.
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run:
+```bash
+cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions/authbridge/cmd/abctl
+go test ./tui/ -run TestShowPluginDetail -v
+```
+Expected: tests FAIL — current `showPluginDetail` renders the placeholder text "(per-plugin runtime config will be added when..." instead of "Config: ...".
+
+- [ ] **Step 4: Write minimal implementation**
+
+In `authbridge/cmd/abctl/tui/plugin_detail_pane.go`, locate the closing lines of `showPluginDetail`:
+
+```go
+fmt.Fprintln(&b)
+b.WriteString(styleHint.Render("(per-plugin runtime config will be added when the Plugin interface\nexposes a Config() method — tracked as a follow-up.)"))
+```
+
+Replace those two lines with:
+
+```go
+fmt.Fprintln(&b)
+b.WriteString(styleMuted.Render("Config:    "))
+if len(p.Config) == 0 {
+	b.WriteString(" (none)\n")
+} else {
+	b.WriteString("\n")
+	b.WriteString(ColorizeJSONBytes(p.Config))
+	b.WriteString("\n")
+}
+```
+
+`ColorizeJSONBytes` is the existing helper in `tui/json_colorize.go`. No new imports needed if the file already imports `fmt` and `strings` (it does).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run:
+```bash
+cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions/authbridge/cmd/abctl
+go test ./tui/
+go vet ./tui/
+go build ./...
+```
+Expected: all tests PASS, vet clean, binary builds.
+
+Smoke-build the binary against the live IBAC cluster (optional but recommended):
+
+```bash
+go build -o ./abctl .
+./abctl
+# Pick team1 → email-agent → drill into Pipeline pane → Enter on a plugin
+# (e.g. jwt-validation) → should see the plugin's actual config block
+# rendered as colored JSON. Esc back, try ibac plugin (also Configurable).
+# Try a non-Configurable plugin if any are visible — should show "(none)".
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/haihuang/works/go/src/github.com/kagenti/kagenti-extensions
+git add authbridge/cmd/abctl/tui/plugin_detail_pane.go authbridge/cmd/abctl/tui/plugin_detail_pane_test.go
+git commit -s -m "feat(abctl): Render plugin runtime config in plugin-detail pane
+
+Replaces the (per-plugin runtime config will be added...) placeholder
+with the plugin's actual config, rendered as colorized JSON via the
+existing ColorizeJSONBytes helper. Plugins without runtime config
+(non-Configurable) render Config: (none).
+
+Closes the deferred follow-up tracked in PR #445.
+
+Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review Checklist
+
+After all six tasks land, before opening the PR:
+
+**1. Spec coverage:**
+- ✅ Goal: replace placeholder with actual config — Task 6.
+- ✅ Server-side, post-${VAR} expansion — Tasks 1-4 (framework holds the bytes that came from the post-expansion YAML).
+- ✅ Framework-wrap approach (zero plugin source changes) — Tasks 1-3.
+- ✅ Optional-interface forwarding (load-bearing) — Task 2.
+- ✅ Wire shape `Config json.RawMessage` with `omitempty` — Task 4.
+- ✅ apiclient mirrors wire shape — Task 5.
+- ✅ TUI renders via `ColorizeJSONBytes`, `(none)` for non-Configurable — Task 6.
+- ✅ Acceptance criterion #1 (Configurable plugin's config visible) — Task 6 smoke-build.
+- ✅ Acceptance criterion #2 (`Config: (none)` for non-Configurable) — Task 6 second test.
+- ✅ Acceptance criterion #3 (hot-reload reflected) — Task 4 type-assert reads through `Holder.Plugins()` which is hot-swap-aware (no new code needed).
+- ✅ Acceptance criterion #4 (additive wire shape) — Task 4 `omitempty`.
+- ✅ Acceptance criterion #5 (zero plugin source changes) — verify with `git diff main..HEAD authbridge/authlib/plugins/*/` shows changes only in tests, not in plugin implementations.
+- ✅ Acceptance criterion #6 (`go test ./...` passes) — every task ends with `go test`.
+
+**2. Type consistency:**
+- `WrapConfigured(p Plugin, raw json.RawMessage) Plugin` — Task 1 + Task 2 + Task 3 use the same signature.
+- `interface{ RawConfig() json.RawMessage }` — Task 1 (test), Task 4 (sessionapi populate), all spell the method identically.
+- `Config json.RawMessage` — Task 4 (server view), Task 5 (apiclient), Task 6 (TUI access via `p.Config`) — same name + type throughout.
+- `pipelinePluginView` (sessionapi internal) vs `apiclient.PipelinePlugin` (cross-package wire view) — different types, deliberately, with the same wire shape.
+
+**3. Placeholder scan:**
+- No `TBD` / `TODO` / "fill in details" anywhere in the plan. Each task contains complete code.
+- Task 1's note about omitting `context` from the import block until Task 2 is descriptive (Go's unused-import strictness), not a placeholder.
+- Tasks 4 / 5 / 6 reference patterns from existing tests (e.g., "the surrounding TestHandlePipeline setup"). The patterns are spelled out in the task code; the references are pointers for diagnostic context, not gaps.

--- a/authbridge/docs/superpowers/specs/2026-05-28-abctl-plugin-config-design.md
+++ b/authbridge/docs/superpowers/specs/2026-05-28-abctl-plugin-config-design.md
@@ -1,0 +1,300 @@
+# Plugin runtime config in abctl's plugin-detail pane
+
+**Status:** Design — pending user review
+**Date:** 2026-05-28
+
+## Goal
+
+`abctl`'s Pipeline pane shows each plugin's name, direction, position,
+read/write slots, and event count. The plugin-detail view (Enter on a
+row) shows those same fields plus a placeholder line:
+
+> *(per-plugin runtime config will be added when the Plugin interface
+> exposes a Config() method — tracked as a follow-up.)*
+
+This spec replaces that placeholder with the plugin's actual runtime
+config — the `config:` subtree from the runtime YAML, post-`${VAR}`
+expansion — rendered as colorized pretty JSON. The most common
+operator question when triaging an agent ("what is plugin X
+configured to do?") is then answerable inside `abctl` without
+reading the per-agent ConfigMap separately.
+
+## Non-goals
+
+- Per-field redaction. The convention (mirrored from the existing
+  `:9093/config` endpoint) is that secrets live behind `*_file` paths,
+  not inline. A redaction pass can ship as a separate follow-up if a
+  known-sensitive field ever surfaces.
+- Editing config from `abctl`. The TUI stays read-only.
+- Diffing config across reloads. `:9093/reload/status` already serves
+  that need.
+- Surfacing config for non-`Configurable` plugins (those that don't
+  declare `Configure(raw json.RawMessage) error`). They render as
+  `Config: (none)`.
+- Showing the pre-expansion ConfigMap form. Operators want the resolved
+  values they'd see inside the pod; the framework already holds them.
+
+## Source-of-truth choice
+
+The runtime config lives in the per-agent ConfigMap (`authbridge-config-<agent>`)
+in pre-expansion form. The pod's framework loads it, expands `${VAR}`
+references against its env, and runs against the resolved form. We
+expose the **resolved form from the running pod**, not the raw
+ConfigMap, because:
+
+- `${VAR}`-heavy configs render as useless template text from the ConfigMap.
+- During hot-reload, the ConfigMap can be ahead of what the pod is
+  actually running. The operator question is "what is this pod doing
+  RIGHT NOW," which only the pod can answer.
+- `:9094` is already port-forwarded by the picker; adding a field to
+  `/v1/pipeline` (already there) is cheaper than introducing a second
+  port-forward to `:9093/config` or a kubectl-shell-out for the
+  ConfigMap.
+
+## Architecture
+
+```
+runtime YAML
+    │
+    ▼  (already exists)
+PluginEntry{Name, Config json.RawMessage}
+    │
+    ▼  registry.Build()  — NEW: wrap Configurable plugins
+configuredPlugin{Plugin; raw json.RawMessage}
+    │
+    ▼  pipeline.Holder.Plugins() returns []Plugin
+    │
+    ▼  /v1/pipeline → describePipeline()  — NEW: type-assert + populate Config
+pipelinePluginView{ ..., Config json.RawMessage }
+    │
+    ▼  apiclient.PipelinePlugin.Config  — NEW: mirror wire shape
+    │
+    ▼  tui/plugin_detail_pane.go showPluginDetail()
+"Config:\n  <pretty-JSON, colorized>"  — render via existing json_colorize.go
+```
+
+The framework wraps `Configurable` plugins automatically. **Zero
+changes to any existing plugin.** Non-`Configurable` plugins flow
+through unwrapped; the type-assert in describePipeline misses, and
+the view renders `Config: (none)`.
+
+## Components
+
+### 1. `configuredPlugin` wrapper (`authlib/pipeline/configured.go`, new)
+
+```go
+package pipeline
+
+import "encoding/json"
+
+// configuredPlugin wraps a Configurable plugin with the raw config bytes
+// it was constructed from, so the session API can surface them on
+// /v1/pipeline. All Plugin interface methods forward to the embedded
+// plugin — zero observable behavior change at the request hot path.
+//
+// The wrapper is constructed by the plugins/registry only for plugins
+// that implement Configurable. Non-Configurable plugins pass through
+// unwrapped.
+type configuredPlugin struct {
+    Plugin
+    raw json.RawMessage
+}
+
+// RawConfig returns the raw config bytes the wrapped plugin was
+// configured with. Used by the session API to populate the Config
+// field on /v1/pipeline.
+func (c *configuredPlugin) RawConfig() json.RawMessage { return c.raw }
+```
+
+The struct embeds `Plugin` so the four required methods (`Name()`,
+`Capabilities()`, `OnRequest()`, `OnResponse()`) and the new
+`RawConfig()` accessor are part of `*configuredPlugin`'s method set.
+
+**Optional interfaces require explicit forwarding.** Go does NOT
+promote method-set membership through an embedded interface — methods
+declared on `Initializer` / `Shutdowner` / `Finisher` / `Readier`
+(but absent from `Plugin`) are unreachable on `*configuredPlugin` even
+when the wrapped concrete type implements them. The framework's
+dispatchers (verified at `pipeline.go:292`, `:308`, `:364`, `:382`,
+`:406`, `:474`) all do `p.(Initializer)`-shaped type assertions; a
+naive wrapper would silently drop Init/Shutdown/Finish/Ready calls.
+
+The wrapper therefore implements all four optional interfaces
+unconditionally, each method forwarding to the wrapped plugin if it
+implements the interface and no-opping otherwise:
+
+```go
+func (c *configuredPlugin) Init(ctx context.Context) error {
+    if init, ok := c.Plugin.(Initializer); ok {
+        return init.Init(ctx)
+    }
+    return nil
+}
+
+func (c *configuredPlugin) Shutdown(ctx context.Context) error {
+    if sh, ok := c.Plugin.(Shutdowner); ok {
+        return sh.Shutdown(ctx)
+    }
+    return nil
+}
+
+func (c *configuredPlugin) OnFinish(ctx context.Context, pctx *Context) {
+    if fin, ok := c.Plugin.(Finisher); ok {
+        fin.OnFinish(ctx, pctx)
+    }
+}
+
+func (c *configuredPlugin) Ready() bool {
+    if r, ok := c.Plugin.(Readier); ok {
+        return r.Ready()
+    }
+    return true
+}
+```
+
+**Behavioral implication:** every Configurable plugin appears to
+implement all four optional interfaces after wrapping. The
+framework's `if x, ok := p.(Initializer); ok` branches always succeed
+for wrapped plugins; `Init()` is called on every wrapped plugin and
+no-ops for those that don't really implement `Initializer`. Same for
+the other three. The end-to-end behavior is identical to the
+pre-wrap world — a non-Initializer plugin still has nothing to do at
+Init time — but the dispatcher's "ok" branch is now a tautology for
+wrapped plugins. The `Ready()` default of `true` preserves the
+"plugins without Readier are considered always-ready" semantics
+documented at `pipeline.go:287-289`.
+
+This forwarding behavior is the load-bearing safety property and is
+verified by `TestConfiguredPluginForwardsOptionalInterfaces` (see
+Testing).
+
+### 2. Registry wrapping (`authlib/plugins/registry.go`)
+
+The two existing `c.Configure(e.Config)` call sites (around lines 119
+and 167 in current code) become:
+
+```go
+if c, ok := plugin.(pipeline.Configurable); ok {
+    if err := c.Configure(e.Config); err != nil {
+        return nil, err
+    }
+    plugin = &pipeline.ConfiguredPlugin{Plugin: plugin, Raw: e.Config}
+    // Or use the unexported helper described in Components §1; the
+    // exact API surface is finalized during implementation.
+}
+```
+
+Two open shape questions resolved during implementation:
+
+- **Exported vs unexported.** Either `pipeline.configuredPlugin` (with
+  a `pipeline.WrapConfigured(p, raw) Plugin` constructor) or an
+  exported `pipeline.ConfiguredPlugin` struct. Implementation will
+  pick whichever keeps the plugins package's call site cleaner; both
+  are equivalent in capability.
+- **Where the wrap happens.** Inside the existing Configure-success
+  branch in registry.go. Adds 1 line per call site.
+
+### 3. Wire shape (`authlib/sessionapi/server.go`)
+
+```go
+type pipelinePluginView struct {
+    Name       string          `json:"name"`
+    Direction  string          `json:"direction"`
+    Position   int             `json:"position"`
+    BodyAccess bool            `json:"bodyAccess"`
+    Writes     []string        `json:"writes,omitempty"`
+    Reads      []string        `json:"reads,omitempty"`
+    Config     json.RawMessage `json:"config,omitempty"` // NEW
+}
+```
+
+`describePipeline` populates Config via type-assertion:
+
+```go
+type rawConfigGetter interface{ RawConfig() json.RawMessage }
+
+for i, pl := range plugins {
+    caps := pl.Capabilities()
+    view := pipelinePluginView{ /* existing fields */ }
+    if rc, ok := pl.(rawConfigGetter); ok {
+        view.Config = rc.RawConfig()
+    }
+    out[i] = view
+}
+```
+
+`omitempty` drops the field from the JSON output when it's nil (i.e.,
+non-Configurable plugins) so the wire payload stays the same shape
+for those.
+
+### 4. apiclient (`cmd/abctl/apiclient/client.go`)
+
+```go
+type PipelinePlugin struct {
+    Name       string          `json:"name"`
+    Direction  string          `json:"direction"`
+    Position   int             `json:"position"`
+    BodyAccess bool            `json:"bodyAccess"`
+    Writes     []string        `json:"writes"`
+    Reads      []string        `json:"reads"`
+    Config     json.RawMessage `json:"config,omitempty"` // NEW
+}
+```
+
+### 5. TUI rendering (`cmd/abctl/tui/plugin_detail_pane.go`)
+
+`showPluginDetail()` replaces:
+
+```go
+b.WriteString(styleHint.Render(
+    "(per-plugin runtime config will be added when the Plugin interface\n" +
+    "exposes a Config() method — tracked as a follow-up.)"))
+```
+
+with:
+
+```go
+b.WriteString(styleMuted.Render("Config:    "))
+if len(p.Config) == 0 {
+    b.WriteString(" (none)\n")
+} else {
+    b.WriteString("\n")
+    b.WriteString(ColorizeJSONBytes(p.Config))
+    b.WriteString("\n")
+}
+```
+
+`ColorizeJSONBytes` is the existing helper in
+`cmd/abctl/tui/json_colorize.go`. It parses, indents, colorizes, and
+falls back to a muted raw render on parse failure — no caller-side
+fallback needed. Long configs scroll via the existing detail
+viewport; no layout changes.
+
+## Testing
+
+| File | What |
+|---|---|
+| `authlib/pipeline/configured_test.go` (new) | Verify `configuredPlugin.RawConfig()` returns the bytes passed in; verify pass-through of `Name() / Capabilities() / OnRequest() / OnResponse()` to the embedded plugin (a fake plugin that records each call). |
+| `authlib/pipeline/configured_test.go` | `TestConfiguredPluginForwardsOptionalInterfaces`: for each of `Initializer`/`Shutdowner`/`Finisher`/`Readier`, a concrete plugin implementing both `Configurable` AND that optional interface is wrapped; the wrapper's corresponding method is reachable via type-assertion AND forwards to the wrapped plugin's implementation (verified by spy counters / return values). For each optional interface, also test the no-op case: a Configurable plugin that does NOT implement the optional interface; the wrapper's method type-asserts true (because of unconditional embedding) but the underlying call is the documented no-op (Init/Shutdown return nil; OnFinish does nothing; Ready returns true). |
+| `authlib/plugins/registry_test.go` | Extend an existing test: a Configurable plugin built via the registry exposes `RawConfig()` returning the config bytes from the YAML; a non-Configurable plugin does not (type-assert returns false). |
+| `authlib/sessionapi/server_test.go` | Extend `TestHandlePipeline`: a Configurable plugin's response JSON contains the `config` field with the expected raw bytes; a non-Configurable plugin's response omits the field. |
+| `cmd/abctl/apiclient/client_test.go` | Decode a pipeline JSON payload that includes `config`; assert the field is preserved as `json.RawMessage` round-trip. |
+| `cmd/abctl/tui/plugin_detail_pane_test.go` (extend) | Render with a Configurable-shape `PipelinePlugin` carrying a small JSON config; assert the rendered output contains the indented JSON. Render with `Config: nil`; assert "(none)" appears. |
+
+## Acceptance criteria
+
+1. A Configurable plugin's `config:` subtree from the runtime YAML
+   appears in `abctl`'s plugin-detail pane (post-`${VAR}` expansion,
+   colorized JSON).
+2. A non-Configurable plugin shows `Config: (none)`.
+3. Hot-reload: editing the per-agent ConfigMap causes `abctl`'s
+   plugin-detail pane to reflect the new config after the framework
+   completes its reload (verified via `/v1/pipeline` returning the
+   new raws). No abctl-side polling needed beyond the existing
+   `/v1/pipeline` fetch on pane entry.
+4. Existing `/v1/pipeline` consumers (operators using `curl` directly,
+   any future tooling) continue to work — the new field is additive
+   and `omitempty`-elided when absent.
+5. Zero changes to existing plugin source files.
+6. `go test ./...` from `authbridge/` and `authbridge/cmd/abctl/`
+   passes including the new tests.

--- a/authbridge/docs/superpowers/specs/2026-05-28-abctl-plugin-config-design.md
+++ b/authbridge/docs/superpowers/specs/2026-05-28-abctl-plugin-config-design.md
@@ -53,7 +53,7 @@ ConfigMap, because:
 
 ## Architecture
 
-```
+```text
 runtime YAML
     │
     ▼  (already exists)


### PR DESCRIPTION
## Summary

Replaces the placeholder text in abctl's plugin-detail pane with each plugin's actual runtime config (post-`${VAR}` expansion), surfaced via a new optional `Config` field on `/v1/pipeline`. Closes the deferred follow-up tracked in PR #445.

The framework wraps `Configurable` plugins in a `pipeline.WrapConfigured` wrapper that retains the raw JSON config bytes alongside an embedded `Plugin`. **Zero changes to any existing plugin source file** — the wrap happens once in the registry. The wrapper forwards the four optional plugin interfaces (`Initializer`/`Shutdowner`/`Finisher`/`Readier`) explicitly, since Go does not promote method-set membership through an embedded interface.

## Live verification

`/v1/pipeline` against an IBAC agent pod now returns:

```json
{
  "inbound": [{
    "name": "jwt-validation",
    "config": {
      "issuer": "http://keycloak.localtest.me:8080/realms/kagenti",
      "keycloak_realm": "kagenti",
      "keycloak_url": "http://keycloak-service.keycloak.svc:8080"
    }
  }],
  "outbound": [{
    "name": "token-exchange",
    "config": {
      "default_policy": "passthrough",
      "identity": {"type": "client-secret"},
      "keycloak_realm": "kagenti",
      "keycloak_url": "http://keycloak-service.keycloak.svc:8080"
    }
  }]
}
```

Note: values are the post-expansion form (resolved `${VAR}`), not the ConfigMap's template form — the operator-facing answer to "what is this pod actually configured to do."

## Commits

| # | Subject |
|---|---|
| 1 | `feat(authlib): Add configuredPlugin wrapper retaining raw config` |
| 2 | `feat(authlib): Forward optional plugin interfaces in configuredPlugin` |
| 3 | `feat(authlib): Wrap Configurable plugins in the registry` |
| 4 | `feat(sessionapi): Surface plugin runtime config on /v1/pipeline` |
| 5 | `feat(abctl): Decode Config field on PipelinePlugin` |
| 6 | `feat(abctl): Render plugin runtime config in plugin-detail pane` |

Each commit is independently reviewable, TDD-shaped, and lands one isolated unit.

## Spec & plan

The branch was developed spec-first via the superpowers brainstorming → writing-plans → subagent-driven flow. Both artifacts are committed in the diff for reviewer reference:

- Spec: [`authbridge/docs/superpowers/specs/2026-05-28-abctl-plugin-config-design.md`](authbridge/docs/superpowers/specs/2026-05-28-abctl-plugin-config-design.md)
- Plan: [`authbridge/docs/superpowers/plans/2026-05-28-abctl-plugin-config.md`](authbridge/docs/superpowers/plans/2026-05-28-abctl-plugin-config.md)

## Backward compatibility

- The new `config` field uses `json:"config,omitempty"`; non-Configurable plugins emit no field. Existing `/v1/pipeline` consumers see an unchanged response shape.
- `pipeline.Plugin` interface unchanged — every existing plugin compiles and behaves identically.
- The wrapper's per-method dispatch chain grows by one frame; no observable behavior change at the request hot path.

## Test plan

- [x] `go test -race ./authlib/...` clean (33 packages)
- [x] `go test -race ./cmd/abctl/...` clean
- [x] `go vet` clean across all touched packages
- [x] Live `/v1/pipeline` smoke-test against the IBAC pod shows the expanded config bytes for `jwt-validation` and `token-exchange`
- [x] Pre-existing `TestHandlePipeline` continues to pass unchanged (omitempty preserves wire shape for non-Configurable plugins)
- [ ] Reviewer to drill into the Pipeline pane in a live abctl session and Enter on a plugin → should see colored JSON config under `Config:`

## Sensitive data

The convention (mirrored from the existing `:9093/config` endpoint) is that secrets live behind `*_file` paths, not inline. Configs render verbatim; no redaction pass in this PR. If a known-sensitive field surfaces later, redaction can ship as a follow-up.

## Deferred follow-ups (out of scope, captured for memory)

- Tighten `slog.Debug` noise from `Pipeline.Start`/`Stop` lifecycle logs that now fire for every wrapped plugin (most are no-ops). Optional micro-cleanup.
- Align `Writes` / `Reads` JSON tag conventions between server (`omitempty`) and client (no omitempty). Pre-existing inconsistency.
- Inline secret redaction for any future plugin that puts sensitive data in its config.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * abctl now shows each plugin's runtime configuration as pretty JSON in the plugin-detail pane; plugins without config show "(none)". The pipeline API now includes an optional per-plugin config field so clients can fetch raw config bytes.

* **Tests**
  * Added unit and integration tests covering config wrapping, lifecycle passthrough, API exposure, client decoding, and TUI rendering (including malformed/absent config).

* **Documentation**
  * Added design spec and implementation plan for surfacing plugin configs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kagenti/kagenti-extensions/pull/447?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->