### PR TITLE
demo(authbridge): fail fast in echo demo preflight when python-keycloak is missing

### DIFF
--- a/authbridge/demos/echo/Makefile
+++ b/authbridge/demos/echo/Makefile
@@ -94,6 +94,13 @@ preflight:  ## Verify kagenti is installed + tools are available
 	  echo "       Install: pip3 install --user pyyaml"; \
 	  exit 1; \
 	}
+	@python3 -c 'import keycloak' 2>/dev/null || { \
+	  echo "ERROR: python-keycloak is required (used later by setup-keycloak)."; \
+	  echo "       Install: pip install python-keycloak"; \
+	  echo "       Checked here in preflight so demo-echo fails before the"; \
+	  echo "       build/deploy steps rather than after them."; \
+	  exit 1; \
+	}
 
 # ---------- Sidecar (authbridge proxy) ----------
 


### PR DESCRIPTION
## Summary

Follow-up to #464 (credential placeholder-swap). Small UX fix to the `echo` demo's `make demo-echo`.

`make demo-echo` checks `python-keycloak` only inside the late `setup-keycloak` target. When the package is missing, the demo fails **after** building the sidecar + demo images, overriding the operator's platform config, and deploying the agent/upstream — wasting all of that work before erroring on a missing pip package.

This moves the `python-keycloak` check into `preflight` (the first step of `demo-echo`), so it fails fast with a clear install hint before any build/deploy/cluster mutation. `preflight` already checks PyYAML the same way.

## Change

```make
@python3 -c 'import keycloak' 2>/dev/null || { \
  echo "ERROR: python-keycloak is required (used later by setup-keycloak)."; \
  echo "       Install: pip install python-keycloak"; \
  ...
  exit 1; \
}
```

Demo-only; no production code touched.

## Attribution

Assisted-By: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced demo setup validation to detect missing Python dependencies upfront with explicit error messages and installation instructions, enabling faster failure detection during the initial setup phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->