### PR TITLE
fix(abctl): correct pipeline divider row cell count (fixes startup panic)

### DIFF
--- a/authbridge/cmd/abctl/tui/pipeline_pane.go
+++ b/authbridge/cmd/abctl/tui/pipeline_pane.go
@@ -40,8 +40,11 @@ func (m *model) rebuildPipelineTable() {
 	for _, p := range m.pipeline.Inbound {
 		rows = append(rows, pipelineRow(p, counts[p.Name], m.pipeline.Inbound))
 	}
-	// Divider between inbound and outbound.
-	rows = append(rows, table.Row{"", "", "── (app) ──", "", "", "", ""})
+	// Divider between inbound and outbound. Cell count MUST match the 6
+	// columns defined in newPipelineTable (#, DIRECTION, PLUGIN, DEPS, BODY,
+	// EVENTS) — bubbles' table.renderRow indexes columns by cell position and
+	// panics on a mismatch.
+	rows = append(rows, table.Row{"", "", "── (app) ──", "", "", ""})
 	for _, p := range m.pipeline.Outbound {
 		rows = append(rows, pipelineRow(p, counts[p.Name], m.pipeline.Outbound))
 	}

--- a/authbridge/cmd/abctl/tui/pipeline_pane_test.go
+++ b/authbridge/cmd/abctl/tui/pipeline_pane_test.go
@@ -1,0 +1,38 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/kagenti/kagenti-extensions/authbridge/cmd/abctl/apiclient"
+)
+
+// TestRebuildPipelineTable_AllRowsMatchColumnCount is a regression guard:
+// every row added to the pipeline table — including the inbound/outbound
+// "(app)" divider — must have exactly as many cells as the table has columns.
+// The divider previously carried 7 cells against 6 columns, which made
+// bubbles' table.renderRow panic ("index out of range [6] with length 6")
+// the moment abctl rendered any pipeline.
+func TestRebuildPipelineTable_AllRowsMatchColumnCount(t *testing.T) {
+	m := &model{
+		pipeline: &apiclient.PipelineView{
+			Inbound:  []apiclient.PipelinePlugin{{Name: "jwt-validation", Direction: "inbound", Position: 1}},
+			Outbound: []apiclient.PipelinePlugin{{Name: "token-exchange", Direction: "outbound", Position: 1}},
+		},
+		pipelineTbl: newPipelineTable(),
+	}
+
+	// Must not panic: the buggy 7-cell divider panicked here via
+	// SetRows → UpdateViewport → renderRow.
+	m.rebuildPipelineTable()
+
+	rows := m.pipelineTbl.Rows()
+	if len(rows) != 3 { // inbound plugin + divider + outbound plugin
+		t.Fatalf("rows = %d, want 3 (inbound + divider + outbound)", len(rows))
+	}
+	const wantCells = 6 // #, DIRECTION, PLUGIN, DEPS, BODY, EVENTS
+	for i, r := range rows {
+		if len(r) != wantCells {
+			t.Errorf("row %d has %d cells, want %d (must match column count)", i, len(r), wantCells)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`abctl` panics on startup the moment it renders a pipeline:

```
Caught panic:
runtime error: index out of range [6] with length 6
  .../bubbles/table.(*Model).renderRow
  .../bubbles/table.(*Model).UpdateViewport
  .../bubbles/table.(*Model).SetRows
  .../abctl/tui.(*model).rebuildPipelineTable  pipeline_pane.go:48
```

## Root cause

The pipeline table defines **6 columns** (`#`, `DIRECTION`, `PLUGIN`, `DEPS`, `BODY`, `EVENTS`), and `pipelineRow` returns 6 cells — but the inbound/outbound `── (app) ──` **divider row** still had **7 cells**:

```go
rows = append(rows, table.Row{"", "", "── (app) ──", "", "", "", ""}) // 7 cells
```

It's a leftover from when the table had a 7th `WRITES` column (removed in the capability-simplification change). bubbles' `table.renderRow` indexes the column slice by cell position, so the 7th cell on a 6-column table panics with `index out of range [6] with length 6`.

## Fix

- Trim the divider row to 6 cells (matching the columns).
- Add `pipeline_pane_test.go` — a regression test asserting **every** row built by `rebuildPipelineTable` (including the divider) has exactly the column count, so this can't silently recur.

`go test ./cmd/abctl/tui/` passes; `abctl` no longer panics rendering a pipeline.

## Attribution

Assisted-By: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential crash when rendering the pipeline table with multiple plugin sections.

* **Tests**
  * Added regression test to validate pipeline table row structure integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->