### PR TITLE
Feat: Add build-tag based plugin selection for authbridge binaries

### DIFF
--- a/authbridge/CLAUDE.md
+++ b/authbridge/CLAUDE.md
@@ -11,9 +11,10 @@ binaries with shared auth logic in `authlib/`:
 
 - `cmd/authbridge-proxy/` — proxy-sidecar mode (default). HTTP forward + reverse
   proxies. Full plugin set (jwt-validation, token-exchange, a2a-parser,
-  mcp-parser, inference-parser, ibac, sparc).
+  mcp-parser, inference-parser, ibac, sparc). Ibac is excludable via
+  `-tags exclude_plugin_ibac`.
 - `cmd/authbridge-envoy/` — envoy-sidecar mode. ext_proc gRPC server hooked
-  into Envoy. Full plugin set.
+  into Envoy. Full plugin set. Same build-tag exclusions apply.
 - `cmd/authbridge-lite/` — proxy-sidecar mode, lite plugin set (auth gates
   only, parsers dropped). For size-optimized deployments that don't need
   protocol-aware session events.

--- a/authbridge/README.md
+++ b/authbridge/README.md
@@ -383,6 +383,66 @@ python keycloak_sync.py --config routes.yaml --agent-client "spiffe://..." --yes
 
 This creates target clients, audience scopes, and assigns scopes to the agent.
 
+## Build-tag plugin selection
+
+Downstream distributions and custom deployments can exclude specific
+plugins at build time using Go build tags. The default build (no tags)
+includes every plugin — existing Dockerfiles, CI, and Makefiles keep
+working with zero changes.
+
+### Available tags
+
+| Tag | Plugin excluded | Effect |
+|-----|----------------|--------|
+| `exclude_plugin_ibac` | IBAC (Intent-Based Access Control) | Removes the LLM-judge plugin and its runtime dependencies |
+
+### Usage
+
+**Go build:**
+
+```bash
+# Default — all plugins included (same as today)
+go build ./cmd/authbridge-proxy
+
+# Exclude IBAC
+go build -tags exclude_plugin_ibac ./cmd/authbridge-proxy
+```
+
+**Docker build:**
+
+```bash
+# Default — all plugins
+docker build -f cmd/authbridge-proxy/Dockerfile .
+
+# Exclude IBAC
+docker build --build-arg GO_BUILD_TAGS=exclude_plugin_ibac \
+  -f cmd/authbridge-proxy/Dockerfile .
+```
+
+Multiple tags can be combined with commas: `-tags "exclude_plugin_ibac,exclude_plugin_foo"`.
+
+### Adding build tags to a new plugin
+
+To make a plugin excludable:
+
+1. Create a `plugins_<name>.go` file in each `cmd/` binary that imports the plugin:
+
+```go
+//go:build !exclude_plugin_<name>
+
+package main
+
+import _ "github.com/kagenti/kagenti-extensions/authbridge/authlib/plugins/<name>"
+```
+
+2. Remove the corresponding `_ "...plugins/<name>"` import from that binary's `main.go`.
+
+3. Add the tag to the table above.
+
+The build constraint `!exclude_plugin_<name>` means the file is included by
+default. Passing `-tags exclude_plugin_<name>` excludes it, which prevents the
+plugin package from being imported and compiled into the binary.
+
 ## Component Documentation
 
 - [authlib](authlib/README.md) — Shared auth building blocks (Go library)

