### PR TITLE
fix(authbridge): record inbound allow events without requiring a2a-parser

### DIFF
--- a/authbridge/authlib/listener/reverseproxy/recording_test.go
+++ b/authbridge/authlib/listener/reverseproxy/recording_test.go
@@ -1,0 +1,101 @@
+package reverseproxy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/kagenti/kagenti-extensions/authbridge/authlib/pipeline"
+	"github.com/kagenti/kagenti-extensions/authbridge/authlib/session"
+)
+
+// allowOnlyPlugin records an ALLOW invocation but never sets
+// pctx.Extensions.A2A — it simulates a jwt-validation gate on an
+// auth-only pipeline that has no a2a-parser. The Holder's pipeline run
+// stamps the plugin name onto the invocation (via setCurrent), so no
+// manual SetCurrentPlugin is needed here.
+type allowOnlyPlugin struct{}
+
+func (allowOnlyPlugin) Name() string                              { return "test-allow" }
+func (allowOnlyPlugin) Capabilities() pipeline.PluginCapabilities { return pipeline.PluginCapabilities{} }
+func (allowOnlyPlugin) OnRequest(_ context.Context, pctx *pipeline.Context) pipeline.Action {
+	pctx.Allow("ok") // records ActionAllow; holder stamps the plugin name
+	return pipeline.Action{Type: pipeline.Continue}
+}
+func (allowOnlyPlugin) OnResponse(_ context.Context, _ *pipeline.Context) pipeline.Action {
+	return pipeline.Action{Type: pipeline.Continue}
+}
+
+// TestReverseProxy_RecordsInboundAllowWithoutA2A is the regression guard
+// for the observability bug: reverseproxy only recorded inbound session
+// events when pctx.Extensions.A2A was set, so a jwt-validation ALLOW on
+// an auth-only pipeline (no a2a-parser) was never recorded — while
+// denials always were (recordInboundReject gates on Invocations). The
+// request-phase gate is now widened to record when A2A OR Invocations OR
+// plugin-public Custom entries are present (mirroring extproc). Before the
+// fix, the asserted inbound request event would be absent entirely.
+func TestReverseProxy_RecordsInboundAllowWithoutA2A(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	p, err := pipeline.New([]pipeline.Plugin{allowOnlyPlugin{}})
+	if err != nil {
+		t.Fatalf("pipeline.New: %v", err)
+	}
+
+	store := session.New(5*time.Minute, 100, 100)
+	defer store.Close()
+
+	srv, err := NewServer(pipeline.NewHolder(p), store, backend.URL, nil)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	proxy := httptest.NewServer(srv.Handler())
+	defer proxy.Close()
+
+	// Drive an A2A-less GET request through the proxy.
+	req, _ := http.NewRequest(http.MethodGet, proxy.URL+"/work", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do: %v", err)
+	}
+	resp.Body.Close()
+
+	// No A2A means no contextId, so the event lands in the default bucket.
+	v := store.View(session.DefaultSessionID)
+	if v == nil {
+		t.Fatalf("no session recorded in default bucket; inbound ALLOW was dropped (the bug)")
+	}
+
+	var reqEvent *pipeline.SessionEvent
+	for i := range v.Events {
+		ev := v.Events[i]
+		if ev.Direction == pipeline.Inbound && ev.Phase == pipeline.SessionRequest {
+			reqEvent = &v.Events[i]
+			break
+		}
+	}
+	if reqEvent == nil {
+		t.Fatalf("no inbound request event recorded; events=%+v", v.Events)
+	}
+
+	// The recorded request event must carry the test-allow ALLOW invocation.
+	if reqEvent.Invocations == nil || len(reqEvent.Invocations.Inbound) == 0 {
+		t.Fatalf("request event has no inbound invocations: %+v", reqEvent)
+	}
+	var foundAllow bool
+	for _, inv := range reqEvent.Invocations.Inbound {
+		if inv.Plugin == "test-allow" && inv.Action == pipeline.ActionAllow {
+			foundAllow = true
+			break
+		}
+	}
+	if !foundAllow {
+		t.Fatalf("test-allow ALLOW invocation not found on request event: %+v", reqEvent.Invocations.Inbound)
+	}
+}

--- a/authbridge/authlib/listener/reverseproxy/recording_test.go
+++ b/authbridge/authlib/listener/reverseproxy/recording_test.go
@@ -24,7 +24,8 @@ func (allowOnlyPlugin) OnRequest(_ context.Context, pctx *pipeline.Context) pipe
 	pctx.Allow("ok") // records ActionAllow; holder stamps the plugin name
 	return pipeline.Action{Type: pipeline.Continue}
 }
