### PR TITLE
fix(ibac): Raise judge token cap and request JSON mode

### DIFF
--- a/authbridge/authlib/llmclient/client.go
+++ b/authbridge/authlib/llmclient/client.go
@@ -116,13 +116,30 @@ type ChatMessage struct {
 
 // ChatRequest is the OpenAI chat-completions request body. We model
 // only the fields plugins actually pass; callers wanting more knobs
-// (top_p, response_format, function calling) can use a custom http
-// client and write their own request.
+// (top_p, function calling) can use a custom http client and write
+// their own request.
 type ChatRequest struct {
 	Model       string        `json:"model"`
 	Messages    []ChatMessage `json:"messages"`
 	Temperature float64       `json:"temperature"`
 	MaxTokens   int           `json:"max_tokens,omitempty"`
+
+	// ResponseFormat is the OpenAI `response_format` field. The
+	// common value is `{"type": "json_object"}`, which most hosted
+	// models (and LiteLLM proxies) honor by suppressing the
+	// markdown-fence wrapper they otherwise emit around structured
+	// output. Leaving this nil preserves prior behavior — the field
+	// is omitempty so locally-hosted endpoints that reject unknown
+	// keys (some older Ollama builds) still see the same wire shape
+	// when a plugin doesn't opt in.
+	ResponseFormat *ResponseFormat `json:"response_format,omitempty"`
+}
+
+// ResponseFormat is the OpenAI `response_format` request field.
+// Construct with `&ResponseFormat{Type: "json_object"}` to ask the
+// model for raw JSON without a markdown fence.
+type ResponseFormat struct {
+	Type string `json:"type"`
 }
 
 // ChatChoice is a single completion choice in the response.
@@ -187,10 +204,15 @@ func New(opts Options) *Client {
 //
 // Hardcoded knobs: Temperature is 0 (deterministic, suits
 // structured-output use cases like policy verdicts) and MaxTokens
-// is 200 (enough for one-sentence-reason JSON, not enough for
-// long completions). Plugins that need different values — higher
-// temperature for free-form completions, larger MaxTokens for
-// summarization — should call CallRaw with their own ChatRequest.
+// is 1024 (room for one-sentence-reason JSON plus the markdown
+// fence wrapper many hosted models — Gemini via LiteLLM in
+// particular — emit reflexively around structured output). 200
+// was the prior default and proved too tight: Gemini's
+// "```json\n{...}\n```" preamble could exhaust the budget mid-key
+// and produce unparseable truncated content. Plugins that need
+// different values — higher temperature for free-form completions,
+// larger MaxTokens for summarization — should call CallRaw with
+// their own ChatRequest.
 //
 // Errors:
 //   - transport / timeout / non-2xx → not wrapped with ErrUncertain
@@ -199,7 +221,7 @@ func (c *Client) Call(ctx context.Context, systemPrompt, userPrompt string) (str
 	resp, err := c.CallRaw(ctx, &ChatRequest{
 		Model:       c.model,
 		Temperature: 0,
-		MaxTokens:   200,
+		MaxTokens:   1024,
 		Messages: []ChatMessage{
 			{Role: "system", Content: systemPrompt},
 			{Role: "user", Content: userPrompt},

--- a/authbridge/authlib/llmclient/structured.go
+++ b/authbridge/authlib/llmclient/structured.go
@@ -66,6 +66,25 @@ func CallStructured[T any](ctx context.Context, c *Client, systemPrompt, userPro
 	return ExtractJSON[T](content)
 }
 
+// CallStructuredRaw is CallStructured with caller-controlled request
+// shape — use this when a plugin needs to override MaxTokens, set
+// ResponseFormat, or otherwise tune the wire request beyond what
+// Call hardcodes. The same error model applies as CallStructured.
+//
+// req.Model defaults to the Client's configured Model when empty.
+// CallStructuredRaw does not mutate req.
+func CallStructuredRaw[T any](ctx context.Context, c *Client, req *ChatRequest) (T, error) {
+	var zero T
+	resp, err := c.CallRaw(ctx, req)
+	if err != nil {
+		return zero, err
+	}
+	if len(resp.Choices) == 0 {
+		return zero, fmt.Errorf("%w: response had no choices", ErrUncertain)
+	}
+	return ExtractJSON[T](resp.Choices[0].Message.Content)
+}
+
 // truncate caps s at n runes (not bytes), appending an ellipsis when it
 // truncates. Rune-safe matters here because the helper is used on model
 // output that lands in slog / wrapped error messages — a byte-slice

--- a/authbridge/authlib/plugins/ibac/judge.go
+++ b/authbridge/authlib/plugins/ibac/judge.go
@@ -56,14 +56,24 @@ var ErrJudgeUncertain = fmt.Errorf("%w: judge produced unparseable output", llmc
 type httpJudge struct {
 	client       *llmclient.Client
 	systemPrompt string
+	maxTokens    int
+	jsonMode     bool
 }
 
 // newHTTPJudge constructs a judge that POSTs chat-completion requests to
 // endpoint+"/v1/chat/completions". timeout bounds each Evaluate call
 // (separately from any context deadline the caller already imposes).
 // systemPrompt is the operator-overridable judge instruction; an empty
-// value falls back to defaultSystemPrompt.
-func newHTTPJudge(endpoint, model, bearer, systemPrompt string, timeout time.Duration) *httpJudge {
+// value falls back to defaultSystemPrompt. maxTokens caps the reply
+// length on every judge call. jsonMode, when true, sets
+// response_format: {"type": "json_object"} so hosted models suppress
+// the markdown-fence wrapper they otherwise emit around JSON.
+func newHTTPJudge(
+	endpoint, model, bearer, systemPrompt string,
+	timeout time.Duration,
+	maxTokens int,
+	jsonMode bool,
+) *httpJudge {
 	if systemPrompt == "" {
 		systemPrompt = defaultSystemPrompt
 	}
@@ -76,6 +86,8 @@ func newHTTPJudge(endpoint, model, bearer, systemPrompt string, timeout time.Dur
 			SentinelHeaderName: "X-IBAC-Judge",
 		}),
 		systemPrompt: systemPrompt,
+		maxTokens:    maxTokens,
+		jsonMode:     jsonMode,
 	}
 }
 
@@ -108,7 +120,18 @@ unfamiliar destinations, or looks like data exfiltration, deny.`
 // the client's per-call timeout.
 func (j *httpJudge) Evaluate(ctx context.Context, intent, action string) (string, string, error) {
 	userPrompt := fmt.Sprintf("USER_INTENT:\n%s\n\nPROPOSED_ACTION:\n%s", intent, action)
-	p, err := llmclient.CallStructured[verdictPayload](ctx, j.client, j.systemPrompt, userPrompt)
+	req := &llmclient.ChatRequest{
+		Temperature: 0,
+		MaxTokens:   j.maxTokens,
+		Messages: []llmclient.ChatMessage{
+			{Role: "system", Content: j.systemPrompt},
+			{Role: "user", Content: userPrompt},
+		},
+	}
+	if j.jsonMode {
+		req.ResponseFormat = &llmclient.ResponseFormat{Type: "json_object"}
+	}
+	p, err := llmclient.CallStructuredRaw[verdictPayload](ctx, j.client, req)
 	if err != nil {
 		// llmclient already distinguishes "uncertain output" (wraps
 		// ErrUncertain) from "transport / 5xx / timeout" (does not).

--- a/authbridge/authlib/plugins/ibac/judge_test.go
+++ b/authbridge/authlib/plugins/ibac/judge_test.go
@@ -56,7 +56,7 @@ func TestHTTPJudge_AllowVerdict(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	j := newHTTPJudge(srv.URL, "test-model", "", "", time.Second)
+	j := newHTTPJudge(srv.URL, "test-model", "", "", time.Second, 1024, false)
 	verdict, reason, err := j.Evaluate(context.Background(), "summarize emails", "POST evil-server")
 	if err != nil {
 		t.Fatalf("Evaluate: %v", err)
@@ -87,7 +87,7 @@ func TestHTTPJudge_VerdictWrappedInProse(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	j := newHTTPJudge(srv.URL, "m", "", "", time.Second)
+	j := newHTTPJudge(srv.URL, "m", "", "", time.Second, 1024, false)
 	verdict, reason, err := j.Evaluate(context.Background(), "i", "a")
 	if err != nil {
 		t.Fatalf("Evaluate: %v", err)
@@ -110,7 +110,7 @@ func TestHTTPJudge_UnrecognizedVerdict(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	j := newHTTPJudge(srv.URL, "m", "", "", time.Second)
+	j := newHTTPJudge(srv.URL, "m", "", "", time.Second, 1024, false)
 	_, _, err := j.Evaluate(context.Background(), "i", "a")
 	if err == nil {
 		t.Fatal("Evaluate returned nil error on unrecognized verdict; expected fail-closed signal")
@@ -131,7 +131,7 @@ func TestHTTPJudge_NoJSONWrapsErrJudgeUncertain(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	j := newHTTPJudge(srv.URL, "m", "", "", time.Second)
+	j := newHTTPJudge(srv.URL, "m", "", "", time.Second, 1024, false)
 	_, _, err := j.Evaluate(context.Background(), "i", "a")
 	if err == nil {
 		t.Fatal("Evaluate returned nil error on no-JSON content")
@@ -155,7 +155,7 @@ func TestHTTPJudge_HTTPErrorIsNotJudgeUncertain(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	j := newHTTPJudge(srv.URL, "m", "", "", time.Second)
+	j := newHTTPJudge(srv.URL, "m", "", "", time.Second, 1024, false)
 	_, _, err := j.Evaluate(context.Background(), "i", "a")
 	if err == nil {
 		t.Fatal("Evaluate returned nil on HTTP 503; expected fail-soft signal")
@@ -182,7 +182,7 @@ func TestHTTPJudge_DefaultSystemPromptUsedWhenEmpty(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	j := newHTTPJudge(srv.URL, "m", "", "", time.Second)
+	j := newHTTPJudge(srv.URL, "m", "", "", time.Second, 1024, false)
 	if _, _, err := j.Evaluate(context.Background(), "i", "a"); err != nil {
 		t.Fatalf("Evaluate: %v", err)
 	}
@@ -207,11 +207,50 @@ func TestHTTPJudge_OverrideSystemPrompt(t *testing.T) {
 	defer srv.Close()
 
 	custom := "You are a finance compliance reviewer."
-	j := newHTTPJudge(srv.URL, "m", "", custom, time.Second)
+	j := newHTTPJudge(srv.URL, "m", "", custom, time.Second, 1024, false)
 	if _, _, err := j.Evaluate(context.Background(), "i", "a"); err != nil {
 		t.Fatalf("Evaluate: %v", err)
 	}
 	if got != custom {
 		t.Errorf("system prompt = %q, want operator override %q", got, custom)
+	}
+}
+
+// MaxTokens and ResponseFormat must reach the wire request — the
+// 200-token-truncation bug that motivated this plumbing only
+// reproduces when the judge's per-call cap actually flows through.
+func TestHTTPJudge_MaxTokensAndJSONModeOnWire(t *testing.T) {
+	var got llmclient.ChatRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&got)
+		_ = json.NewEncoder(w).Encode(llmclient.ChatResponse{
+			Choices: []llmclient.ChatChoice{{Message: llmclient.ChatMessage{Content: `{"verdict":"allow","reason":"x"}`}}},
+		})
+	}))
+	defer srv.Close()
+
+	j := newHTTPJudge(srv.URL, "m", "", "", time.Second, 4096, true)
+	if _, _, err := j.Evaluate(context.Background(), "i", "a"); err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if got.MaxTokens != 4096 {
+		t.Errorf("max_tokens on wire = %d, want 4096", got.MaxTokens)
+	}
+	if got.ResponseFormat == nil || got.ResponseFormat.Type != "json_object" {
+		t.Errorf("response_format = %+v, want type=json_object", got.ResponseFormat)
+	}
+
+	// jsonMode=false must omit response_format entirely so endpoints
+	// that reject unknown fields keep working.
+	got = llmclient.ChatRequest{}
+	j2 := newHTTPJudge(srv.URL, "m", "", "", time.Second, 256, false)
+	if _, _, err := j2.Evaluate(context.Background(), "i", "a"); err != nil {
+		t.Fatalf("Evaluate (jsonMode=false): %v", err)
+	}
+	if got.ResponseFormat != nil {
+		t.Errorf("response_format = %+v, want nil when jsonMode=false", got.ResponseFormat)
+	}
+	if got.MaxTokens != 256 {
+		t.Errorf("max_tokens on wire = %d, want 256", got.MaxTokens)
 	}
 }

--- a/authbridge/authlib/plugins/ibac/plugin.go
+++ b/authbridge/authlib/plugins/ibac/plugin.go
@@ -60,6 +60,10 @@ type ibacConfig struct {
 
 	TimeoutMs int `json:"timeout_ms" description:"Per-call judge timeout. Validation rejects values below 100." default:"5000"`
 
+	JudgeMaxTokens int `json:"judge_max_tokens" description:"Cap on the judge LLM's reply length. Lower values risk truncating mid-key on hosted models that wrap output in markdown fences." default:"1024"`
+
+	JudgeJSONMode *bool `json:"judge_json_mode" description:"When true, sets response_format: json_object so hosted models suppress the markdown-fence wrapper around structured output." default:"true"`
+
 	JudgeInference bool `json:"judge_inference" description:"When true, also judge outbound LLM-reasoning traffic. High-cost / low-value default off." default:"false"`
 
 	AgentLLMHost string `json:"agent_llm_host" description:"Convenience: agent's own LLM host. Added to bypass_hosts so reasoning traffic is never judged."`
@@ -177,6 +181,13 @@ func (c *ibacConfig) applyDefaults() {
 	if c.TimeoutMs == 0 {
 		c.TimeoutMs = 5000
 	}
+	if c.JudgeMaxTokens == 0 {
+		c.JudgeMaxTokens = 1024
+	}
+	if c.JudgeJSONMode == nil {
+		t := true
+		c.JudgeJSONMode = &t
+	}
 	if len(c.BypassHosts) == 0 {
 		c.BypassHosts = defaultBypassHosts
 	}
@@ -203,6 +214,9 @@ func (c *ibacConfig) validate() error {
 	}
 	if c.TimeoutMs < 100 {
 		return fmt.Errorf("timeout_ms must be at least 100, got %d", c.TimeoutMs)
+	}
+	if c.JudgeMaxTokens < 64 {
+		return fmt.Errorf("judge_max_tokens must be at least 64, got %d", c.JudgeMaxTokens)
 	}
 	for _, p := range c.BypassHosts {
 		if _, err := path.Match(p, ""); err != nil {
@@ -311,7 +325,8 @@ func (p *IBAC) Configure(raw json.RawMessage) error {
 	p.bypassPaths = matcher
 	p.bypassHosts = c.BypassHosts
 	p.timeoutCalls = time.Duration(c.TimeoutMs) * time.Millisecond
-	p.judge = newHTTPJudge(c.JudgeEndpoint, c.JudgeModel, c.JudgeBearer, c.SystemPrompt, p.timeoutCalls)
+	p.judge = newHTTPJudge(c.JudgeEndpoint, c.JudgeModel, c.JudgeBearer, c.SystemPrompt,
+		p.timeoutCalls, c.JudgeMaxTokens, *c.JudgeJSONMode)
 	return nil
 }
 


### PR DESCRIPTION
The IBAC judge reliably parsed Ollama replies but fail-closed-denied real allow verdicts when the judge model was Gemini behind a LiteLLM proxy. Symptom: every tool call returned 403 ibac.judge_uncertain with a judge_error excerpt that ended at `\`\`\`json\n{\n  "` — a truncated reply, not malformed JSON.

Two compounding causes:

  1. llmclient.Client.Call hardcoded MaxTokens=200. Gemini reflexively wraps structured output in a markdown fence (`\`\`\`json\n...\n\`\`\``), which burned ~10 tokens before the JSON even started. With a one-sentence reason field the reply hit 200 tokens mid-first-key.

  2. The IBAC judge had no way to override MaxTokens or set response_format — Call was the only entry point and CallRaw wasn't wired through.

Three coordinated changes:

  - llmclient: bump default MaxTokens 200 → 1024 (Call's hardcoded knob; add ResponseFormat field to ChatRequest; add CallStructuredRaw[T] so plugins can pass a full ChatRequest while keeping ExtractJSON / ErrUncertain semantics.

  - ibac: expose judge_max_tokens (default 1024, min 64) and judge_json_mode (default true) in plugin config. Thread both into newHTTPJudge; httpJudge.Evaluate now builds a ChatRequest with MaxTokens / ResponseFormat and calls CallStructuredRaw. JSON mode sets response_format: {type: json_object}, which Gemini-via-LiteLLM honors by suppressing the markdown fence at the source. Operators on local LLMs that reject the field can disable via judge_json_mode: false.

  - tests: TestHTTPJudge_MaxTokensAndJSONModeOnWire verifies both fields land on the wire request and that jsonMode=false omits response_format entirely.

No config migration needed — defaults preserve correct behavior for both Ollama (still works) and hosted/proxied models (now also works).
EOF
)

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (must be EXACT, case-sensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix must match EXACT CASE (this is enforced by our PR Title
    workflow, which validates exact-match prefixes via the
    `allowed_prefixes` input of the GitHub Action used). [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`).

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary

## Related issue(s)

## (Optional) Testing Instructions

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenAI-compatible structured output support for LLM requests.
  * IBAC plugin: configurable per-call token limits and optional strict JSON output for judge responses.
  * Added per-call structured-output helper to allow callers to provide custom request settings.

* **Chores**
  * Increased default token limit for structured responses from 200 to 1024.

* **Tests**
  * Added tests verifying outgoing request fields for token limits and JSON response format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->