--- a/authbridge/authlib/plugins/README.md
+++ b/authbridge/authlib/plugins/README.md
@@ -38,3 +38,17 @@ side-effect import. See
 for the contract and
 [`docs/plugin-tutorial.md`](../../docs/plugin-tutorial.md#step-6--out-of-tree-plugins)
 for the walkthrough.
+
+### Build-tag plugin exclusion
+
+Some plugins can be excluded at build time using Go build tags. Their
+side-effect import lives in a dedicated `plugins_<name>.go` file (in
+each `cmd/` binary) gated by `//go:build !exclude_plugin_<name>`.
+The default build (no tags) includes everything.
+
+| Tag | Plugin excluded |
+|-----|----------------|
+| `exclude_plugin_ibac` | `ibac` |
+
+See the [authbridge README](../../README.md#build-tag-plugin-selection)
+for usage examples and instructions for tagging additional plugins.

--- a/authbridge/cmd/authbridge-envoy/Dockerfile
+++ b/authbridge/cmd/authbridge-envoy/Dockerfile
@@ -19,8 +19,9 @@ WORKDIR /app
 COPY authlib/ authlib/
 COPY cmd/authbridge-envoy/ cmd/authbridge-envoy/
 
+ARG GO_BUILD_TAGS=""
 ENV GOWORK=off
-RUN cd cmd/authbridge-envoy && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /authbridge-envoy .
+RUN cd cmd/authbridge-envoy && CGO_ENABLED=0 GOOS=linux go build -tags "${GO_BUILD_TAGS}" -ldflags="-s -w" -o /authbridge-envoy .
 
 # Stage 2: Get Envoy binary. Already stripped upstream; nothing to do.
 FROM docker.io/envoyproxy/envoy:v1.37.1 AS envoy-source

--- a/authbridge/cmd/authbridge-envoy/main.go
+++ b/authbridge/cmd/authbridge-envoy/main.go
@@ -50,7 +50,6 @@ import (
 	// Plugins. Auth gates first, then the protocol parsers that
 	// supply session-event context for abctl.
 	_ "github.com/kagenti/kagenti-extensions/authbridge/authlib/plugins/a2aparser"
-	_ "github.com/kagenti/kagenti-extensions/authbridge/authlib/plugins/ibac"
 	_ "github.com/kagenti/kagenti-extensions/authbridge/authlib/plugins/inferenceparser"
 	_ "github.com/kagenti/kagenti-extensions/authbridge/authlib/plugins/jwtvalidation"
 	_ "github.com/kagenti/kagenti-extensions/authbridge/authlib/plugins/mcpparser"

--- a/authbridge/cmd/authbridge-envoy/plugins_ibac.go
+++ b/authbridge/cmd/authbridge-envoy/plugins_ibac.go
@@ -1,0 +1,5 @@
+//go:build !exclude_plugin_ibac
+
+package main
+
+import _ "github.com/kagenti/kagenti-extensions/authbridge/authlib/plugins/ibac"

--- a/authbridge/cmd/authbridge-proxy/Dockerfile
+++ b/authbridge/cmd/authbridge-proxy/Dockerfile
@@ -26,8 +26,9 @@ WORKDIR /app
 COPY authlib/ authlib/
 COPY cmd/authbridge-proxy/ cmd/authbridge-proxy/
 
+ARG GO_BUILD_TAGS=""
 ENV GOWORK=off
-RUN cd cmd/authbridge-proxy && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /authbridge-proxy .
+RUN cd cmd/authbridge-proxy && CGO_ENABLED=0 GOOS=linux go build -tags "${GO_BUILD_TAGS}" -ldflags="-s -w" -o /authbridge-proxy .
 
 # Stage 2: Runtime — alpine (has bash, ~5 MB base)
 FROM alpine:3.20@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d

--- a/authbridge/cmd/authbridge-proxy/main.go
+++ b/authbridge/cmd/authbridge-proxy/main.go
@@ -45,7 +45,6 @@ import (
 	// Plugins. Auth gates first, then the protocol parsers that
 	// supply session-event context for abctl.
 	_ "github.com/kagenti/kagenti-extensions/authbridge/authlib/plugins/a2aparser"
-	_ "github.com/kagenti/kagenti-extensions/authbridge/authlib/plugins/ibac"
 	_ "github.com/kagenti/kagenti-extensions/authbridge/authlib/plugins/inferenceparser"
 	_ "github.com/kagenti/kagenti-extensions/authbridge/authlib/plugins/jwtvalidation"
 	_ "github.com/kagenti/kagenti-extensions/authbridge/authlib/plugins/mcpparser"

--- a/authbridge/cmd/authbridge-proxy/plugins_ibac.go
+++ b/authbridge/cmd/authbridge-proxy/plugins_ibac.go
@@ -1,0 +1,5 @@
+//go:build !exclude_plugin_ibac
+
+package main
+
+import _ "github.com/kagenti/kagenti-extensions/authbridge/authlib/plugins/ibac"


### PR DESCRIPTION
## Summary

Add Go build tags to authbridge so downstream distributions can control which plugins are compiled into the sidecar binary at build time, without maintaining forked `main.go` files.

This implements **Option 2 (opt-out tags)** from #476: the default build includes everything; passing `-tags exclude_plugin_<name>` removes the plugin. Zero disruption to existing users.

## Changes

- **`cmd/authbridge-proxy/plugins_ibac.go`** (new) — build-tagged side-effect import gated by `//go:build !exclude_plugin_ibac`
- **`cmd/authbridge-envoy/plugins_ibac.go`** (new) — same for the envoy binary
- **`cmd/authbridge-proxy/main.go`** — removed ibac blank import (moved to `plugins_ibac.go`)
- **`cmd/authbridge-envoy/main.go`** — same
- **`cmd/authbridge-proxy/Dockerfile`** — added `ARG GO_BUILD_TAGS=""` and `-tags "${GO_BUILD_TAGS}"` to the `go build` line
- **`cmd/authbridge-envoy/Dockerfile`** — same
- **`README.md`** — added "Build-tag plugin selection" section with usage examples and contributor guide for tagging new plugins
- **`authlib/plugins/README.md`** — extended the registry docs with the build-tag exclusion pattern
- **`CLAUDE.md`** — updated binary descriptions to note ibac is excludable

## How it works

Each excludable plugin's side-effect import is moved from `main.go` into a dedicated file with a build constraint:

```go
//go:build !exclude_plugin_ibac

package main

import _ "github.com/kagenti/kagenti-extensions/authbridge/authlib/plugins/ibac"
```

- Default build (no tags): file is included, ibac is registered — identical to today
- With `-tags exclude_plugin_ibac`: file is excluded, ibac package is never imported

The plugin package itself is untouched. When the import is excluded, Go never compiles the ibac package into the binary.

Dockerfiles accept a `GO_BUILD_TAGS` build arg:

```bash
# Upstream default — all plugins
docker build -f cmd/authbridge-proxy/Dockerfile .

# Downstream — exclude ibac
docker build --build-arg GO_BUILD_TAGS=exclude_plugin_ibac \
  -f cmd/authbridge-proxy/Dockerfile .
```

## Testing

All verification done locally on darwin/arm64 and via Docker (linux/amd64):

| Test | Result |
|---|---|
| `go build` proxy default | ✅ ibac present (confirmed via `strings` and runtime) |
| `go build` proxy `-tags exclude_plugin_ibac` | ✅ ibac absent (confirmed via `strings` and runtime) |
| `go build` envoy default | ✅ ibac present |
| `go build` envoy `-tags exclude_plugin_ibac` | ✅ ibac absent |
| `go build` lite (unchanged) | ✅ ibac absent (never imported) |
| `docker build` proxy default | ✅ image builds clean |
| `docker build` proxy `GO_BUILD_TAGS=exclude_plugin_ibac` | ✅ image builds clean |
| `go test ./...` authlib (default) | ✅ all pass |
| `go test -tags exclude_plugin_ibac ./...` authlib | ✅ all pass |
| Runtime: default binary + ibac config | ✅ plugin recognized, config validation runs |
| Runtime: excluded binary + ibac config | ✅ `unknown plugin "ibac" (registered: [a2a-parser inference-parser jwt-validation mcp-parser opa sparc token-broker token-exchange])` |

## Scope

This PR tags only the `ibac` plugin as the first excludable plugin. The remaining 8 plugins stay untagged (always included), matching current behavior exactly. The README documents the pattern for future plugin authors to follow.

## Related

- Resolves #476
- Jira: [RHAIENG-5712](https://redhat.atlassian.net/browse/RHAIENG-5712)

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive build-tag plugin selection documentation explaining how to exclude specific plugins (IBAC) at build time.
  * Included configuration examples for Go and Docker builds for downstream distributions and custom deployments.

* **New Features**
  * AuthBridge binaries now support conditional plugin compilation via build tags, enabling optional plugin exclusion and reduced dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->