### PR TITLE
CI: grant pull-request read permission for verify-pr-title job to pr-verifier caller

### DIFF
--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -8,4 +8,6 @@ permissions: {}
 
 jobs:
   verify-pr-title:
+    permissions:
+      pull-requests: read
     uses: kagenti/.github/.github/workflows/pr-verifier-required.yml@4e535f2436d167295d39d488ce5c44b5a2d49792


### PR DESCRIPTION
## Summary

A small PR to fix the issue that was present in kagenti/kagenti-operator repository CI workflow with the job to verify PR title failing due to missing permissions. Unlike the PR that fixed the job in that repository (https://github.com/kagenti/kagenti-operator/pull/379), this one limits the permissions to the job specifically, rather than caller-wide (in case more jobs are added where permissions would need to be fine tuned differently).

## Testing

- [x] The job starts on PR creation and the test passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions configuration to enhance security controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->