### PR TITLE
fix(ibac): Bypass transport-layer calls and let agents take self-actions

### DIFF
--- a/authbridge/authlib/listener/extproc/server.go
+++ b/authbridge/authlib/listener/extproc/server.go
@@ -144,6 +144,7 @@ func (s *Server) handleInbound(stream extprocv3.ExternalProcessor_ProcessServer,
 	ctx := stream.Context()
 	pctx := &pipeline.Context{
 		Direction: pipeline.Inbound,
+		Method:    getHeader(headers, ":method"),
 		Scheme:    getHeader(headers, ":scheme"),
 		Path:      getHeader(headers, ":path"),
 		Headers:   headerMapToHTTP(headers),
@@ -165,6 +166,7 @@ func (s *Server) handleInboundBody(stream extprocv3.ExternalProcessor_ProcessSer
 	ctx := stream.Context()
 	pctx := &pipeline.Context{
 		Direction: pipeline.Inbound,
+		Method:    getHeader(headers, ":method"),
 		Scheme:    getHeader(headers, ":scheme"),
 		Path:      getHeader(headers, ":path"),
 		Headers:   headerMapToHTTP(headers),
@@ -446,6 +448,7 @@ func (s *Server) handleOutbound(stream extprocv3.ExternalProcessor_ProcessServer
 	ctx := stream.Context()
 	pctx := &pipeline.Context{
 		Direction: pipeline.Outbound,
+		Method:    getHeader(headers, ":method"),
 		Scheme:    getHeader(headers, ":scheme"),
 		Host:      getHeader(headers, ":authority"),
 		Path:      getHeader(headers, ":path"),
@@ -483,6 +486,7 @@ func (s *Server) handleOutboundBody(stream extprocv3.ExternalProcessor_ProcessSe
 	ctx := stream.Context()
 	pctx := &pipeline.Context{
 		Direction: pipeline.Outbound,
+		Method:    getHeader(headers, ":method"),
 		Scheme:    getHeader(headers, ":scheme"),
 		Host:      getHeader(headers, ":authority"),
 		Path:      getHeader(headers, ":path"),

--- a/authbridge/authlib/listener/forwardproxy/server.go
+++ b/authbridge/authlib/listener/forwardproxy/server.go
@@ -158,6 +158,7 @@ func (s *Server) handleRequest(w http.ResponseWriter, r *http.Request) {
 
 	pctx := &pipeline.Context{
 		Direction: pipeline.Outbound,
+		Method:    r.Method,
 		Scheme:    r.URL.Scheme,
 		Host:      r.Host,
 		Path:      r.URL.Path,
@@ -410,7 +411,8 @@ const connectDialTimeout = 30 * time.Second
 func (s *Server) handleConnect(w http.ResponseWriter, r *http.Request) {
 	pctx := &pipeline.Context{
 		Direction: pipeline.Outbound,
-		Scheme:    "tcp", // marker: bytes are opaque, not HTTP
+		Method:    r.Method, // always "CONNECT" here, but populated for parity with handleRequest
+		Scheme:    "tcp",    // marker: bytes are opaque, not HTTP
 		Host:      r.Host,
 		Path:      "",
 		Headers:   r.Header.Clone(),

--- a/authbridge/authlib/listener/reverseproxy/server.go
+++ b/authbridge/authlib/listener/reverseproxy/server.go
@@ -164,6 +164,7 @@ func (s *Server) Handler() http.Handler {
 func (s *Server) handleRequest(w http.ResponseWriter, r *http.Request) {
 	pctx := &pipeline.Context{
 		Direction: pipeline.Inbound,
+		Method:    r.Method,
 		Scheme:    requestScheme(r),
 		Host:      r.Host,
 		Path:      r.URL.Path,

--- a/authbridge/authlib/plugins/ibac/plugin.go
+++ b/authbridge/authlib/plugins/ibac/plugin.go
@@ -79,7 +79,39 @@ type ibacConfig struct {
 	// BypassPaths are URL path globs skipped without judging.
 	// Defaults to bypass.DefaultPatterns (.well-known, healthz, etc).
 	BypassPaths []string `json:"bypass_paths"`
+
+	// NoIntentPolicy controls behavior when a request reaches step 6
+	// without a recorded user intent — either because Session is nil
+	// (no inbound A2A turn has populated the active bucket yet) or
+	// because the session contains no extractable user-role A2A
+	// fragment. Two values:
+	//
+	//   - "allow" (default): Skip with reason "no_user_context" and
+	//     pass through. Right for deployments where agents take
+	//     legitimate self-actions (initialization, machine-to-machine
+	//     calls, headless cron-driven flows) — IBAC should not be in
+	//     the middle of those decisions because there's no user
+	//     intent to align against.
+	//
+	//   - "deny": Reject with 403 and the existing "no_session" /
+	//     "no_intent" reasons. Right for deployments where every
+	//     outbound is supposed to be user-driven and a missing intent
+	//     is a real misconfiguration worth surfacing as a denial.
+	//
+	// The default is "allow" because IBAC's threat model targets
+	// prompt-injection attacks where the LLM emits user-misaligned
+	// actions — that requires there to be a user in the first place.
+	// Deployments that mix user-driven and self-driven traffic get
+	// the right behavior automatically; deployments that want hard
+	// fail-closed semantics opt in via "deny".
+	NoIntentPolicy string `json:"no_intent_policy"`
 }
+
+// no_intent_policy values.
+const (
+	NoIntentPolicyAllow = "allow"
+	NoIntentPolicyDeny  = "deny"
+)
 
 // defaultBypassHosts is the conservative starting set. Operators with
 // SPIRE / Keycloak / observability stacks deployed under different
@@ -120,6 +152,9 @@ func (c *ibacConfig) applyDefaults() {
 	if len(c.BypassPaths) == 0 {
 		c.BypassPaths = defaultBypassPaths
 	}
+	if c.NoIntentPolicy == "" {
+		c.NoIntentPolicy = NoIntentPolicyAllow
+	}
 }
 
 func (c *ibacConfig) validate() error {
@@ -154,6 +189,13 @@ func (c *ibacConfig) validate() error {
 			return fmt.Errorf("bypass_paths pattern %q matches everything; "+
 				"if you mean to disable IBAC, remove it from the pipeline instead", p)
 		}
+	}
+	switch c.NoIntentPolicy {
+	case NoIntentPolicyAllow, NoIntentPolicyDeny:
+		// ok
+	default:
+		return fmt.Errorf("no_intent_policy must be %q or %q, got %q",
+			NoIntentPolicyAllow, NoIntentPolicyDeny, c.NoIntentPolicy)
 	}
 	return nil
 }
@@ -289,16 +331,41 @@ func (p *IBAC) OnRequest(ctx context.Context, pctx *pipeline.Context) pipeline.A
 	}
 
 	// 6. Pull the user's most recent declared intent. Two distinct
-	//    nil pathways, both fail closed but with different reasons so
-	//    operator dashboards can tell them apart:
+	//    nil pathways, distinguished so operator dashboards can tell
+	//    them apart:
 	//      - no_session: no inbound A2A request has populated the
 	//        active session bucket yet (or session tracking is off
 	//        entirely). Common at agent startup before any user turn.
 	//      - no_intent: a session exists but contains no extractable
 	//        user message (a2a-parser missing from inbound chain, or
 	//        events present but none are user-role A2A requests).
+	//
+	//    Both states mean "IBAC has no user intent to align against"
+	//    — i.e., the request is either genuinely user-less (agent
+	//    self-action, machine-to-machine, headless cron) or there's
+	//    a misconfiguration upstream. NoIntentPolicy controls which
+	//    interpretation wins:
+	//      - allow (default): treat as self-action, Skip and Continue.
+	//        Right for deployments that mix user-driven and self-driven
+	//        traffic.
+	//      - deny: treat as misconfiguration, Reject 403. Right for
+	//        deployments where every outbound is user-driven and a
+	//        missing intent should surface as a hard failure.
 	if pctx.Session == nil {
 		action := describeAction(pctx, p.cfg.JudgeInference)
+		if p.cfg.NoIntentPolicy == NoIntentPolicyAllow {
+			pctx.Record(pipeline.Invocation{
+				Action: pipeline.ActionSkip,
+				Phase:  pipeline.InvocationPhaseRequest,
+				Reason: "no_user_context",
+				Details: map[string]string{
+					"action":      action,
+					"sub_reason":  "no_session",
+					"explanation": "no active session — treating as agent self-action per no_intent_policy=allow",
+				},
+			})
+			return pipeline.Action{Type: pipeline.Continue}
+		}
 		pctx.Record(pipeline.Invocation{
 			Action: pipeline.ActionDeny,
 			Phase:  pipeline.InvocationPhaseRequest,
@@ -313,6 +380,19 @@ func (p *IBAC) OnRequest(ctx context.Context, pctx *pipeline.Context) pipeline.A
 	intentText := extractIntentText(intent)
 	if intentText == "" {
 		action := describeAction(pctx, p.cfg.JudgeInference)
+		if p.cfg.NoIntentPolicy == NoIntentPolicyAllow {
+			pctx.Record(pipeline.Invocation{
+				Action: pipeline.ActionSkip,
+				Phase:  pipeline.InvocationPhaseRequest,
+				Reason: "no_user_context",
+				Details: map[string]string{
+					"action":      action,
+					"sub_reason":  "no_intent",
+					"explanation": "session exists but no user intent — treating as agent self-action per no_intent_policy=allow",
+				},
+			})
+			return pipeline.Action{Type: pipeline.Continue}
+		}
 		pctx.Record(pipeline.Invocation{
 			Action: pipeline.ActionDeny,
 			Phase:  pipeline.InvocationPhaseRequest,

--- a/authbridge/authlib/plugins/ibac/plugin.go
+++ b/authbridge/authlib/plugins/ibac/plugin.go
@@ -324,11 +324,11 @@ func (p *IBAC) OnRequest(ctx context.Context, pctx *pipeline.Context) pipeline.A
 		return pipeline.DenyStatus(403, "ibac.no_intent", "no recorded user intent")
 	}
 
-	// 6. Build action description and call judge.
+	// 7. Build action description and call judge.
 	action := describeAction(pctx, p.cfg.JudgeInference)
 	verdict, reason, err := p.judge.Evaluate(ctx, intentText, action)
 
-	// 7. Fail closed on judge errors. Two flavors, distinguished
+	// 8. Fail closed on judge errors. Two flavors, distinguished
 	//    via the ErrJudgeUncertain sentinel so operator dashboards
 	//    don't conflate model-output bugs with infra outages:
 	//      - uncertain: judge is up but emitted unparseable / unknown
@@ -368,7 +368,7 @@ func (p *IBAC) OnRequest(ctx context.Context, pctx *pipeline.Context) pipeline.A
 		return pipeline.DenyStatus(503, "ibac.judge_unavailable", errPreview)
 	}
 
-	// 8. Apply verdict.
+	// 9. Apply verdict.
 	if verdict == "deny" {
 		pctx.Record(pipeline.Invocation{
 			Action: pipeline.ActionDeny,

--- a/authbridge/authlib/plugins/ibac/plugin.go
+++ b/authbridge/authlib/plugins/ibac/plugin.go
@@ -261,6 +261,21 @@ func (p *IBAC) OnRequest(ctx context.Context, pctx *pipeline.Context) pipeline.A
 		return pipeline.Action{Type: pipeline.Continue}
 	}
 
+	// 5b. Transport-stream bypass. Body-less GET requests carry no
+	//     action payload to evaluate — typical patterns: MCP Streamable
+	//     HTTP's server→client SSE channel, agent-card fetches, OAuth
+	//     metadata probes. Sending these to the judge is a category
+	//     error: there's nothing to judge, and the LLM either denies
+	//     for lack of context or returns a non-deterministic verdict
+	//     that depends on noise in the prompt. Side-effect requests
+	//     (POST/PUT/DELETE/PATCH) always have bodies and reach the
+	//     judge; an attacker can't smuggle an action through a body-
+	//     less GET without a request body to put it in.
+	if pctx.Method == "GET" && len(pctx.Body) == 0 {
+		pctx.Skip("transport_stream")
+		return pipeline.Action{Type: pipeline.Continue}
+	}
+
 	// 6. Pull the user's most recent declared intent. Two distinct
 	//    nil pathways, both fail closed but with different reasons so
 	//    operator dashboards can tell them apart:

--- a/authbridge/authlib/plugins/ibac/plugin.go
+++ b/authbridge/authlib/plugins/ibac/plugin.go
@@ -261,17 +261,29 @@ func (p *IBAC) OnRequest(ctx context.Context, pctx *pipeline.Context) pipeline.A
 		return pipeline.Action{Type: pipeline.Continue}
 	}
 
-	// 5b. Transport-stream bypass. Body-less GET requests carry no
-	//     action payload to evaluate — typical patterns: MCP Streamable
-	//     HTTP's server→client SSE channel, agent-card fetches, OAuth
-	//     metadata probes. Sending these to the judge is a category
+	// 5b. Transport-stream bypass. Body-less retrieval-shaped requests
+	//     carry no action payload to evaluate — typical patterns: MCP
+	//     Streamable HTTP's server→client SSE channel (GET), agent-
+	//     card fetches (GET), OAuth metadata probes (GET), CORS
+	//     preflights (OPTIONS), HEAD probes for cache validation /
+	//     existence checks. Sending these to the judge is a category
 	//     error: there's nothing to judge, and the LLM either denies
 	//     for lack of context or returns a non-deterministic verdict
-	//     that depends on noise in the prompt. Side-effect requests
-	//     (POST/PUT/DELETE/PATCH) always have bodies and reach the
-	//     judge; an attacker can't smuggle an action through a body-
-	//     less GET without a request body to put it in.
-	if pctx.Method == "GET" && len(pctx.Body) == 0 {
+	//     that depends on noise in the prompt.
+	//
+	//     Threat model: an attacker can't smuggle a payload through a
+	//     body-less GET/HEAD/OPTIONS — there's no request body to put
+	//     the action in. Side-effect HTTP methods (POST/PUT/DELETE/
+	//     PATCH) always reach the judge, body-having or not.
+	//
+	//     Caveat: servers that handle side-effect operations through
+	//     GET query strings (e.g. ?action=delete&id=42) violate REST
+	//     semantics and would bypass IBAC here — by design. Defending
+	//     against that needs to live in the server, not in IBAC; the
+	//     plugin trusts HTTP method semantics as a proxy for "is this
+	//     an action?", and a server that breaks that convention is
+	//     making its own authorization promises that IBAC can't see.
+	if isTransportRetrieval(pctx.Method) && len(pctx.Body) == 0 {
 		pctx.Skip("transport_stream")
 		return pipeline.Action{Type: pipeline.Continue}
 	}
@@ -491,6 +503,22 @@ func formatBodyExcerpt(body []byte, n int) string {
 // JSON-RPC notifications (any method starting with `notifications/`)
 // are also bypassed: they're one-way protocol signals, never tied to
 // a specific user turn.
+// isTransportRetrieval reports whether an HTTP method is one of the
+// retrieval-shaped methods that, combined with an empty body, signal
+// "transport-layer call, not a user-meaningful action." See step 5b
+// in OnRequest for the full threat-model rationale.
+//
+// HEAD shares GET's semantics by RFC 9110 §9.3.2 (servers MUST answer
+// HEAD identically to GET, sans body); OPTIONS is CORS preflight or
+// capability discovery, never an action.
+func isTransportRetrieval(method string) bool {
+	switch method {
+	case "GET", "HEAD", "OPTIONS":
+		return true
+	}
+	return false
+}
+
 func isMCPHousekeeping(method string) bool {
 	switch method {
 	case "initialize",

--- a/authbridge/authlib/plugins/ibac/plugin.go
+++ b/authbridge/authlib/plugins/ibac/plugin.go
@@ -583,6 +583,21 @@ func formatBodyExcerpt(body []byte, n int) string {
 // JSON-RPC notifications (any method starting with `notifications/`)
 // are also bypassed: they're one-way protocol signals, never tied to
 // a specific user turn.
+func isMCPHousekeeping(method string) bool {
+	switch method {
+	case "initialize",
+		"ping",
+		"tools/list",
+		"prompts/list",
+		"resources/list",
+		"resources/templates/list",
+		"completion/complete",
+		"logging/setLevel":
+		return true
+	}
+	return strings.HasPrefix(method, "notifications/")
+}
+
 // isTransportRetrieval reports whether an HTTP method is one of the
 // retrieval-shaped methods that, combined with an empty body, signal
 // "transport-layer call, not a user-meaningful action." See step 5b
@@ -597,21 +612,6 @@ func isTransportRetrieval(method string) bool {
 		return true
 	}
 	return false
-}
-
-func isMCPHousekeeping(method string) bool {
-	switch method {
-	case "initialize",
-		"ping",
-		"tools/list",
-		"prompts/list",
-		"resources/list",
-		"resources/templates/list",
-		"completion/complete",
-		"logging/setLevel":
-		return true
-	}
-	return strings.HasPrefix(method, "notifications/")
 }
 
 // extractMCPToolName pulls the tool name from a tools/call request's

--- a/authbridge/authlib/plugins/ibac/plugin_test.go
+++ b/authbridge/authlib/plugins/ibac/plugin_test.go
@@ -55,8 +55,11 @@ func invokeOnRequest(p pipeline.Plugin, pctx *pipeline.Context) pipeline.Action 
 }
 
 // makePCtx builds a minimal outbound pctx with a Session containing a
-// single A2A user-intent message ("summarize my emails"). Callers that
-// want to override individual fields mutate the returned context.
+// single A2A user-intent message ("summarize my emails"). Defaults
+// model a typical side-effect request — POST with a non-empty body —
+// so the pctx reaches the judge unless the test opts into a transport-
+// shaped path (body-less GET, housekeeping method, etc). Tests
+// override fields by mutating the returned context.
 func makePCtx(t *testing.T) *pipeline.Context {
 	t.Helper()
 	view := &pipeline.SessionView{
@@ -76,11 +79,12 @@ func makePCtx(t *testing.T) *pipeline.Context {
 	}
 	return &pipeline.Context{
 		Direction: pipeline.Outbound,
-		Method:    "GET",
+		Method:    "POST",
 		Scheme:    "http",
 		Host:      "weather-tool.team1.svc",
 		Path:      "/api/weather",
 		Headers:   http.Header{},
+		Body:      []byte(`{"city":"sf"}`),
 		Session:   view,
 	}
 }
@@ -370,6 +374,80 @@ func TestOnRequest_MCPToolsCallIsNotHousekeeping(t *testing.T) {
 
 	if fj.calls != 1 {
 		t.Errorf("judge calls = %d, want 1 (tools/call must be judged)", fj.calls)
+	}
+}
+
+// Body-less GET requests (MCP Streamable HTTP SSE channel, agent-card
+// fetches, OAuth metadata probes) carry no action payload and must
+// bypass the judge with reason "transport_stream". Without this, the
+// MCP client's SSE channel-open keeps getting 403'd, the connection
+// dies, and the agent loops on reconnect.
+func TestOnRequest_TransportStreamBypass_BodylessGET(t *testing.T) {
+	fj := &fakeJudge{}
+	p := newConfiguredIBAC(t, fj)
+
+	pctx := makePCtx(t)
+	pctx.Session = nil // bypass must fire before the session check
+	pctx.Method = "GET"
+	pctx.Host = "exgentic-mcp-gsm8k-mcp:8000"
+	pctx.Path = "/mcp"
+	pctx.Body = nil
+	action := invokeOnRequest(p, pctx)
+
+	if action.Type != pipeline.Continue {
+		t.Errorf("got %v, want Continue for body-less GET", action.Type)
+	}
+	if fj.calls != 0 {
+		t.Errorf("judge calls = %d, want 0 (body-less GET must not reach judge)", fj.calls)
+	}
+	inv := lastInvocation(t, pctx)
+	if inv.Action != pipeline.ActionSkip {
+		t.Errorf("Invocation action = %v, want ActionSkip", inv.Action)
+	}
+	if inv.Reason != "transport_stream" {
+		t.Errorf("Invocation reason = %q, want 'transport_stream'", inv.Reason)
+	}
+}
+
+// Body-having GETs (rare, but legal — e.g. some search APIs) must
+// still reach the judge: the body is the action.
+func TestOnRequest_TransportStreamBypass_GETWithBodyIsJudged(t *testing.T) {
+	fj := &fakeJudge{verdict: "allow"}
+	p := newConfiguredIBAC(t, fj)
+
+	pctx := makePCtx(t)
+	pctx.Method = "GET"
+	pctx.Host = "search-api"
+	pctx.Path = "/q"
+	pctx.Body = []byte(`{"q":"acme financials"}`)
+	_ = invokeOnRequest(p, pctx)
+
+	if fj.calls != 1 {
+		t.Errorf("judge calls = %d, want 1 (GET with body is an action)", fj.calls)
+	}
+}
+
+// Body-less POST/PUT/DELETE/PATCH must NOT bypass — the absence of
+// body alone isn't enough; the method must signal "retrieval" too.
+// A body-less POST is unusual but legal (semantic "do action") and
+// IBAC should still judge it.
+func TestOnRequest_TransportStreamBypass_BodylessPOSTIsJudged(t *testing.T) {
+	for _, method := range []string{"POST", "PUT", "DELETE", "PATCH"} {
+		t.Run(method, func(t *testing.T) {
+			fj := &fakeJudge{verdict: "allow"}
+			p := newConfiguredIBAC(t, fj)
+
+			pctx := makePCtx(t)
+			pctx.Method = method
+			pctx.Host = "api.example.com"
+			pctx.Path = "/refresh"
+			pctx.Body = nil
+			_ = invokeOnRequest(p, pctx)
+
+			if fj.calls != 1 {
+				t.Errorf("judge calls = %d, want 1 for body-less %s", fj.calls, method)
+			}
+		})
 	}
 }
 

--- a/authbridge/authlib/plugins/ibac/plugin_test.go
+++ b/authbridge/authlib/plugins/ibac/plugin_test.go
@@ -32,12 +32,28 @@ func (f *fakeJudge) Evaluate(_ context.Context, intent, action string) (string, 
 }
 
 // newConfiguredIBAC returns an IBAC plugin pre-wired with a fake judge,
-// minimal config, and a sensible bypass list. Callers that want to
-// override behavior can mutate p.cfg / p.judge after the fact.
+// minimal config, and a sensible bypass list. Uses the default
+// no_intent_policy ("allow"). Callers that want to override behavior
+// can mutate p.cfg / p.judge after the fact, or use
+// newConfiguredIBACDeny for the strict-deny variant.
 func newConfiguredIBAC(t *testing.T, fj *fakeJudge) *IBAC {
 	t.Helper()
 	p := NewIBAC()
 	cfg := []byte(`{"judge_endpoint":"http://judge.invalid","judge_model":"test","timeout_ms":1000}`)
+	if err := p.Configure(json.RawMessage(cfg)); err != nil {
+		t.Fatalf("Configure: %v", err)
+	}
+	p.judge = fj
+	return p
+}
+
+// newConfiguredIBACDeny returns an IBAC configured with
+// no_intent_policy: "deny" — used by tests that exercise the strict
+// fail-closed behavior on no_session / no_intent.
+func newConfiguredIBACDeny(t *testing.T, fj *fakeJudge) *IBAC {
+	t.Helper()
+	p := NewIBAC()
+	cfg := []byte(`{"judge_endpoint":"http://judge.invalid","judge_model":"test","timeout_ms":1000,"no_intent_policy":"deny"}`)
 	if err := p.Configure(json.RawMessage(cfg)); err != nil {
 		t.Fatalf("Configure: %v", err)
 	}
@@ -120,6 +136,37 @@ func TestConfigure_AppliesDefaults(t *testing.T) {
 	}
 	if len(p.cfg.BypassPaths) == 0 {
 		t.Errorf("expected non-empty default BypassPaths")
+	}
+	if p.cfg.NoIntentPolicy != NoIntentPolicyAllow {
+		t.Errorf("default NoIntentPolicy = %q, want %q (allow)",
+			p.cfg.NoIntentPolicy, NoIntentPolicyAllow)
+	}
+}
+
+func TestConfigure_NoIntentPolicy_RejectsUnknownValue(t *testing.T) {
+	p := NewIBAC()
+	cfg := `{"judge_endpoint":"http://j","judge_model":"m","no_intent_policy":"maybe"}`
+	err := p.Configure(json.RawMessage(cfg))
+	if err == nil {
+		t.Fatal("expected error for unknown no_intent_policy value")
+	}
+	if !strings.Contains(err.Error(), "no_intent_policy") {
+		t.Errorf("error should mention no_intent_policy; got %q", err.Error())
+	}
+}
+
+func TestConfigure_NoIntentPolicy_AcceptsExplicitValues(t *testing.T) {
+	for _, v := range []string{"allow", "deny"} {
+		t.Run(v, func(t *testing.T) {
+			p := NewIBAC()
+			cfg := fmt.Sprintf(`{"judge_endpoint":"http://j","judge_model":"m","no_intent_policy":%q}`, v)
+			if err := p.Configure(json.RawMessage(cfg)); err != nil {
+				t.Fatalf("Configure(%q): %v", v, err)
+			}
+			if p.cfg.NoIntentPolicy != v {
+				t.Errorf("NoIntentPolicy = %q, want %q", p.cfg.NoIntentPolicy, v)
+			}
+		})
 	}
 }
 
@@ -266,20 +313,19 @@ func TestOnRequest_InferenceJudgedWhenEnabled(t *testing.T) {
 	}
 }
 
-// no_intent fail-closed: if a2a-parser isn't in the inbound chain (or
-// no user message was sent yet), IBAC has no recorded intent. Deny —
-// the alternative would be to allow blind tool calls, which defeats
-// the purpose of the plugin.
-func TestOnRequest_NoIntent_FailsClosed(t *testing.T) {
+// no_intent under policy=deny: when the operator configures strict
+// fail-closed semantics, missing intent must reject with "no_intent".
+// Validates the legacy behavior is still reachable via explicit config.
+func TestOnRequest_NoIntent_PolicyDeny_FailsClosed(t *testing.T) {
 	fj := &fakeJudge{}
-	p := newConfiguredIBAC(t, fj)
+	p := newConfiguredIBACDeny(t, fj)
 
 	pctx := makePCtx(t)
 	pctx.Session = &pipeline.SessionView{ID: "empty"} // no events
 	action := invokeOnRequest(p, pctx)
 
 	if action.Type != pipeline.Reject {
-		t.Errorf("got %v, want Reject when LastIntent is nil", action.Type)
+		t.Errorf("got %v, want Reject when LastIntent is nil under policy=deny", action.Type)
 	}
 	if fj.calls != 0 {
 		t.Errorf("judge should not be called when there's no intent")
@@ -290,22 +336,49 @@ func TestOnRequest_NoIntent_FailsClosed(t *testing.T) {
 	}
 }
 
-// Nil Session must not panic. The forward-proxy listener leaves
-// pctx.Session nil whenever no inbound A2A request has seeded the
-// active session bucket yet — common at agent startup. Treat it as
-// a distinct fail-closed reason (no_session) so dashboards can tell
-// "no inbound has happened yet" apart from "session exists but
-// contains no intent" (no_intent).
-func TestOnRequest_NilSession_FailsClosed(t *testing.T) {
+// no_intent under policy=allow (default): missing intent means the
+// request is either a legitimate agent self-action or a non-user-
+// driven flow. IBAC should not be in the middle — Skip with reason
+// "no_user_context" and Continue.
+func TestOnRequest_NoIntent_PolicyAllow_Bypasses(t *testing.T) {
 	fj := &fakeJudge{}
-	p := newConfiguredIBAC(t, fj)
+	p := newConfiguredIBAC(t, fj) // default policy=allow
+
+	pctx := makePCtx(t)
+	pctx.Session = &pipeline.SessionView{ID: "empty"} // no events
+	action := invokeOnRequest(p, pctx)
+
+	if action.Type != pipeline.Continue {
+		t.Errorf("got %v, want Continue when no intent under policy=allow", action.Type)
+	}
+	if fj.calls != 0 {
+		t.Errorf("judge should not be called when there's no intent")
+	}
+	inv := lastInvocation(t, pctx)
+	if inv.Action != pipeline.ActionSkip {
+		t.Errorf("Invocation action = %v, want ActionSkip", inv.Action)
+	}
+	if inv.Reason != "no_user_context" {
+		t.Errorf("Invocation reason = %q, want 'no_user_context'", inv.Reason)
+	}
+	if inv.Details["sub_reason"] != "no_intent" {
+		t.Errorf("Invocation sub_reason = %q, want 'no_intent'", inv.Details["sub_reason"])
+	}
+}
+
+// Nil Session under policy=deny: forward-proxy at agent startup
+// (before any inbound A2A) leaves pctx.Session nil. With strict
+// fail-closed configured, that must reject with "no_session".
+func TestOnRequest_NilSession_PolicyDeny_FailsClosed(t *testing.T) {
+	fj := &fakeJudge{}
+	p := newConfiguredIBACDeny(t, fj)
 
 	pctx := makePCtx(t)
 	pctx.Session = nil // before any inbound A2A
 	action := invokeOnRequest(p, pctx)
 
 	if action.Type != pipeline.Reject {
-		t.Errorf("got %v, want Reject when Session is nil", action.Type)
+		t.Errorf("got %v, want Reject when Session is nil under policy=deny", action.Type)
 	}
 	if fj.calls != 0 {
 		t.Errorf("judge should not be called when there's no session")
@@ -313,6 +386,36 @@ func TestOnRequest_NilSession_FailsClosed(t *testing.T) {
 	inv := lastInvocation(t, pctx)
 	if inv.Reason != "no_session" {
 		t.Errorf("Invocation reason = %q, want 'no_session'", inv.Reason)
+	}
+}
+
+// Nil Session under policy=allow (default): the canonical "agent
+// self-action at startup" case. The agent (e.g. exgentic-a2a-tool-
+// calling) makes outbound calls during its bootstrap before any user
+// turn — IBAC must Skip and Continue, not deny.
+func TestOnRequest_NilSession_PolicyAllow_Bypasses(t *testing.T) {
+	fj := &fakeJudge{}
+	p := newConfiguredIBAC(t, fj) // default policy=allow
+
+	pctx := makePCtx(t)
+	pctx.Session = nil // before any inbound A2A
+	action := invokeOnRequest(p, pctx)
+
+	if action.Type != pipeline.Continue {
+		t.Errorf("got %v, want Continue when Session is nil under policy=allow", action.Type)
+	}
+	if fj.calls != 0 {
+		t.Errorf("judge should not be called when there's no session")
+	}
+	inv := lastInvocation(t, pctx)
+	if inv.Action != pipeline.ActionSkip {
+		t.Errorf("Invocation action = %v, want ActionSkip", inv.Action)
+	}
+	if inv.Reason != "no_user_context" {
+		t.Errorf("Invocation reason = %q, want 'no_user_context'", inv.Reason)
+	}
+	if inv.Details["sub_reason"] != "no_session" {
+		t.Errorf("Invocation sub_reason = %q, want 'no_session'", inv.Details["sub_reason"])
 	}
 }
 

--- a/authbridge/authlib/plugins/ibac/plugin_test.go
+++ b/authbridge/authlib/plugins/ibac/plugin_test.go
@@ -377,40 +377,47 @@ func TestOnRequest_MCPToolsCallIsNotHousekeeping(t *testing.T) {
 	}
 }
 
-// Body-less GET requests (MCP Streamable HTTP SSE channel, agent-card
-// fetches, OAuth metadata probes) carry no action payload and must
-// bypass the judge with reason "transport_stream". Without this, the
-// MCP client's SSE channel-open keeps getting 403'd, the connection
-// dies, and the agent loops on reconnect.
-func TestOnRequest_TransportStreamBypass_BodylessGET(t *testing.T) {
-	fj := &fakeJudge{}
-	p := newConfiguredIBAC(t, fj)
+// Body-less retrieval-shaped requests (MCP Streamable HTTP SSE channel,
+// agent-card fetches, OAuth metadata probes, CORS preflights, HEAD
+// probes) carry no action payload and must bypass the judge with reason
+// "transport_stream". Without this, the MCP client's SSE channel-open
+// keeps getting 403'd, the connection dies, and the agent loops on
+// reconnect. Covers GET, HEAD, OPTIONS — all share the body-less
+// retrieval semantics per RFC 9110.
+func TestOnRequest_TransportStreamBypass_BodylessRetrieval(t *testing.T) {
+	for _, method := range []string{"GET", "HEAD", "OPTIONS"} {
+		t.Run(method, func(t *testing.T) {
+			fj := &fakeJudge{}
+			p := newConfiguredIBAC(t, fj)
 
-	pctx := makePCtx(t)
-	pctx.Session = nil // bypass must fire before the session check
-	pctx.Method = "GET"
-	pctx.Host = "exgentic-mcp-gsm8k-mcp:8000"
-	pctx.Path = "/mcp"
-	pctx.Body = nil
-	action := invokeOnRequest(p, pctx)
+			pctx := makePCtx(t)
+			pctx.Session = nil // bypass must fire before the session check
+			pctx.Method = method
+			pctx.Host = "exgentic-mcp-gsm8k-mcp:8000"
+			pctx.Path = "/mcp"
+			pctx.Body = nil
+			action := invokeOnRequest(p, pctx)
 
-	if action.Type != pipeline.Continue {
-		t.Errorf("got %v, want Continue for body-less GET", action.Type)
-	}
-	if fj.calls != 0 {
-		t.Errorf("judge calls = %d, want 0 (body-less GET must not reach judge)", fj.calls)
-	}
-	inv := lastInvocation(t, pctx)
-	if inv.Action != pipeline.ActionSkip {
-		t.Errorf("Invocation action = %v, want ActionSkip", inv.Action)
-	}
-	if inv.Reason != "transport_stream" {
-		t.Errorf("Invocation reason = %q, want 'transport_stream'", inv.Reason)
+			if action.Type != pipeline.Continue {
+				t.Errorf("got %v, want Continue for body-less %s", action.Type, method)
+			}
+			if fj.calls != 0 {
+				t.Errorf("judge calls = %d, want 0 (body-less %s must not reach judge)", fj.calls, method)
+			}
+			inv := lastInvocation(t, pctx)
+			if inv.Action != pipeline.ActionSkip {
+				t.Errorf("Invocation action = %v, want ActionSkip", inv.Action)
+			}
+			if inv.Reason != "transport_stream" {
+				t.Errorf("Invocation reason = %q, want 'transport_stream'", inv.Reason)
+			}
+		})
 	}
 }
 
-// Body-having GETs (rare, but legal — e.g. some search APIs) must
-// still reach the judge: the body is the action.
+// Body-having retrieval-shaped requests (rare, but legal — e.g. some
+// search APIs accept GET with a JSON body) must still reach the judge:
+// the body is the action.
 func TestOnRequest_TransportStreamBypass_GETWithBodyIsJudged(t *testing.T) {
 	fj := &fakeJudge{verdict: "allow"}
 	p := newConfiguredIBAC(t, fj)
@@ -448,6 +455,34 @@ func TestOnRequest_TransportStreamBypass_BodylessPOSTIsJudged(t *testing.T) {
 				t.Errorf("judge calls = %d, want 1 for body-less %s", fj.calls, method)
 			}
 		})
+	}
+}
+
+// describeAction's first non-empty token must be the HTTP method, with
+// no leading whitespace. This locks in the listener-side pctx.Method
+// wiring contract: if any listener regresses to leaving Method empty,
+// describeAction renders " http://..." (note the leading space) and
+// the judge sees a malformed prompt while operators see a confusing
+// session-event display. The visible-symptom test catches that here
+// rather than relying on the listener-package tests alone.
+func TestOnRequest_DescribeActionHasNoLeadingWhitespace(t *testing.T) {
+	fj := &fakeJudge{verdict: "allow"}
+	p := newConfiguredIBAC(t, fj)
+
+	pctx := makePCtx(t) // POST + body, will be judged
+	_ = invokeOnRequest(p, pctx)
+
+	if fj.calls != 1 {
+		t.Fatalf("expected judge to be called once; got calls=%d", fj.calls)
+	}
+	if fj.gotAction == "" {
+		t.Fatal("describeAction was empty; cannot assert format")
+	}
+	if first := fj.gotAction[0]; first == ' ' || first == '\t' || first == '\n' {
+		t.Errorf("describeAction starts with whitespace (listener Method regression?); got %q", fj.gotAction)
+	}
+	if !strings.HasPrefix(fj.gotAction, "POST ") {
+		t.Errorf("describeAction should start with 'POST '; got %q", fj.gotAction)
 	}
 }
 


### PR DESCRIPTION
## Summary

Three related IBAC behavior changes that together stop the plugin from blocking legitimate non-user-driven agent traffic, while keeping its core threat model intact:

1. **Populate `pctx.Method`** in all three listeners (forwardproxy, reverseproxy, extproc) — they were leaving it empty, masking a real listener bug and breaking any plugin that wants to act on HTTP method.
2. **`transport_stream` bypass** for body-less retrieval-shaped requests (GET/HEAD/OPTIONS with no body), so the MCP Streamable HTTP server→client SSE channel, agent-card fetches, OAuth metadata probes, and CORS preflights are not sent to the LLM judge.
3. **`no_intent_policy` config field**, default `"allow"`, controlling what happens when IBAC reaches the intent check without a recorded user intent. Allow = treat as agent self-action and Skip; deny = preserve the prior 403 fail-closed semantics.

## Why

On a real agent (`exgentic-a2a-tool-calling-gsm8k` in team1), IBAC was denying multiple classes of legitimate traffic:

| Symptom | Root cause | Fix in this PR |
|---|---|---|
| `no_intent` denials at agent startup, before any user turn | Agent's MCP client opens GET /mcp for SSE alongside its POST endpoint; mcp-parser silently skips body-less requests, IBAC falls through to intent check | `transport_stream` bypass |
| `blocked` denials of the SSE GET after a user turn — judge correctly noting "no specific task or calculation is provided" because the SSE open carries no payload | Same as above; judge was being asked to evaluate something with nothing to evaluate | `transport_stream` bypass |
| `judge_unavailable` denials when Ollama hiccups | Same as above; the SSE GET was needlessly reaching the judge | `transport_stream` bypass |
| Action description in session events showing `" http://..."` (leading space) | Listeners weren't populating `pctx.Method`, so `describeAction()` rendered the empty method as just whitespace | Populate `pctx.Method` in all listeners |
| Hypothetical: agent making `tools/call` with its own credentials before any user turn (initialization, machine-to-machine, headless cron) | IBAC fails closed on no_session / no_intent, with no way to distinguish "non-user-driven flow" from "misconfiguration" | `no_intent_policy: allow` (default) |

All four denies in that pod's session timeline disappear with this PR.

## What changes

### Listener prerequisite

`authlib/listener/{forwardproxy,reverseproxy,extproc}/server.go` — populate `pctx.Method` at every pctx construction site. HTTP listeners read `r.Method`; ext_proc reads the `:method` HTTP/2 pseudo-header (matching the existing `:scheme` / `:path` / `:authority` pattern).

### transport_stream bypass

`authlib/plugins/ibac/plugin.go` — new step 5b in `OnRequest`:

```go
if isTransportRetrieval(pctx.Method) && len(pctx.Body) == 0 {
    pctx.Skip("transport_stream")
    return pipeline.Action{Type: pipeline.Continue}
}
```

Where `isTransportRetrieval` covers `GET`, `HEAD`, `OPTIONS`. Placed after the existing `mcp_housekeeping` check, before the intent fetch.

**Threat model:** an attacker can't smuggle a payload through a body-less GET/HEAD/OPTIONS — there's no request body to put the action in. POST/PUT/DELETE/PATCH (the methods that carry action semantics) always reach the judge.

**Caveat:** servers that handle side-effect operations through GET query strings (e.g. `?action=delete&id=42`) violate REST semantics and would bypass IBAC here — by design. Defending against that needs to live in the server, not in IBAC.

### no_intent_policy

New config field with two values:

- `"allow"` (default): Skip with reason `"no_user_context"`, Continue. Treats the request as a legitimate non-user-driven action. The Invocation carries a `sub_reason` (`"no_session"` or `"no_intent"`) so operators can still distinguish the two states in abctl.
- `"deny"`: Reject 403 with the existing `"no_session"` / `"no_intent"` reasons. Preserves the prior fail-closed semantics.

Default is `"allow"` because IBAC's threat model targets prompt-injection making the agent emit user-misaligned actions — that requires there to be a user. When there isn't one (agent self-actions during init, machine-to-machine A2A, headless cron-driven flows), IBAC has nothing to align against.

The trade-off: an attacker who compromises the agent before the first user turn (e.g. via a poisoned tool-list response triggering bootstrap LLM reasoning) is no longer caught by IBAC during that pre-user window. That's outside IBAC's threat model anyway — credential theft and pre-deployment compromise need different controls (mTLS, SPIFFE attestation, policy on the credential issuer). Operators who deploy IBAC against purely user-driven agents and want hard fail-closed semantics flip to `no_intent_policy: deny`.

## Test plan

- [x] `go test ./...` in `authbridge/authlib` — all packages pass
- [x] New tests cover:
  - body-less GET/HEAD/OPTIONS → skip/transport_stream
  - GET with body → judged
  - body-less POST/PUT/DELETE/PATCH → judged
  - `describeAction` has no leading whitespace (regression lock on listener Method wiring)
  - `no_intent_policy` defaults to `"allow"`
  - Configure rejects unknown values, accepts both `"allow"` and `"deny"`
  - NilSession + policy=allow → skip/no_user_context with sub_reason=no_session
  - NoIntent + policy=allow → skip/no_user_context with sub_reason=no_intent
  - NilSession + policy=deny → reject 403 (legacy)
  - NoIntent + policy=deny → reject 403 (legacy)
- [ ] Redeploy `authbridge:latest` to `team1/exgentic-a2a-tool-calling-gsm8k` and confirm:
  - All four denies (rows 3, 5, 9, 10 in the abctl session timeline) become `skip` rows
  - Agent's MCP transport stays open without re-handshaking
  - Once a user submits a task, `tools/call` traffic is still judged

## Notes

- The listener `pctx.Method` fix is a prerequisite for the GET/HEAD/OPTIONS check — without it, the bypass never matches because `Method == ""` everywhere. Split into a separate commit for review clarity.
- All three behavior changes (transport_stream, no_intent_policy default, listener Method) compound to fix the observed pod symptoms with a single PR. They could ship separately if reviewers prefer; the commits are isolated enough to cherry-pick.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure the HTTP method is consistently included in pipeline contexts for all request and tunnel flows.

* **New Features**
  * Add a configurable policy to control handling of requests with no user intent or session (default: allow-through).

* **Performance**
  * Skip expensive judgment for body-less retrieval-style requests (GET/HEAD/OPTIONS) to avoid unnecessary evaluation.

* **Tests**
  * Expanded coverage for bypass behavior, policy-dependent outcomes, and judge output formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kagenti/kagenti-extensions/pull/450?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->