### PR TITLE
Fix: Run the TLS bridge without SPIRE (need-driven SPIFFE provider; drop in-process trust self-check)

### DIFF
--- a/authbridge/authlib/plugins/registry.go
+++ b/authbridge/authlib/plugins/registry.go
@@ -86,6 +86,12 @@ func RegisteredPlugins() []string {
 // actual need (see cmd/authbridge-proxy's spiffeProviderNeeded) use this to
 // assert their need-detection covers every consumer; a new consumer that slips
 // past the predicate would otherwise silently receive a nil Provider.
+//
+// This probes by constructing each plugin and type-asserting. That is safe
+// because PluginFactory is contractually a cheap, side-effect-free constructor
+// (see PluginFactory: no construction args; deps + goroutines are created in
+// Configure/Init, not the factory). If a factory ever gains construction-time
+// side effects, switch this to a static capability tag instead of a live probe.
 func SPIFFEConsumerPlugins() []string {
 	registryMu.RLock()
 	defer registryMu.RUnlock()

--- a/authbridge/authlib/plugins/registry.go
+++ b/authbridge/authlib/plugins/registry.go
@@ -80,6 +80,25 @@ func RegisteredPlugins() []string {
 	return names
 }
 
+// SPIFFEConsumerPlugins returns the sorted names of registered plugins whose
+// instances implement spiffe.ProviderConsumer — i.e. the plugins BuildWithSPIFFE
+// would inject the Provider into. Callers that gate Provider construction on
+// actual need (see cmd/authbridge-proxy's spiffeProviderNeeded) use this to
+// assert their need-detection covers every consumer; a new consumer that slips
+// past the predicate would otherwise silently receive a nil Provider.
+func SPIFFEConsumerPlugins() []string {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	var names []string
+	for name, factory := range registry {
+		if _, ok := factory().(spiffe.ProviderConsumer); ok {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
 // CatalogEntry pairs a registered plugin's name with the capabilities
 // it advertises and the field-level schema of its config (if it
 // implements pipeline.SchemaProvider). Surfaces in `abctl`'s catalog

--- a/authbridge/authlib/tlsbridge/engine.go
+++ b/authbridge/authlib/tlsbridge/engine.go
@@ -1,10 +1,7 @@
 package tlsbridge
 
 import (
-	"log/slog"
 	"net/http"
-	"os"
-	"strings"
 )
 
 // Engine bundles everything the forward proxy needs to bridge TLS.
@@ -15,32 +12,4 @@ type Engine struct {
 	Skip     *SkipSet
 	Upstream *http.Client
 	CAPEM    []byte
-}
-
-// RunTrustSelfCheck logs a loud WARN when the bridge CA is not present in the
-// trust file the agent runtime is told to use (SSL_CERT_FILE / NODE_EXTRA_CA_CERTS
-// / REQUESTS_CA_BUNDLE). A trust-miss is then a visible signal, not an opaque
-// in-agent handshake error. Best-effort. In Phase 1 (test-only) no agent trust
-// env is set, so this simply notes that egress will safely tunnel.
-func RunTrustSelfCheck(caPEM []byte) {
-	want := strings.TrimSpace(string(caPEM))
-	if want == "" {
-		// An empty CA would make strings.Contains below always true → a false
-		// "trust self-check OK". Guard so an empty/misconstructed CA is visible.
-		slog.Warn("tls-bridge trust self-check skipped: empty CA PEM")
-		return
-	}
-	for _, env := range []string{"SSL_CERT_FILE", "NODE_EXTRA_CA_CERTS", "REQUESTS_CA_BUNDLE"} {
-		p := os.Getenv(env)
-		if p == "" {
-			continue
-		}
-		if b, err := os.ReadFile(p); err == nil && strings.Contains(string(b), want) {
-			slog.Info("tls-bridge trust self-check OK", "env", env, "path", p)
-			return
-		}
-	}
-	slog.Warn("tls-bridge trust self-check: CA not found in any agent trust file " +
-		"(SSL_CERT_FILE/NODE_EXTRA_CA_CERTS/REQUESTS_CA_BUNDLE); agent will not trust " +
-		"minted leaves and egress will safely tunnel (expected in Phase 1 / test-only)")
 }

--- a/authbridge/cmd/authbridge-proxy/main.go
+++ b/authbridge/cmd/authbridge-proxy/main.go
@@ -11,6 +11,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
@@ -87,6 +88,51 @@ func startSignalToggle() {
 	}()
 }
 
+// spiffeProviderNeeded reports whether any configured feature actually consumes
+// the SPIFFE Provider: top-level mTLS (needs the X509Source on both listeners)
+// or a plugin whose identity is spiffe-based (needs the JWT-SVID source — today
+// only token-exchange, gated on identity.type=spiffe). When nothing consumes
+// it, the provider — and its blocking SPIRE Workload API dial in NewProvider —
+// is skipped, so the binary boots even on clusters without SPIRE.
+func spiffeProviderNeeded(c *config.Config) bool {
+	if c.MTLS != nil {
+		return true
+	}
+	for _, p := range c.Pipeline.Inbound.Plugins {
+		if pluginUsesSPIFFEIdentity(p) {
+			return true
+		}
+	}
+	for _, p := range c.Pipeline.Outbound.Plugins {
+		if pluginUsesSPIFFEIdentity(p) {
+			return true
+		}
+	}
+	return false
+}
+
+// pluginUsesSPIFFEIdentity reports whether a plugin's config selects the spiffe
+// identity scheme (identity.type=spiffe) — the only plugin-level consumer of
+// the Provider today (token-exchange). The `identity` block is a shared
+// convention; a new SPIFFE-consuming plugin must either follow it or extend
+// this predicate.
+func pluginUsesSPIFFEIdentity(p config.PluginEntry) bool {
+	if len(p.Config) == 0 {
+		return false
+	}
+	var probe struct {
+		Identity struct {
+			Type string `json:"type"`
+		} `json:"identity"`
+	}
+	if err := json.Unmarshal(p.Config, &probe); err != nil {
+		// Unparseable here just means the plugin's own typed decode will fail
+		// later with a precise error; don't force the provider on for it.
+		return false
+	}
+	return probe.Identity.Type == "spiffe"
+}
+
 func main() {
 	configPath := flag.String("config", "", "path to config YAML file")
 	flag.Parse()
@@ -112,8 +158,17 @@ func main() {
 	if err != nil {
 		log.Fatalf("initial config load: %v", err)
 	}
+	// Build the SPIFFE Provider only when something actually consumes it —
+	// top-level mTLS (X509Source for the listeners) or a plugin whose identity
+	// is spiffe-based (JWT-SVID for token-exchange). The platform's base config
+	// ships an empty `spiffe: {}` for every agent, and NewProvider blocks until
+	// the SPIRE Workload API returns the first SVID; constructing it on mere
+	// presence of the block would hang any agent on a cluster without SPIRE —
+	// e.g. a proxy-sidecar agent that only runs the TLS bridge, which mints
+	// leaves from a cert-manager CA and never touches an SVID. Need-driven
+	// construction keeps such agents decoupled from SPIRE. See spiffeProviderNeeded.
 	var provider *spiffe.Provider
-	if bootCfg.SPIFFE != nil {
+	if bootCfg.SPIFFE != nil && spiffeProviderNeeded(bootCfg) {
 		mirrorFiles := true
 		if bootCfg.SPIFFE.MirrorFiles != nil {
 			mirrorFiles = *bootCfg.SPIFFE.MirrorFiles
@@ -127,6 +182,9 @@ func main() {
 			log.Fatalf("spiffe provider: %v", err)
 		}
 		defer provider.Close()
+	} else if bootCfg.SPIFFE != nil {
+		slog.Info("spiffe block present but unused (no mTLS, no spiffe-identity plugin) — " +
+			"skipping SPIRE provider; no Workload API connection will be attempted")
 	}
 
 	// This binary is hardcoded to proxy-sidecar. Rejecting other modes
@@ -286,7 +344,6 @@ func main() {
 			Upstream: up,
 			CAPEM:    src.CACertPEM(),
 		}
-		tlsbridge.RunTrustSelfCheck(bridge.CAPEM)
 		slog.Info("tls-bridge enabled", "ca_dir", cfg.TLSBridge.CADir)
 	}
 

--- a/authbridge/cmd/authbridge-proxy/main.go
+++ b/authbridge/cmd/authbridge-proxy/main.go
@@ -53,7 +53,9 @@ import (
 	_ "github.com/kagenti/kagenti-extensions/authbridge/authlib/plugins/opa"
 	_ "github.com/kagenti/kagenti-extensions/authbridge/authlib/plugins/sparc"
 	_ "github.com/kagenti/kagenti-extensions/authbridge/authlib/plugins/tokenbroker"
-	_ "github.com/kagenti/kagenti-extensions/authbridge/authlib/plugins/tokenexchange"
+	// Named (not blank) so pluginUsesSPIFFEIdentity can reference the shared
+	// SpiffeIdentity constant instead of duplicating the "spiffe" literal.
+	"github.com/kagenti/kagenti-extensions/authbridge/authlib/plugins/tokenexchange"
 )
 
 var logLevel = new(slog.LevelVar)
@@ -130,7 +132,7 @@ func pluginUsesSPIFFEIdentity(p config.PluginEntry) bool {
 		// later with a precise error; don't force the provider on for it.
 		return false
 	}
-	return probe.Identity.Type == "spiffe"
+	return probe.Identity.Type == tokenexchange.SpiffeIdentity
 }
 
 func main() {

--- a/authbridge/cmd/authbridge-proxy/main_test.go
+++ b/authbridge/cmd/authbridge-proxy/main_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kagenti/kagenti-extensions/authbridge/authlib/config"
+)
+
+func identityConfig(idType string) json.RawMessage {
+	return json.RawMessage(`{"identity":{"type":"` + idType + `"}}`)
+}
+
+// TestSpiffeProviderNeeded pins the need-driven gate: the SPIFFE provider is
+// built only when mTLS is on or a plugin selects the spiffe identity scheme.
+// A bare `spiffe: {}` block with neither must NOT trigger it — that is what
+// lets the TLS bridge (cert-manager CA, no SVID) boot without SPIRE.
+func TestSpiffeProviderNeeded(t *testing.T) {
+	outbound := func(entries ...config.PluginEntry) *config.Config {
+		return &config.Config{Pipeline: config.PipelineConfig{
+			Outbound: config.PipelineStageConfig{Plugins: entries},
+		}}
+	}
+	inbound := func(entries ...config.PluginEntry) *config.Config {
+		return &config.Config{Pipeline: config.PipelineConfig{
+			Inbound: config.PipelineStageConfig{Plugins: entries},
+		}}
+	}
+
+	tests := []struct {
+		name string
+		cfg  *config.Config
+		want bool
+	}{
+		{"empty config", &config.Config{}, false},
+		{"mtls present", &config.Config{MTLS: &config.MTLSConfig{}}, true},
+		{"token-exchange client-secret", outbound(config.PluginEntry{
+			Name: "token-exchange", Config: identityConfig("client-secret"),
+		}), false},
+		{"token-exchange spiffe (outbound)", outbound(config.PluginEntry{
+			Name: "token-exchange", Config: identityConfig("spiffe"),
+		}), true},
+		{"spiffe identity (inbound)", inbound(config.PluginEntry{
+			Name: "some-plugin", Config: identityConfig("spiffe"),
+		}), true},
+		{"plugin with no config", outbound(config.PluginEntry{Name: "jwt-validation"}), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := spiffeProviderNeeded(tt.cfg); got != tt.want {
+				t.Errorf("spiffeProviderNeeded() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/authbridge/cmd/authbridge-proxy/main_test.go
+++ b/authbridge/cmd/authbridge-proxy/main_test.go
@@ -45,6 +45,9 @@ func TestSpiffeProviderNeeded(t *testing.T) {
 			Name: "some-plugin", Config: identityConfig("spiffe"),
 		}), true},
 		{"plugin with no config", outbound(config.PluginEntry{Name: "jwt-validation"}), false},
+		{"malformed plugin config", outbound(config.PluginEntry{
+			Name: "bad-plugin", Config: json.RawMessage(`{not valid json`),
+		}), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -67,10 +70,21 @@ func TestProviderConsumersCoveredByPredicate(t *testing.T) {
 	// Plugins whose SPIFFE need spiffeProviderNeeded is known to detect.
 	covered := map[string]bool{"token-exchange": true}
 	for _, name := range plugins.SPIFFEConsumerPlugins() {
+		// Tripwire: a new consumer must be consciously reviewed and listed.
 		if !covered[name] {
 			t.Errorf("plugin %q implements spiffe.ProviderConsumer but is not covered by "+
 				"spiffeProviderNeeded; make it signal its need via identity.type=spiffe (or "+
 				"extend the predicate), then add %q to this set", name, name)
+		}
+		// Functional: the predicate must actually fire for that consumer's
+		// spiffe config, so it never receives a nil Provider.
+		cfg := &config.Config{Pipeline: config.PipelineConfig{
+			Outbound: config.PipelineStageConfig{Plugins: []config.PluginEntry{
+				{Name: name, Config: identityConfig("spiffe")},
+			}},
+		}}
+		if !spiffeProviderNeeded(cfg) {
+			t.Errorf("spiffeProviderNeeded must return true for consumer %q with identity.type=spiffe", name)
 		}
 	}
 }

--- a/authbridge/cmd/authbridge-proxy/main_test.go
+++ b/authbridge/cmd/authbridge-proxy/main_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/kagenti/kagenti-extensions/authbridge/authlib/config"
+	"github.com/kagenti/kagenti-extensions/authbridge/authlib/plugins"
 )
 
 func identityConfig(idType string) json.RawMessage {
@@ -51,5 +52,25 @@ func TestSpiffeProviderNeeded(t *testing.T) {
 				t.Errorf("spiffeProviderNeeded() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestProviderConsumersCoveredByPredicate enforces the invariant that ties
+// spiffeProviderNeeded to plugins.BuildWithSPIFFE: the predicate detects a
+// plugin's need via identity.type=spiffe, which covers token-exchange — the
+// only spiffe.ProviderConsumer today. If a new ProviderConsumer is registered,
+// this fails so the author confirms spiffeProviderNeeded detects its need;
+// otherwise that plugin would silently receive a nil Provider on a SPIRE-less
+// cluster. The main package blank-imports every plugin, so the registry here is
+// the full production set.
+func TestProviderConsumersCoveredByPredicate(t *testing.T) {
+	// Plugins whose SPIFFE need spiffeProviderNeeded is known to detect.
+	covered := map[string]bool{"token-exchange": true}
+	for _, name := range plugins.SPIFFEConsumerPlugins() {
+		if !covered[name] {
+			t.Errorf("plugin %q implements spiffe.ProviderConsumer but is not covered by "+
+				"spiffeProviderNeeded; make it signal its need via identity.type=spiffe (or "+
+				"extend the predicate), then add %q to this set", name, name)
+		}
 	}
 }

--- a/authbridge/docs/superpowers/plans/2026-06-17-authbridge-tlsbridge-phase1.md
+++ b/authbridge/docs/superpowers/plans/2026-06-17-authbridge-tlsbridge-phase1.md
@@ -40,7 +40,7 @@
 - `authlib/tlsbridge/upstream.go` — `NewUpstreamClient` (system + injected roots).
 - `authlib/tlsbridge/terminator.go` — `Terminator` (tls.Server wrap, ALPN h2+http/1.1).
 - `authlib/tlsbridge/serve.go` — `ServeConn` (one-conn keep-alive http.Server, h2-enabled).
-- `authlib/tlsbridge/engine.go` — `Engine` facade + `RunTrustSelfCheck`.
+- `authlib/tlsbridge/engine.go` — `Engine` facade + `RunTrustSelfCheck`. **(Historical: `RunTrustSelfCheck` was removed in #523 — it inspected the sidecar's own trust env, but the operator sets that on the agent container, so it false-WARNed on every deployment.)**
 - `authlib/tlsbridge/*_test.go` — per-unit tests.
 
 **Modified (proxy integration):**
@@ -1405,7 +1405,7 @@ Hook it into the loader beside the existing `MTLS`/`SPIFFE` validation (`config.
 
 Run: `go test ./config/ -run TestConfig_TLSBridge -v`
 
-- [ ] **Step 5: Add `RunTrustSelfCheck` to `engine.go`**
+- [ ] **Step 5: Add `RunTrustSelfCheck` to `engine.go`** — _(removed in #523; an in-process check can't see the agent container's trust store, so it false-WARNed on every operator deployment)_
 
 ```go
 import (


### PR DESCRIPTION
## Summary

Two boot-path fixes so the AuthBridge TLS bridge (proxy-sidecar) runs on clusters **without SPIRE**. Follow-up to #522.

### 1. Build the SPIFFE provider only when something consumes it

The platform base config ships an empty `spiffe: {}` for every agent. `cmd/authbridge-proxy` built the SPIFFE provider on mere *presence* of that block — but `spiffe.NewProvider` → `workloadapi.NewX509Source` blocks until the SPIRE Workload API returns the first SVID, with no timeout. A proxy-sidecar agent that only runs the TLS bridge mints leaves from a **cert-manager** CA and never touches an SVID, so on a SPIRE-less cluster it would **hang forever before binding any listener** (pod `Running` but every port closed, no error).

`spiffeProviderNeeded` now gates construction on a real consumer:
- top-level mTLS (needs the `X509Source`), or
- a plugin whose identity is spiffe-based (`identity.type=spiffe` — today only `token-exchange`).

An unused `spiffe: {}` logs `skipping SPIRE provider` and is skipped. mTLS without a spiffe block still fails loud via the existing guard.

### 2. Remove `RunTrustSelfCheck`

It read the **sidecar's own** `SSL_CERT_FILE` / `NODE_EXTRA_CA_CERTS` / `REQUESTS_CA_BUNDLE`, but the operator sets those on the **agent** container — so it logged a false `agent will not trust minted leaves and egress will safely tunnel` WARN on every real deployment (even when the agent trusts the CA fine). An in-process check can't validate another container's trust store.

## Test Plan

- [x] `go build` + `go vet` (authlib, cmd/authbridge-proxy)
- [x] `go test` — added `spiffeProviderNeeded` unit coverage (mtls→true, spiffe-identity→true, client-secret→false, empty→false); tlsbridge package tests pass
- [x] End-to-end on Kind with the SPIRE socket **unmounted**: sidecar logs `skipping SPIRE provider` + `tls-bridge enabled`, binds `:8081`, forges a leaf from the cert-manager CA (`issuer=authbridge-tls-bridge-ca-<workload>`), and the agent's HTTPS to example.com is decrypted (`HTTP/2 404`) — no hang, no `permission denied`, no `trust self-check` WARN, no SPIRE volume mounted. (Requires the companion operator fix that sets `fsGroup` for the CA mount.)

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Optimized SPIFFE provider initialization to only build when enabled by mTLS or when plugin identity configuration requires it.
  * Added log messaging when SPIFFE configuration is present but not used.
* **Bug Fixes / Behavior Change**
  * Removed TLS bridge “trust self-check” warnings during engine setup.
* **Tests**
  * Added unit tests covering SPIFFE activation and provider-consumer coverage rules, including malformed configuration handling.
* **Documentation**
  * Updated the TLS bridge phase plan to reflect the removal of the trust self-check step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->