-func (allowOnlyPlugin) OnResponse(_ context.Context, _ *pipeline.Context) pipeline.Action {
+func (allowOnlyPlugin) OnResponse(_ context.Context, pctx *pipeline.Context) pipeline.Action {
+	pctx.Observe("resp-ok") // response-phase invocation; exercises the modifyResponse gate
 	return pipeline.Action{Type: pipeline.Continue}
 }
 
@@ -97,5 +98,33 @@ func TestReverseProxy_RecordsInboundAllowWithoutA2A(t *testing.T) {
 	}
 	if !foundAllow {
 		t.Fatalf("test-allow ALLOW invocation not found on request event: %+v", reqEvent.Invocations.Inbound)
+	}
+
+	// The response-phase gate in modifyResponse is widened the same way.
+	// Assert the inbound response event was recorded with its response-phase
+	// invocation, locking in the second gate against regression too.
+	var respEvent *pipeline.SessionEvent
+	for i := range v.Events {
+		ev := v.Events[i]
+		if ev.Direction == pipeline.Inbound && ev.Phase == pipeline.SessionResponse {
+			respEvent = &v.Events[i]
+			break
+		}
+	}
+	if respEvent == nil {
+		t.Fatalf("no inbound response event recorded; events=%+v", v.Events)
+	}
+	if respEvent.Invocations == nil || len(respEvent.Invocations.Inbound) == 0 {
+		t.Fatalf("response event has no inbound invocations: %+v", respEvent)
+	}
+	var foundResp bool
+	for _, inv := range respEvent.Invocations.Inbound {
+		if inv.Plugin == "test-allow" && inv.Action == pipeline.ActionObserve {
+			foundResp = true
+			break
+		}
+	}
+	if !foundResp {
+		t.Fatalf("test-allow response invocation not found on response event: %+v", respEvent.Invocations.Inbound)
 	}
 }

--- a/authbridge/authlib/listener/reverseproxy/server.go
+++ b/authbridge/authlib/listener/reverseproxy/server.go
@@ -236,13 +236,15 @@ func (s *Server) handleRequest(w http.ResponseWriter, r *http.Request) {
 		r.Header.Set("Authorization", newAuth)
 	}
 
