### PR TITLE
Fix: Exempt DNS by resolv.conf nameservers, retire CLUSTER_CIDRS

### DIFF
--- a/authbridge/proxy-init/README.md
+++ b/authbridge/proxy-init/README.md
@@ -48,18 +48,19 @@ nat-table target but the nat table forbids `DROP` (`iptables` errors with
 
 - **`nat` OUTPUT / `AB_REDIRECT`** (position 1): `RETURN` ztunnel mark
   `0x539`, the proxy UID (`--uid-owner $PROXY_UID`, avoids the loop),
-  loopback, and in-cluster **DNS-over-TCP** (`-p tcp --dport 53` to
-  `CLUSTER_CIDRS`, so cluster name resolution stays direct); then
-  `REDIRECT` all remaining **TCP** — external **and** in-cluster — to
+  loopback, and **DNS-over-TCP** (`-p tcp --dport 53`) to each
+  `/etc/resolv.conf` nameserver (so cluster name resolution stays direct);
+  then `REDIRECT` all remaining **TCP** — external **and** in-cluster — to
   `TRANSPARENT_PORT`, so agent→in-cluster calls (e.g. agent→tool) are
   captured by the egress pipeline too.
-- **`mangle` OUTPUT / `AB_NOTCP`** (position 1): the same exemptions
-  (plus `ESTABLISHED,RELATED` first, so UDP conntrack replies like DNS
-  pass), **including the full `CLUSTER_CIDRS` `RETURN`** so in-cluster
-  non-TCP (DNS-over-UDP and any other in-cluster UDP) stays direct; then
-  `-p tcp -j RETURN` (TCP is handled by the nat REDIRECT) and a terminal
-  `DROP` for external **non-TCP** (UDP/QUIC), so HTTP/3 cannot bypass —
-  well-behaved clients fall back to TCP and get captured.
+- **`mangle` OUTPUT / `AB_NOTCP`** (position 1): the same UID/mark/loopback
+  exemptions (plus `ESTABLISHED,RELATED` first, so UDP conntrack replies
+  like DNS pass), then **DNS-over-UDP** (`-p udp --dport 53`) to each
+  resolv.conf nameserver so cluster DNS keeps working; then `-p tcp -j
+  RETURN` (TCP is handled by the nat REDIRECT) and a terminal `DROP` for
+  all other **non-TCP** (UDP/QUIC), so HTTP/3 cannot bypass and non-DNS
+  in-cluster UDP is dropped too — well-behaved clients fall back to TCP and
+  get captured.
 
 Because the OUTPUT hook order is `raw → mangle → nat → filter`, the
 mangle chain drops non-TCP on its original destination while TCP falls
@@ -73,25 +74,26 @@ bypassing it. IPv6 mirrors apply the same rules. See
 [`test-enforce-redirect.sh`](./test-enforce-redirect.sh), which proves
 the capture, the preemption, and the non-TCP drop via packet counters.
 
-> **`CLUSTER_CIDRS` is Kind-shaped by default.** It now governs only what
-> stays **direct**: in-cluster DNS-over-TCP (`tcp/53`) and in-cluster
-> non-TCP (so cluster DNS keeps working). The `10.0.0.0/8` default covers
-> Kind (pods `10.244.0.0/16` + services `10.96.0.0/16`). Other distros
-> differ — **OpenShift** uses services `172.30.0.0/16` and pods
-> `10.128.0.0/14`, and `172.30.0.0/16` is **outside** `10/8`, so with the
-> default, cluster DNS (CoreDNS on `172.30.x`) is no longer left direct and
-> **resolution breaks**. On OCP/EKS/etc. you **must** override
-> `CLUSTER_CIDRS` with the cluster's real pod+service ranges. The script
-> logs the resolved value at startup, and the operator sets it from the
-> cluster's CIDRs.
+> **DNS stays direct by following the pod's actual resolvers — no CIDR
+> guessing.** The only thing left direct is DNS (`tcp/53` + `udp/53`) to the
+> `nameserver` IPs in `/etc/resolv.conf`, which kubelet writes per the pod's
+> `dnsPolicy`. This is cluster-agnostic by construction: it works whether the
+> resolver is a Kind/OpenShift/EKS service ClusterIP (any service CIDR — incl.
+> OpenShift's `172.30.0.0/16`, which is **outside** `10/8`) or a NodeLocal
+> DNSCache at a link-local `169.254.x` address. The script logs the resolved
+> nameservers at startup; override the file path with `RESOLV_CONF` (mainly
+> for tests). There is **no** in-cluster CIDR knob — `enforce-redirect` no
+> longer needs one. (A prior `CLUSTER_CIDRS` env was removed; its `10.0.0.0/8`
+> default silently dropped DNS on OpenShift, where the resolver sits outside
+> `10/8`.)
 
 > **`enforce-redirect` intentionally ignores `OUTBOUND_PORTS_EXCLUDE`** (a
 > `redirect`-mode knob). Any destination previously bypassed that way —
 > e.g. a direct LLM endpoint at `host.docker.internal:11434` — is now
 > captured (external TCP) or dropped (external non-TCP). In-cluster TCP is
-> captured as well (only in-cluster DNS stays direct), so `CLUSTER_CIDRS`
-> is **not** a TCP bypass — it only keeps cluster DNS and in-cluster UDP
-> direct. That is the point: `enforce-redirect` closes direct-egress holes.
+> captured as well (only DNS to the resolvers stays direct). That is the
+> point: `enforce-redirect` closes direct-egress holes, and the DNS
+> exemption is scoped to `port 53` to the resolver IPs — not a TCP bypass.
 
 ## iptables backend
 
@@ -111,8 +113,7 @@ whichever the host kernel exposes. Override with `IPTABLES_CMD` (and
 | `OUTBOUND_PORTS_EXCLUDE` | (empty) | redirect | Comma-separated outbound port list to skip (e.g. `8080`) |
 | `INBOUND_PORTS_EXCLUDE` | (empty) | redirect | Comma-separated inbound port list to skip |
 | `POD_IP` | (required in `redirect`) | redirect | Set via Downward API; DNAT target for ambient-mesh inbound. Not used by `enforce-redirect`. |
-| `CLUSTER_CIDRS` | `10.0.0.0/8` | enforce-redirect | Comma-separated in-cluster CIDRs kept direct **for DNS only**: DNS-over-TCP (`tcp/53`) + all in-cluster non-TCP (UDP). Other in-cluster TCP is captured. |
-| `CLUSTER_CIDRS6` | (empty) | enforce-redirect | IPv6 in-cluster CIDRs (dual-stack); empty drops all external v6 egress |
+| `RESOLV_CONF` | `/etc/resolv.conf` | enforce-redirect | Path read at init for `nameserver` IPs; DNS (`tcp/53` + `udp/53`) to those IPs is left direct (IPv4→`iptables`, IPv6→`ip6tables`). Override mainly for tests. |
 | `IPTABLES_CMD` | auto-detected | all | Override iptables binary (`iptables-legacy` / `iptables-nft`) |
 | `IP6TABLES_CMD` | derived from `IPTABLES_CMD` | enforce-redirect | Override ip6tables binary |
 

--- a/authbridge/proxy-init/init-iptables.sh
+++ b/authbridge/proxy-init/init-iptables.sh
@@ -178,15 +178,28 @@ SSH_PORT="${SSH_PORT:-22}"
 OUTBOUND_PORTS_EXCLUDE="${OUTBOUND_PORTS_EXCLUDE:-}"
 INBOUND_PORTS_EXCLUDE="${INBOUND_PORTS_EXCLUDE:-}"
 
-# enforce-redirect mode: in-cluster CIDRs used to keep cluster DNS resolution
-# working — in-cluster DNS-over-TCP (TCP/53) and in-cluster non-TCP (UDP, incl.
-# DNS) are left direct, while all OTHER in-cluster TCP is now captured by the
-# egress pipeline so agent->in-cluster calls (e.g. agent->tool) are seen.
-# Defaults to the RFC1918 10/8 block (typical Kind pod 10.244/16 + service
-# 10.96/16); override with the cluster's actual ranges (e.g. OpenShift
-# 172.30.0.0/16) so cluster DNS is not captured.
-CLUSTER_CIDRS="${CLUSTER_CIDRS:-10.0.0.0/8}"
-CLUSTER_CIDRS6="${CLUSTER_CIDRS6:-}"   # IPv6 in-cluster CIDRs (dual-stack); empty = none
+# enforce-redirect mode: under the egress guard, cluster DNS must stay direct
+# (the forward proxy is HTTP-only and cannot carry DNS), while every other
+# in-cluster TCP flow is captured by the pipeline. Rather than guess in-cluster
+# CIDRs — the resolver may sit OUTSIDE them (OpenShift service net 172.30/172.31,
+# outside 10/8) or at a link-local address (NodeLocal DNSCache, 169.254.x) — we
+# read the pod's actual resolvers from /etc/resolv.conf and leave only DNS
+# (UDP/53 + TCP/53) to THOSE IPs direct. kubelet writes resolv.conf per the pod's
+# dnsPolicy, so it is the authoritative, cluster-agnostic source for "where is my
+# resolver". Override the path with RESOLV_CONF (e.g. for tests).
+RESOLV_CONF="${RESOLV_CONF:-/etc/resolv.conf}"
+
+# Emit the `nameserver` IPs from resolv.conf, one per line (IPv4 and IPv6 mixed;
+# callers split by address family). Empty output if the file is missing/unreadable.
+get_nameservers() {
+  [ -r "${RESOLV_CONF}" ] || return 0
+  while read -r _key _val _rest; do
+    [ "${_key}" = "nameserver" ] && [ -n "${_val}" ] && echo "${_val}"
+  done < "${RESOLV_CONF}"
+  # `read` returns non-zero at EOF; force success so `NS=$(get_nameservers)`
+  # under `set -e` does not abort the script (missing/empty resolv.conf is fine).
+  return 0
+}
 
 # IPv6 counterpart of the detected iptables backend (iptables-legacy ->
 # ip6tables-legacy, iptables -> ip6tables). Override with IP6TABLES_CMD.
@@ -228,11 +241,12 @@ fi
 # Rule order: RETURN ztunnel's own sockets (fwmark 0x539, no-op without ambient)
 # -> RETURN the proxy's own re-originated egress (PROXY_UID, avoids the loop) ->
 # RETURN loopback (app -> forward proxy via HTTP_PROXY, and any loopback) ->
-# RETURN in-cluster DNS-over-TCP (TCP/53 to CLUSTER_CIDRS, left direct) ->
+# RETURN DNS-over-TCP (TCP/53) to the resolv.conf nameservers (left direct) ->
 # REDIRECT all remaining TCP -- external AND in-cluster -- to TRANSPARENT_PORT
-# (so agent->in-cluster calls are captured too) -> DROP all other external
-# egress (UDP/QUIC, so HTTP/3 can't bypass; clients fall back to TCP). In-cluster
-# non-TCP (UDP, incl. DNS) is left direct by the mangle chain below.
+# (so agent->in-cluster calls are captured too) -> DROP all other egress
+# (UDP/QUIC, so HTTP/3 can't bypass; clients fall back to TCP). DNS-over-UDP
+# (UDP/53) to the resolvers is left direct by the mangle chain below; all other
+# non-TCP -- including non-DNS in-cluster UDP -- is dropped.
 #
 # The nat REDIRECT chain has no conntrack ESTABLISHED rule: nat only evaluates
 # the first packet of a flow, so replies and established connections are not
@@ -250,9 +264,14 @@ setup_enforce_redirect() {
   REDIR_CHAIN="AB_REDIRECT"
   NOTCP_CHAIN="AB_NOTCP"
 
+  NAMESERVERS=$(get_nameservers)
+  if [ -z "${NAMESERVERS}" ]; then
+    echo "enforce-redirect: WARNING: no nameservers found in ${RESOLV_CONF} — cluster DNS may break (UDP/53 dropped, TCP/53 captured)"
+  fi
+
   echo "enforce-redirect: installing fail-closed egress capture"
   echo "enforce-redirect: external TCP -> 127.0.0.1:${TRANSPARENT_PORT} (nat REDIRECT); external non-TCP -> DROP (mangle)"
-  echo "enforce-redirect: exempt proxy UID=${PROXY_UID}; in-cluster TCP captured (DNS/53 + non-TCP left direct; CIDRs=${CLUSTER_CIDRS})"
+  echo "enforce-redirect: exempt proxy UID=${PROXY_UID}; in-cluster TCP captured; DNS/53 to resolvers left direct (resolvers=$(echo "${NAMESERVERS}" | tr '\n' ' '))"
 
   # --- IPv4: nat REDIRECT for TCP ---
   ${IPT} -t nat -N "${REDIR_CHAIN}" 2>/dev/null || true
@@ -265,13 +284,15 @@ setup_enforce_redirect() {
   # app -> forward proxy over loopback (HTTP_PROXY target), and any loopback.
   ${IPT} -t nat -A "${REDIR_CHAIN}" -o lo -j RETURN
   ${IPT} -t nat -A "${REDIR_CHAIN}" -d 127.0.0.0/8 -j RETURN
-  # in-cluster DNS-over-TCP (TCP/53) — left direct so cluster name resolution is
-  # not captured. All OTHER in-cluster TCP falls through to the REDIRECT below,
-  # so the egress pipeline sees agent->in-cluster calls (e.g. agent->tool). The
-  # proxy's re-originated egress (PROXY_UID, RETURNed above) is exempt, and in an
-  # Istio ambient mesh it falls through to ISTIO_OUTPUT -> ztunnel for mTLS.
-  for cidr in $(echo "${CLUSTER_CIDRS}" | tr ',' ' '); do
-    [ -n "${cidr}" ] && ${IPT} -t nat -A "${REDIR_CHAIN}" -p tcp --dport 53 -d "${cidr}" -j RETURN
+  # DNS-over-TCP (TCP/53) to the pod's resolvers — left direct so cluster name
+  # resolution is not captured (the forward proxy can't carry DNS). All OTHER
+  # in-cluster TCP falls through to the REDIRECT below, so the egress pipeline
+  # sees agent->in-cluster calls (e.g. agent->tool). The proxy's re-originated
+  # egress (PROXY_UID, RETURNed above) is exempt, and in an Istio ambient mesh it
+  # falls through to ISTIO_OUTPUT -> ztunnel for mTLS.
+  for ns in ${NAMESERVERS}; do
+    case "${ns}" in *:*) continue ;; esac   # IPv6 resolver — handled in the v6 block
+    ${IPT} -t nat -A "${REDIR_CHAIN}" -p tcp --dport 53 -d "${ns}" -j RETURN
   done
   # all remaining TCP (external + in-cluster, minus in-cluster DNS) — capture it transparently.
   ${IPT} -t nat -A "${REDIR_CHAIN}" -p tcp -j REDIRECT --to-port "${TRANSPARENT_PORT}"
@@ -288,11 +309,13 @@ setup_enforce_redirect() {
   ${IPT} -t mangle -A "${NOTCP_CHAIN}" -m owner --uid-owner "${PROXY_UID}" -j RETURN
   ${IPT} -t mangle -A "${NOTCP_CHAIN}" -o lo -j RETURN
   ${IPT} -t mangle -A "${NOTCP_CHAIN}" -d 127.0.0.0/8 -j RETURN
-  # in-cluster non-TCP (UDP, incl. DNS) — left direct. In-cluster TCP is now
-  # captured by the nat chain above; only in-cluster UDP relies on this RETURN
-  # (notably DNS-over-UDP, which the terminal DROP below would otherwise kill).
-  for cidr in $(echo "${CLUSTER_CIDRS}" | tr ',' ' '); do
-    [ -n "${cidr}" ] && ${IPT} -t mangle -A "${NOTCP_CHAIN}" -d "${cidr}" -j RETURN
+  # DNS-over-UDP (UDP/53) to the pod's resolvers — left direct (the terminal DROP
+  # below would otherwise kill cluster name resolution). Scoped to the resolvers
+  # and port 53: all other non-TCP, including non-DNS in-cluster UDP, is dropped
+  # so nothing can bypass the pipeline over UDP.
+  for ns in ${NAMESERVERS}; do
+    case "${ns}" in *:*) continue ;; esac   # IPv6 resolver — handled in the v6 block
+    ${IPT} -t mangle -A "${NOTCP_CHAIN}" -p udp --dport 53 -d "${ns}" -j RETURN
   done
   # TCP is handled by the nat REDIRECT above — let it pass mangle untouched.
   ${IPT} -t mangle -A "${NOTCP_CHAIN}" -p tcp -j RETURN
@@ -304,9 +327,9 @@ setup_enforce_redirect() {
   echo "enforce-redirect: IPv4 egress capture configured"
 
   # --- IPv6 ---
-  # Mirror of IPv4. Until v6 cluster CIDRs are wired (CLUSTER_CIDRS6), allow
-  # loopback + link-local (fe80::/10 unicast, ff02::/16 NDP/MLD multicast) and
-  # the proxy UID / ztunnel mark; REDIRECT external v6 TCP; DROP other v6 egress.
+  # Mirror of IPv4: allow loopback + link-local (fe80::/10 unicast, ff02::/16
+  # NDP/MLD multicast) and the proxy UID / ztunnel mark; leave DNS to any IPv6
+  # resolv.conf nameservers direct; REDIRECT external v6 TCP; DROP other v6 egress.
   if command -v "${IP6T%% *}" >/dev/null 2>&1 && ${IP6T} -t nat -L >/dev/null 2>&1; then
     ${IP6T} -t nat -N "${REDIR_CHAIN}" 2>/dev/null || true
     ${IP6T} -t nat -F "${REDIR_CHAIN}"
@@ -316,10 +339,11 @@ setup_enforce_redirect() {
     ${IP6T} -t nat -A "${REDIR_CHAIN}" -d ::1/128 -j RETURN
     ${IP6T} -t nat -A "${REDIR_CHAIN}" -d fe80::/10 -j RETURN
     ${IP6T} -t nat -A "${REDIR_CHAIN}" -d ff02::/16 -j RETURN
-    # in-cluster DNS-over-TCP (TCP/53) only — mirror of IPv4; all other in-cluster
-    # v6 TCP is captured below.
-    for cidr in $(echo "${CLUSTER_CIDRS6}" | tr ',' ' '); do
-      [ -n "${cidr}" ] && ${IP6T} -t nat -A "${REDIR_CHAIN}" -p tcp --dport 53 -d "${cidr}" -j RETURN
+    # DNS-over-TCP (TCP/53) to IPv6 resolvers only — mirror of IPv4; all other
+    # in-cluster v6 TCP is captured below.
+    for ns in ${NAMESERVERS}; do
+      case "${ns}" in *:*) ;; *) continue ;; esac   # IPv4 resolver — handled in the v4 block
+      ${IP6T} -t nat -A "${REDIR_CHAIN}" -p tcp --dport 53 -d "${ns}" -j RETURN
     done
     ${IP6T} -t nat -A "${REDIR_CHAIN}" -p tcp -j REDIRECT --to-port "${TRANSPARENT_PORT}"
     if ! ${IP6T} -t nat -C OUTPUT -j "${REDIR_CHAIN}" 2>/dev/null; then
@@ -335,8 +359,10 @@ setup_enforce_redirect() {
     ${IP6T} -t mangle -A "${NOTCP_CHAIN}" -d ::1/128 -j RETURN
     ${IP6T} -t mangle -A "${NOTCP_CHAIN}" -d fe80::/10 -j RETURN
     ${IP6T} -t mangle -A "${NOTCP_CHAIN}" -d ff02::/16 -j RETURN
-    for cidr in $(echo "${CLUSTER_CIDRS6}" | tr ',' ' '); do
-      [ -n "${cidr}" ] && ${IP6T} -t mangle -A "${NOTCP_CHAIN}" -d "${cidr}" -j RETURN
+    # DNS-over-UDP (UDP/53) to IPv6 resolvers only — mirror of IPv4.
+    for ns in ${NAMESERVERS}; do
+      case "${ns}" in *:*) ;; *) continue ;; esac   # IPv4 resolver — handled in the v4 block
+      ${IP6T} -t mangle -A "${NOTCP_CHAIN}" -p udp --dport 53 -d "${ns}" -j RETURN
     done
     ${IP6T} -t mangle -A "${NOTCP_CHAIN}" -p tcp -j RETURN
     ${IP6T} -t mangle -A "${NOTCP_CHAIN}" -j DROP

--- a/authbridge/proxy-init/init-iptables.sh
+++ b/authbridge/proxy-init/init-iptables.sh
@@ -264,9 +264,17 @@ setup_enforce_redirect() {
   REDIR_CHAIN="AB_REDIRECT"
   NOTCP_CHAIN="AB_NOTCP"
 
+  # Fail closed and LOUD on zero resolvers: without a nameserver to exempt, the
+  # rules below would drop UDP/53 and capture TCP/53, leaving a running-but-DNS-
+  # dead pod that is far harder to triage than a failed init container. In a
+  # Kubernetes pod kubelet always populates resolv.conf, so an empty result means
+  # a real misconfiguration — surface it as Init:Error rather than silent breakage.
   NAMESERVERS=$(get_nameservers)
   if [ -z "${NAMESERVERS}" ]; then
-    echo "enforce-redirect: WARNING: no nameservers found in ${RESOLV_CONF} — cluster DNS may break (UDP/53 dropped, TCP/53 captured)"
+    echo "enforce-redirect: ERROR: no nameservers found in ${RESOLV_CONF}" >&2
+    echo "enforce-redirect: refusing to start — DNS egress would be dropped (UDP/53) / captured (TCP/53), silently breaking name resolution." >&2
+    echo "enforce-redirect: set RESOLV_CONF to a file with valid 'nameserver' entries if running outside Kubernetes." >&2
+    exit 1
   fi
 
   echo "enforce-redirect: installing fail-closed egress capture"

--- a/authbridge/proxy-init/test-enforce-redirect.sh
+++ b/authbridge/proxy-init/test-enforce-redirect.sh
@@ -8,8 +8,11 @@
 #      position 1 with the expected RETURN exemptions and a `-p tcp` REDIRECT to
 #      TRANSPARENT_PORT (no DROP — the nat table forbids it); and the AB_NOTCP
 #      chain is hooked from mangle OUTPUT with `-p tcp RETURN` then a terminal
-#      DROP for external non-TCP egress. In-cluster DNS-over-TCP (TCP/53) is left
-#      direct; all OTHER in-cluster TCP is captured (no blanket in-cluster RETURN).
+#      DROP for external non-TCP egress. DNS (TCP/53 + UDP/53) to the resolv.conf
+#      nameservers is left direct; all OTHER TCP is captured and all OTHER non-TCP
+#      is dropped. The resolver here (172.31.0.10) is OUTSIDE 10/8 on purpose —
+#      it proves the exemption follows the actual resolver, not a guessed CIDR
+#      (the OpenShift/HyperShift regression: services + DNS live in 172.31/16).
 #   2. CAPTURE (not drop) + AMBIENT ROBUSTNESS — external TCP egress is
 #      REDIRECTed to TRANSPARENT_PORT, preempting a simulated Istio ambient
 #      "nat OUTPUT REDIRECT" appended after our chain. Proven via packet
@@ -28,6 +31,8 @@ INIT="${INIT_SCRIPT:-${SCRIPT_DIR}/init-iptables.sh}"
 IPT="${IPTABLES_CMD:-iptables-nft}"
 EXTERNAL="198.51.100.7"   # RFC5737 TEST-NET-2, guaranteed unused
 TPORT="8082"
+RESOLVER_V4="172.31.0.10"        # OCP-style resolver, deliberately OUTSIDE 10/8
+RESOLVER_V6="fd00:10:96::10"     # IPv6 resolver, exercises the ip6tables path
 
 # Re-exec into a private network namespace.
 if [ -z "${_AB_NETNS_REEXEC:-}" ]; then
@@ -48,8 +53,18 @@ else
   echo "WARN: dummy interface unavailable; capture packet may not be generated"
 fi
 
-echo "### Installing enforce-redirect rules"
-env MODE=enforce-redirect PROXY_UID=1337 CLUSTER_CIDRS=10.0.0.0/8 \
+# Mock resolv.conf: the script must derive the DNS exemption from these
+# nameservers, NOT from any CIDR. The v4 resolver is outside 10/8 on purpose.
+RESOLV_MOCK=$(mktemp)
+cat > "${RESOLV_MOCK}" <<EOF
+search team1.svc.cluster.local svc.cluster.local cluster.local
+nameserver ${RESOLVER_V4}
+nameserver ${RESOLVER_V6}
+options ndots:5
+EOF
+
+echo "### Installing enforce-redirect rules (resolvers from ${RESOLV_MOCK})"
+env MODE=enforce-redirect PROXY_UID=1337 RESOLV_CONF="${RESOLV_MOCK}" \
     TRANSPARENT_PORT="${TPORT}" \
     IPTABLES_CMD="${IPT}" IP6TABLES_CMD=ip6tables-nft \
     sh "${INIT}" || { echo "FAIL: init script exited non-zero"; exit 1; }
@@ -66,13 +81,18 @@ assert "nat ztunnel mark RETURN"            'AB_REDIRECT .*mark.*0x539.*-j RETUR
 assert "nat proxy UID RETURN"               'AB_REDIRECT .*--uid-owner 1337 -j RETURN' "${natdump}"
 assert "nat loopback iface RETURN"          'AB_REDIRECT -o lo -j RETURN' "${natdump}"
 assert "nat loopback cidr RETURN"           'AB_REDIRECT -d 127.0.0.0/8 -j RETURN' "${natdump}"
-# in-cluster DNS-over-TCP (TCP/53) is left direct so cluster name resolution is
-# not captured; all OTHER in-cluster TCP now falls through to the REDIRECT.
-assert "nat in-cluster DNS-over-TCP RETURN" 'AB_REDIRECT.*10\.0\.0\.0/8.*dport 53.*RETURN' "${natdump}"
-# the blanket in-cluster RETURN must be gone — in-cluster TCP is now captured.
-if echo "${natdump}" | grep -qE '^-A AB_REDIRECT -d 10\.0\.0\.0/8 -j RETURN$'; then
-  echo "FAIL: nat AB_REDIRECT still blanket-RETURNs in-cluster (in-cluster TCP not captured)"; fail=1
-else echo "PASS: no blanket in-cluster RETURN — in-cluster TCP captured, only DNS/53 left direct"; fi
+# DNS-over-TCP (TCP/53) to the resolv.conf resolver is left direct so cluster
+# name resolution is not captured; all OTHER TCP falls through to the REDIRECT.
+assert "nat DNS-over-TCP RETURN to resolver" "AB_REDIRECT.*${RESOLVER_V4}.*dport 53.*RETURN" "${natdump}"
+# the exemption must follow the resolver, not a CIDR: no 10/8 remnant at all.
+if echo "${natdump}" | grep -qE '10\.0\.0\.0/8'; then
+  echo "FAIL: nat ruleset still references 10.0.0.0/8 (CLUSTER_CIDRS not fully removed)"; fail=1
+else echo "PASS: no 10/8 / CLUSTER_CIDRS remnant — DNS exemption is resolver-scoped"; fi
+# the resolver RETURN must be port-53-scoped, not a blanket dest RETURN (else
+# non-DNS in-cluster TCP to that host would escape capture).
+if echo "${natdump}" | grep -qE "^-A AB_REDIRECT -d ${RESOLVER_V4}/32 -j RETURN\$"; then
+  echo "FAIL: resolver RETURN is blanket (should be scoped to tcp/53)"; fail=1
+else echo "PASS: resolver DNS RETURN is port-53-scoped — non-DNS in-cluster TCP still captured"; fi
 assert "nat tcp REDIRECT to transparent"    "AB_REDIRECT -p tcp -j REDIRECT --to-ports ${TPORT}" "${natdump}"
 if echo "${natdump}" | grep -qE 'AB_REDIRECT -j DROP'; then
   echo "FAIL: nat AB_REDIRECT must not contain DROP (nat table forbids it)"; fail=1
@@ -81,9 +101,19 @@ else echo "PASS: nat AB_REDIRECT has no DROP (correctly delegated to mangle)"; f
 assert "AB_NOTCP hooked from mangle OUTPUT"  '^-A OUTPUT -j AB_NOTCP' "${mangledump}"
 assert "mangle established/related RETURN"   'AB_NOTCP -m conntrack --ctstate (ESTABLISHED,RELATED|RELATED,ESTABLISHED) -j RETURN' "${mangledump}"
 assert "mangle proxy UID RETURN"             'AB_NOTCP .*--uid-owner 1337 -j RETURN' "${mangledump}"
-assert "mangle cluster cidr RETURN"          'AB_NOTCP -d 10.0.0.0/8 -j RETURN' "${mangledump}"
+assert "mangle DNS-over-UDP RETURN to resolver" "AB_NOTCP.*${RESOLVER_V4}.*udp.*dport 53.*RETURN" "${mangledump}"
 assert "mangle tcp RETURN (defer to nat)"    'AB_NOTCP -p tcp -j RETURN' "${mangledump}"
 assert "mangle terminal DROP (non-tcp)"      'AB_NOTCP -j DROP' "${mangledump}"
+
+# --- IPv6 mirror: DNS to the IPv6 resolver must be exempt (tcp/53 + udp/53) ---
+if ip6tables-nft -t nat -S AB_REDIRECT >/dev/null 2>&1; then
+  nat6=$(ip6tables-nft -t nat -S)
+  mangle6=$(ip6tables-nft -t mangle -S)
+  assert "v6 nat DNS-over-TCP RETURN to resolver"    "AB_REDIRECT.*${RESOLVER_V6}.*dport 53.*RETURN" "${nat6}"
+  assert "v6 mangle DNS-over-UDP RETURN to resolver" "AB_NOTCP.*${RESOLVER_V6}.*udp.*dport 53.*RETURN" "${mangle6}"
+else
+  echo "SKIP: ip6tables AB_REDIRECT chain absent — IPv6 resolver assertions skipped"
+fi
 
 pos1=$("${IPT}" -t nat -L OUTPUT --line-numbers -n | awk '$1=="1"{print $2}')
 if [ "${pos1}" = "AB_REDIRECT" ]; then echo "PASS: AB_REDIRECT at nat OUTPUT position 1"

--- a/authbridge/proxy-init/test-enforce-redirect.sh
+++ b/authbridge/proxy-init/test-enforce-redirect.sh
@@ -147,6 +147,19 @@ else
   echo "FAIL: external UDP not dropped (DROP=${dropc:-?})"; fail=1
 fi
 
+echo "### Fail-closed test: empty resolv.conf must abort init (exit non-zero)"
+# The zero-resolver check runs before any iptables mutation, so this re-invocation
+# leaves the rules above untouched. A running-but-DNS-dead pod is worse than a
+# failed init, so enforce-redirect refuses to start without a resolver to exempt.
+EMPTY_RESOLV=$(mktemp)   # created empty: no `nameserver` lines
+if env MODE=enforce-redirect PROXY_UID=1337 RESOLV_CONF="${EMPTY_RESOLV}" \
+       TRANSPARENT_PORT="${TPORT}" IPTABLES_CMD="${IPT}" IP6TABLES_CMD=ip6tables-nft \
+       sh "${INIT}" >/dev/null 2>&1; then
+  echo "FAIL: init succeeded with empty resolv.conf (should exit non-zero)"; fail=1
+else
+  echo "PASS: init aborts fail-closed when resolv.conf has no nameservers"
+fi
+
 echo
 [ "${fail}" -eq 0 ] && echo "ALL TESTS PASSED" || echo "SOME TESTS FAILED"
 exit "${fail}"


### PR DESCRIPTION
## Problem

`enforce-redirect` left in-cluster DNS direct only for `CLUSTER_CIDRS`, whose default was Kind-shaped `10.0.0.0/8`. On OpenShift/HyperShift the DNS resolver and Services live in the **service network** (`172.30.0.0/16` default, `172.31.0.0/16` on hosted clusters) — **outside `10/8`** — so the agent's `UDP/53` to the resolver hit the `mangle` terminal `DROP` → `Temporary failure in name resolution` → **all** in-cluster egress (including agent→MCP) failed.

This is the root cause of the PR #1911 HyperShift e2e failure (`Cannot connect to MCP weather service ...weather-tool-mcp.team1.svc...:8000/mcp`): the agent's own log shows `Failed to resolve otel-collector...svc.cluster.local ([Errno -3])`, the hosted-cluster pod route is for `172.31.0.0/16`, and `weather-service.team1.svc` resolves to `172.31.188.89`. The fix in #498 (capture in-cluster TCP) was validated only on Kind (service net `10.96/16`, inside `10/8`) and never exercised this.

The resolver address is also unpredictable in general — a service ClusterIP in *any* service CIDR, or a **NodeLocal DNSCache** at a link-local `169.254.x` address — so no CIDR guess reliably covers it.

## Fix

Exempt DNS by the pod's **actual resolvers** instead of a guessed CIDR:

- Read `nameserver` IPs from `/etc/resolv.conf` (kubelet-written per the pod's `dnsPolicy` — the authoritative, cluster-agnostic source) and leave only DNS (`UDP/53` + `TCP/53`) to **those IPs** direct (IPv4→`iptables`, IPv6→`ip6tables`).
- **Remove `CLUSTER_CIDRS` / `CLUSTER_CIDRS6` entirely.** Post in-cluster-capture (#498), their only remaining job was the DNS carve-out, and a hard-coded CIDR default is both fragile and a footgun.
- Path overridable via `RESOLV_CONF` (mainly for tests).
- **Fail closed on zero resolvers:** if resolv.conf has no `nameserver` entries the init container exits non-zero (Init:Error) rather than starting a silently-DNS-dead pod. In a k8s pod kubelet always populates resolv.conf, so this only fires on genuine misconfiguration.

**Backward-compatible:** the script ignores `CLUSTER_CIDRS` even if an older operator still injects it, so this needs **no lockstep operator change**. The operator/chart cleanup (removing the now-dead `CLUSTER_CIDRS` injection + config field) is a non-urgent follow-up in kagenti-operator.

Also fixes a latent `set -e` bug: `NS=$(get_nameservers)` would have aborted the script on the `while read` EOF status (the helper now `return 0`s).

## ⚠️ Behavior change (release note)

**Non-DNS in-cluster UDP is now dropped under `enforce-redirect`.** Previously the blanket `CLUSTER_CIDRS` RETURN left *all* in-cluster non-TCP direct; now only `UDP/53` to the resolv.conf nameservers is exempt and every other non-TCP datagram is dropped. This closes UDP as a bypass channel (consistent with the existing external-UDP/QUIC drop). The kagenti agent path uses **TCP** for OTLP/telemetry, so it is unaffected — but workloads relying on in-cluster UDP (statsd, syslog-over-UDP, custom UDP telemetry) would need an explicit exemption. DNS is unaffected.

## Testing

`test-enforce-redirect.sh` is driven by a mock `resolv.conf` whose v4 resolver (`172.31.0.10`) is **deliberately outside `10/8`** — encoding the OCP regression — plus a v6 resolver. It asserts `tcp/53` + `udp/53` RETURN to the resolvers (v4 and v6), that the RETURN is port-53-scoped (non-DNS in-cluster TCP still captured), that **no `10/8` / `CLUSTER_CIDRS` remnant** exists, and that an empty resolv.conf aborts init (fail-closed). Locally verified: POSIX `sh -n`, the nameserver parsing + family split, the missing/empty-resolv.conf handling. The full netns rule/packet test runs in CI (Linux/root).

The theory is independently being confirmed on kagenti#1911 by overriding the operator's `clusterCIDRs` to the cluster's real ranges (no rebuild); this PR is the durable, config-free fix.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated DNS exemption behavior documentation: DNS traffic now routes directly to configured pod resolvers instead of cluster CIDRs.

* **Refactor**
  * DNS handling now derives exemptions from actual nameserver configuration; fails safely if no resolvers are found.

* **Tests**
  * Updated DNS exemption test assertions to validate resolver-driven behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->