### PR TITLE
broker plugin: Adding logs

### DIFF
--- a/authbridge/authlib/plugins/tokenbroker/client/client.go
+++ b/authbridge/authlib/plugins/tokenbroker/client/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"time"
 )
@@ -55,6 +56,10 @@ func (c *Client) AcquireToken(ctx context.Context, tokenBrokerURL, token, server
 		return "", fmt.Errorf("token broker request failed: %w", err)
 	}
 	defer resp.Body.Close()
+
+	slog.Debug("token-broker-client: received response from broker",
+		"status_code", resp.StatusCode,
+		"server_url", serverURL)
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20)) // 10MB limit
 	if err != nil {

--- a/authbridge/authlib/plugins/tokenbroker/plugin.go
+++ b/authbridge/authlib/plugins/tokenbroker/plugin.go
@@ -225,18 +225,7 @@ func (p *TokenBroker) OnRequest(ctx context.Context, pctx *pipeline.Context) pip
 		return pipeline.Action{Type: pipeline.Continue}
 	}
 
-	// Extract bearer token
-	subjectToken := extractBearer(authHeader)
-	if subjectToken == "" {
-		return pctx.DenyAndRecord("missing_subject_token", "auth.missing-token",
-			"broker route requires authorization token")
-	}
-
-	// Derive server URL from scheme + host. pctx.Scheme is populated
-	// by the listener from :scheme (ext_proc / ext_authz) or
-	// r.URL.Scheme / r.TLS (forward / reverse proxy). Defaults to
-	// "http" when the listener couldn't determine one — matches the
-	// previous hardcoded behavior.
+	// Derive server URL for logging
 	scheme := pctx.Scheme
 	if scheme == "" {
 		scheme = "http"
@@ -245,6 +234,23 @@ func (p *TokenBroker) OnRequest(ctx context.Context, pctx *pipeline.Context) pip
 
 	// Use the plugin's configured broker URL
 	brokerURL := p.cfg.BrokerURL
+
+	slog.Info("token-broker: processing outbound request",
+		"server_url", serverURL,
+		"broker_url", brokerURL)
+
+	// Extract bearer token
+	subjectToken := extractBearer(authHeader)
+	if subjectToken == "" {
+		return pctx.DenyAndRecord("missing_subject_token", "auth.missing-token",
+			"broker route requires authorization token")
+	}
+
+	slog.Debug("token-broker: requesting token from broker",
+		"server_url", serverURL,
+		"broker_url", brokerURL,
+		"authorization_endpoint", authorizationEndpoint,
+		"token_endpoint", tokenEndpoint)
 
 	// Call broker to acquire token, passing authorization and token endpoints if available
 	token, err := p.client.AcquireToken(ctx, brokerURL, subjectToken, serverURL, authorizationEndpoint, tokenEndpoint)
@@ -292,6 +298,10 @@ func (p *TokenBroker) OnRequest(ctx context.Context, pctx *pipeline.Context) pip
 	// Replace token in authorization header
 	pctx.Headers.Set("Authorization", "Bearer "+token)
 
+	slog.Info("token-broker: token acquired and added to request",
+		"server_url", serverURL,
+		"broker_url", brokerURL)
+
 	// Record successful token replacement
 	pctx.Record(pipeline.Invocation{
 		Action:  pipeline.ActionModify,
@@ -301,7 +311,18 @@ func (p *TokenBroker) OnRequest(ctx context.Context, pctx *pipeline.Context) pip
 	return pipeline.Action{Type: pipeline.Continue}
 }
 
-func (p *TokenBroker) OnResponse(_ context.Context, _ *pipeline.Context) pipeline.Action {
+func (p *TokenBroker) OnResponse(ctx context.Context, pctx *pipeline.Context) pipeline.Action {
+	// Derive server URL for logging
+	scheme := pctx.Scheme
+	if scheme == "" {
+		scheme = "http"
+	}
+	serverURL := scheme + "://" + pctx.Host
+
+	slog.Info("token-broker: received outbound response",
+		"server_url", serverURL,
+		"status_code", pctx.StatusCode,
+		"has_response_body", len(pctx.ResponseBody) > 0)
 	return pipeline.Action{Type: pipeline.Continue}
 }
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (must be EXACT, case-sensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix must match EXACT CASE (this is enforced by our PR Title
    workflow, which validates exact-match prefixes via the
    `allowed_prefixes` input of the GitHub Action used). [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`).

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary
Add logs to Broker Plugin


Fixes #453 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced logging for the Token Broker: responses now record status codes and server URLs.
  * Added structured logs for outbound processing and token-acquisition steps, including pre-call details and post-acquisition confirmation.
  * Response handling now logs presence of a response body alongside status metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->