-	// Inbound recording is gated on A2A by design: reverseproxy is the
-	// A2A-only listener (its session keying and rekey logic are A2A-specific
-	// — see modifyResponse). Forwardproxy widens the analogous gate to
-	// cover MCP/Inference/Invocations/plugins because outbound traffic is
-	// not A2A-only. A non-A2A inbound, or an A2A request that fails to
-	// parse, is intentionally not recorded here.
-	if s.Sessions != nil && pctx.Extensions.A2A != nil {
+	// Record the inbound request event whenever there is something
+	// observable: an A2A conversation, plugin invocations, or plugin-public
+	// Custom entries. Mirrors extproc.recordInboundSession's widened gate so
+	// observability does not depend on the a2a-parser being in the pipeline
+	// (e.g. a jwt-validation allow on an auth-only agent must still show, just
+	// as denials already do via recordInboundReject). The A2A-specific session
+	// rekey in modifyResponse stays A2A-gated.
+	plugins := pipeline.SnapshotPlugins(pctx.Extensions.Custom)
+	if s.Sessions != nil && (pctx.Extensions.A2A != nil || pctx.Extensions.Invocations != nil || plugins != nil) {
 		sid := inboundSessionID(pctx)
 		// Snapshot-copy the protocol extension and use the shared helpers
 		// for plugin invocations / observability / identity. Mirrors what
@@ -254,7 +256,7 @@ func (s *Server) handleRequest(w http.ResponseWriter, r *http.Request) {
 			Phase:       pipeline.SessionRequest,
 			A2A:         pipeline.SnapshotA2A(pctx.Extensions.A2A),
 			Invocations: pipeline.SnapshotInvocations(pctx.Extensions.Invocations, pipeline.InvocationPhaseRequest),
-			Plugins:     pipeline.SnapshotPlugins(pctx.Extensions.Custom),
+			Plugins:     plugins,
 			Identity:    pipeline.SnapshotIdentity(pctx),
 			Host:        pctx.Host,
 			TLS:         eventTLS(pctx),
@@ -326,7 +328,8 @@ func (s *Server) modifyResponse(resp *http.Response) error {
 	// SSE responses still get recorded — the body is whatever the
 	// pipeline saw at this point (may be empty for streamed bodies),
 	// but the status code and plugin invocations are always meaningful.
-	if s.Sessions != nil && pctx.Extensions.A2A != nil {
+	respPlugins := pipeline.SnapshotPlugins(pctx.Extensions.Custom)
+	if s.Sessions != nil && (pctx.Extensions.A2A != nil || pctx.Extensions.Invocations != nil || respPlugins != nil) {
 		sid := inboundSessionID(pctx)
 		s.Sessions.Append(sid, pipeline.SessionEvent{
 			At:          time.Now(),
@@ -334,7 +337,7 @@ func (s *Server) modifyResponse(resp *http.Response) error {
 			Phase:       pipeline.SessionResponse,
 			A2A:         pipeline.SnapshotA2A(pctx.Extensions.A2A),
 			Invocations: pipeline.SnapshotInvocations(pctx.Extensions.Invocations, pipeline.InvocationPhaseResponse),
-			Plugins:     pipeline.SnapshotPlugins(pctx.Extensions.Custom),
+			Plugins:     respPlugins,
 			Identity:    pipeline.SnapshotIdentity(pctx),
 			Host:        pctx.Host,
 			StatusCode:  resp.StatusCode,

--- a/authbridge/authlib/listener/reverseproxy/server.go
+++ b/authbridge/authlib/listener/reverseproxy/server.go
@@ -328,8 +328,8 @@ func (s *Server) modifyResponse(resp *http.Response) error {
 	// SSE responses still get recorded — the body is whatever the
 	// pipeline saw at this point (may be empty for streamed bodies),
 	// but the status code and plugin invocations are always meaningful.
-	respPlugins := pipeline.SnapshotPlugins(pctx.Extensions.Custom)
-	if s.Sessions != nil && (pctx.Extensions.A2A != nil || pctx.Extensions.Invocations != nil || respPlugins != nil) {
+	plugins := pipeline.SnapshotPlugins(pctx.Extensions.Custom)
+	if s.Sessions != nil && (pctx.Extensions.A2A != nil || pctx.Extensions.Invocations != nil || plugins != nil) {
 		sid := inboundSessionID(pctx)
 		s.Sessions.Append(sid, pipeline.SessionEvent{
 			At:          time.Now(),
@@ -337,7 +337,7 @@ func (s *Server) modifyResponse(resp *http.Response) error {
 			Phase:       pipeline.SessionResponse,
 			A2A:         pipeline.SnapshotA2A(pctx.Extensions.A2A),
 			Invocations: pipeline.SnapshotInvocations(pctx.Extensions.Invocations, pipeline.InvocationPhaseResponse),
-			Plugins:     respPlugins,
+			Plugins:     plugins,
 			Identity:    pipeline.SnapshotIdentity(pctx),
 			Host:        pctx.Host,
 			StatusCode:  resp.StatusCode,


### PR DESCRIPTION
## Summary

Plugin-invocation observability in abctl must not depend on whether the `a2a-parser` is in the pipeline. Today it does (for the proxy-sidecar `reverseproxy` listener): an inbound **allow** (e.g. `jwt-validation` authorizing a request) is only recorded as a session event when `pctx.Extensions.A2A != nil`, while **denials** are recorded whenever there are invocations. So for an agent whose inbound pipeline is auth-only (no `a2a-parser`), the deny shows in abctl but the subsequent allow never does.

## Reproduction (weather agent, proxy-sidecar)

Inbound pipeline is just `[jwt-validation]` (no `a2a-parser`). First request → `jwt-validation` deny (401), UI re-auths and retries → allow, agent runs and makes outbound calls. abctl shows the **deny** + all the outbound `token-exchange` skips, but **no inbound allow row**.

Confirmed against the live sidecar's session API: a single `"default"` bucket with N events (deny + outbound) and **no allow event anywhere** — the allow was never recorded, and because no `contextId` bucket was created, outbound calls fell back to `ActiveSession()="default"`, landing next to the deny.

## Root cause

`authlib/listener/reverseproxy/server.go` gated both inbound record sites on `pctx.Extensions.A2A != nil`:
- request-phase record in `handleRequest`
- response-phase record in `modifyResponse`

…while `recordInboundReject` (denials) gates only on `Invocations != nil`. **`extproc` was already fixed** — its `recordInboundSession`/`recordInboundResponseSession` use a widened gate (record when A2A **or** Invocations **or** plugin-public Custom entries are present). `reverseproxy` was never brought in line.

## Fix

Widen `reverseproxy`'s two inbound record gates to match `extproc`:

```go
if s.Sessions != nil && (pctx.Extensions.A2A != nil || pctx.Extensions.Invocations != nil || plugins != nil) {
```

Now a `jwt-validation` allow is recorded under `"default"` alongside the deny, regardless of the `a2a-parser`. The A2A-specific session **rekey** in `modifyResponse` is unchanged (it legitimately needs the A2A contextId). `forwardproxy` already records on invocations, so outbound was never affected.

## Testing

- New `TestReverseProxy_RecordsInboundAllowWithoutA2A`: an inbound request through a pipeline whose plugin records an ALLOW but sets no `A2A` now produces an inbound request SessionEvent (in `"default"`) carrying that allow invocation.
- `go test ./authlib/... -race` green.

## Attribution

Assisted-By: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a regression test verifying reverse-proxy session recording when requests lack A2A context.

* **Bug Fixes**
  * Broadened reverse-proxy session event recording to capture inbound and response events for custom plugins and invocation extensions as well as A2A, ensuring plugin observations are recorded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->