### PR TITLE
Feat: Add Anthropic Messages API support to inference-parser

### DIFF
--- a/authbridge/authlib/plugins/inferenceparser/anthropic.go
+++ b/authbridge/authlib/plugins/inferenceparser/anthropic.go
@@ -1,0 +1,264 @@
+package inferenceparser
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+
+	"github.com/kagenti/kagenti-extensions/authbridge/authlib/pipeline"
+)
+
+// anthropicMessagesPath is the Anthropic Messages API endpoint. Clients
+// (e.g. claude-code via a LiteLLM/Anthropic-compatible gateway) POST here
+// instead of the OpenAI /v1/chat/completions endpoint, so the parser must
+// recognize both dialects.
+const anthropicMessagesPath = "/v1/messages"
+
+// --- request ---
+
+// anthropicRequest is the subset of the Anthropic Messages request we surface.
+// Unlike OpenAI, the system prompt is a top-level field (string or text-block
+// array), not a message with role "system".
+type anthropicRequest struct {
+	Model       string                `json:"model"`
+	Messages    []anthropicReqMessage `json:"messages"`
+	System      json.RawMessage       `json:"system"`
+	Temperature *float64              `json:"temperature"`
+	MaxTokens   *int                  `json:"max_tokens"`
+	TopP        *float64              `json:"top_p"`
+	Stream      bool                  `json:"stream"`
+	Tools       []anthropicTool       `json:"tools"`
+	ToolChoice  any                   `json:"tool_choice"`
+}
+
+// anthropicTool is an Anthropic tool definition. The schema lives under
+// input_schema (vs OpenAI's nested function.parameters).
+type anthropicTool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"input_schema"`
+}
+
+// anthropicReqMessage flattens the request message content to text. Anthropic
+// content is a string or an array of content blocks (text / image / tool_use /
+// tool_result); reuse flattenContent, which keeps text blocks and drops the
+// rest — the same {"type":"text","text":...} shape OpenAI uses.
+type anthropicReqMessage struct {
+	Role    string
+	Content string
+}
+
+func (m *anthropicReqMessage) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	m.Role = raw.Role
+	m.Content = flattenContent(raw.Content)
+	return nil
+}
+
+// parseAnthropicRequest builds an InferenceExtension from an Anthropic Messages
+// request body. Returns nil for an empty or non-JSON body (caller treats nil as
+// "not an inference request we can parse" and continues).
+func parseAnthropicRequest(body []byte) *pipeline.InferenceExtension {
+	if len(body) == 0 {
+		return nil
+	}
+	var req anthropicRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil
+	}
+
+	ext := &pipeline.InferenceExtension{
+		Model:       req.Model,
+		Temperature: req.Temperature,
+		MaxTokens:   req.MaxTokens,
+		TopP:        req.TopP,
+		Stream:      req.Stream,
+		ToolChoice:  req.ToolChoice,
+		// Every populated InferenceExtension is an outbound LLM call — an
+		// agent action. Same classification as the OpenAI path.
+		IsAction: true,
+	}
+
+	// Anthropic carries the system prompt top-level, not as a message role.
+	// Surface it as a leading system message so downstream policy plugins
+	// (IBAC, etc.) see it the same way they see OpenAI's system message.
+	if sys := flattenContent(req.System); sys != "" {
+		ext.Messages = append(ext.Messages, pipeline.InferenceMessage{Role: "system", Content: sys})
+	}
+	for _, msg := range req.Messages {
+		ext.Messages = append(ext.Messages, pipeline.InferenceMessage{Role: msg.Role, Content: msg.Content})
+	}
+	for _, tool := range req.Tools {
+		if tool.Name == "" {
+			continue
+		}
+		ext.Tools = append(ext.Tools, pipeline.InferenceTool{
+			Name:        tool.Name,
+			Description: tool.Description,
+			Parameters:  rawMessageToMap(tool.InputSchema),
+		})
+	}
+	return ext
+}
+
+// --- usage (shared by response + streaming) ---
+
+// anthropicUsage mirrors the Messages API usage block. The true input size is
+// input_tokens + cache_creation_input_tokens + cache_read_input_tokens (cached
+// context still counts as input); promptTotal sums them.
+type anthropicUsage struct {
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+}
+
+func (u anthropicUsage) promptTotal() int {
+	return u.InputTokens + u.CacheCreationInputTokens + u.CacheReadInputTokens
+}
+
+// --- non-streaming response ---
+
+type anthropicResponse struct {
+	Content    []anthropicContentBlock `json:"content"`
+	StopReason string                  `json:"stop_reason"`
+	Usage      anthropicUsage          `json:"usage"`
+}
+
+type anthropicContentBlock struct {
+	Type  string          `json:"type"`
+	Text  string          `json:"text"`
+	ID    string          `json:"id"`
+	Name  string          `json:"name"`
+	Input json.RawMessage `json:"input"`
+}
+
+// parseAnthropicJSON parses a non-streaming Messages response: text blocks ->
+// completion, tool_use blocks -> tool calls, usage -> token counts.
+func parseAnthropicJSON(body []byte, ext *pipeline.InferenceExtension) {
+	var resp anthropicResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return
+	}
+	var b strings.Builder
+	for _, blk := range resp.Content {
+		switch blk.Type {
+		case "text":
+			if blk.Text != "" {
+				if b.Len() > 0 {
+					b.WriteByte('\n')
+				}
+				b.WriteString(blk.Text)
+			}
+		case "tool_use":
+			ext.ToolCalls = append(ext.ToolCalls, pipeline.InferenceToolCall{
+				ID:        blk.ID,
+				Name:      blk.Name,
+				Arguments: string(blk.Input),
+			})
+		}
+	}
+	ext.Completion = b.String()
+	if resp.StopReason != "" {
+		ext.FinishReason = resp.StopReason
+	}
+	ext.PromptTokens = resp.Usage.promptTotal()
+	ext.CompletionTokens = resp.Usage.OutputTokens
+	ext.TotalTokens = ext.PromptTokens + ext.CompletionTokens
+}
+
+// --- streaming ---
+
+// anthropicStreamEvent is one SSE event's data payload. The Messages stream is
+// a sequence of typed events (vs OpenAI's uniform chat.completion.chunk):
+// message_start (carries usage.input_tokens), content_block_delta (text_delta /
+// input_json_delta / thinking_delta), message_delta (delta.stop_reason +
+// cumulative usage.output_tokens), message_stop, plus ping/content_block_*.
+type anthropicStreamEvent struct {
+	Type    string `json:"type"`
+	Message *struct {
+		Usage anthropicUsage `json:"usage"`
+	} `json:"message"`
+	Delta *struct {
+		Type       string `json:"type"`
+		Text       string `json:"text"`
+		StopReason string `json:"stop_reason"`
+	} `json:"delta"`
+	Usage *anthropicUsage `json:"usage"`
+}
+
+// foldAnthropicFrame folds one Messages SSE event into the running stream state.
+// input_tokens come from message_start; the completion accumulates from
+// text_delta blocks; stop_reason and the cumulative output_tokens arrive in
+// message_delta. Unknown events (ping, content_block_start/stop, message_stop)
+// are ignored.
+func foldAnthropicFrame(frame []byte, state *inferenceStreamState, ext *pipeline.InferenceExtension) {
+	var ev anthropicStreamEvent
+	if err := json.Unmarshal(frame, &ev); err != nil {
+		return
+	}
+	switch ev.Type {
+	case "message_start":
+		if ev.Message != nil {
+			state.usage.PromptTokens = ev.Message.Usage.promptTotal()
+		}
+	case "content_block_delta":
+		if ev.Delta != nil && ev.Delta.Type == "text_delta" {
+			state.completion.WriteString(ev.Delta.Text)
+		}
+	case "message_delta":
+		if ev.Delta != nil && ev.Delta.StopReason != "" {
+			ext.FinishReason = ev.Delta.StopReason
+		}
+		if ev.Usage != nil && ev.Usage.OutputTokens > 0 {
+			// usage.output_tokens in message_delta is cumulative — take the
+			// latest. TotalTokens must be non-zero for the shared finalize
+			// block to copy the counts onto the extension.
+			state.usage.CompletionTokens = ev.Usage.OutputTokens
+			state.usage.TotalTokens = state.usage.PromptTokens + ev.Usage.OutputTokens
+		}
+	}
+}
+
+// parseAnthropicSSE folds a fully-buffered Messages SSE body. Mirrors
+// parseInferenceSSE for the legacy OnResponse path; the live listener uses
+// foldAnthropicFrame via OnResponseFrame instead.
+func parseAnthropicSSE(body []byte, ext *pipeline.InferenceExtension) {
+	state := &inferenceStreamState{}
+	for _, line := range bytes.Split(body, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if !bytes.HasPrefix(line, []byte("data:")) {
+			continue
+		}
+		data := bytes.TrimSpace(bytes.TrimPrefix(line, []byte("data:")))
+		if len(data) == 0 {
+			continue
+		}
+		foldAnthropicFrame(data, state, ext)
+	}
+	ext.Completion = state.completion.String()
+	if state.usage.TotalTokens > 0 {
+		ext.PromptTokens = state.usage.PromptTokens
+		ext.CompletionTokens = state.usage.CompletionTokens
+		ext.TotalTokens = state.usage.TotalTokens
+	}
+}
+
+// rawMessageToMap decodes a JSON object into a map, returning nil for an absent
+// or non-object value (so a non-object input_schema doesn't fail the parse).
+func rawMessageToMap(raw json.RawMessage) map[string]any {
+	if len(raw) == 0 {
+		return nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil
+	}
+	return m
+}

--- a/authbridge/authlib/plugins/inferenceparser/anthropic_test.go
+++ b/authbridge/authlib/plugins/inferenceparser/anthropic_test.go
@@ -1,0 +1,156 @@
+package inferenceparser
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kagenti/kagenti-extensions/authbridge/authlib/pipeline"
+)
+
+func TestInferenceParser_AnthropicMessages_Request(t *testing.T) {
+	p := NewInferenceParser()
+	pctx := &pipeline.Context{
+		Path: "/v1/messages",
+		Body: []byte(`{
+			"model": "claude-opus-4-8",
+			"system": "You are a helpful assistant.",
+			"messages": [
+				{"role": "user", "content": "What is the weather in NYC?"}
+			],
+			"max_tokens": 1024,
+			"temperature": 0.7,
+			"stream": false,
+			"tools": [
+				{"name": "get_weather", "description": "Get weather", "input_schema": {"type": "object"}}
+			]
+		}`),
+	}
+
+	if action := p.OnRequest(context.Background(), pctx); action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	ext := pctx.Extensions.Inference
+	if ext == nil {
+		t.Fatal("Extensions.Inference is nil — /v1/messages not parsed")
+	}
+	if ext.Model != "claude-opus-4-8" {
+		t.Errorf("Model = %q, want claude-opus-4-8", ext.Model)
+	}
+	if !ext.IsAction {
+		t.Error("IsAction should be true for an inference request")
+	}
+	// system (top-level) is surfaced as a leading system message, then the user turn.
+	if len(ext.Messages) != 2 || ext.Messages[0].Role != "system" || ext.Messages[1].Role != "user" {
+		t.Fatalf("Messages = %+v, want [system, user]", ext.Messages)
+	}
+	if ext.Messages[0].Content != "You are a helpful assistant." {
+		t.Errorf("system content = %q", ext.Messages[0].Content)
+	}
+	if ext.MaxTokens == nil || *ext.MaxTokens != 1024 {
+		t.Errorf("MaxTokens = %v, want 1024", ext.MaxTokens)
+	}
+	if len(ext.Tools) != 1 || ext.Tools[0].Name != "get_weather" {
+		t.Fatalf("Tools = %+v, want [get_weather]", ext.Tools)
+	}
+}
+
+func TestInferenceParser_AnthropicMessages_ContentBlockArray(t *testing.T) {
+	// Anthropic content can be a block array; flatten text blocks like OpenAI.
+	p := NewInferenceParser()
+	pctx := &pipeline.Context{
+		Path: "/v1/messages",
+		Body: []byte(`{
+			"model": "claude-opus-4-8",
+			"max_tokens": 64,
+			"messages": [
+				{"role": "user", "content": [
+					{"type": "text", "text": "part one"},
+					{"type": "text", "text": "part two"}
+				]}
+			]
+		}`),
+	}
+	p.OnRequest(context.Background(), pctx)
+	ext := pctx.Extensions.Inference
+	if ext == nil || len(ext.Messages) != 1 {
+		t.Fatalf("ext/messages = %+v", ext)
+	}
+	if ext.Messages[0].Content != "part one\npart two" {
+		t.Errorf("flattened content = %q, want \"part one\\npart two\"", ext.Messages[0].Content)
+	}
+}
+
+func TestInferenceParser_AnthropicMessages_NonStreamingResponse(t *testing.T) {
+	p := NewInferenceParser()
+	pctx := &pipeline.Context{Path: "/v1/messages"}
+	// non-streaming: ext.Stream == false → one-shot last=true frame is parsed as JSON.
+	pctx.Extensions.Inference = &pipeline.InferenceExtension{Model: "claude-opus-4-8", IsAction: true}
+
+	body := []byte(`{
+		"id": "msg_1", "type": "message", "role": "assistant", "model": "claude-opus-4-8",
+		"content": [
+			{"type": "text", "text": "It is sunny."},
+			{"type": "tool_use", "id": "toolu_1", "name": "get_weather", "input": {"city": "NYC"}}
+		],
+		"stop_reason": "tool_use",
+		"usage": {"input_tokens": 25, "output_tokens": 8, "cache_read_input_tokens": 2}
+	}`)
+	p.OnResponseFrame(context.Background(), pctx, body, true)
+
+	ext := pctx.Extensions.Inference
+	if ext.Completion != "It is sunny." {
+		t.Errorf("Completion = %q", ext.Completion)
+	}
+	if ext.FinishReason != "tool_use" {
+		t.Errorf("FinishReason = %q, want tool_use", ext.FinishReason)
+	}
+	if len(ext.ToolCalls) != 1 || ext.ToolCalls[0].Name != "get_weather" {
+		t.Fatalf("ToolCalls = %+v", ext.ToolCalls)
+	}
+	// PromptTokens = input_tokens + cache_read (25 + 2); CompletionTokens = output_tokens.
+	if ext.PromptTokens != 27 || ext.CompletionTokens != 8 || ext.TotalTokens != 35 {
+		t.Errorf("tokens = prompt %d / completion %d / total %d, want 27/8/35",
+			ext.PromptTokens, ext.CompletionTokens, ext.TotalTokens)
+	}
+}
+
+func TestInferenceParser_AnthropicMessages_StreamFoldsEvents(t *testing.T) {
+	p := NewInferenceParser()
+	pctx := &pipeline.Context{Path: "/v1/messages"}
+	pctx.Extensions.Inference = &pipeline.InferenceExtension{Model: "claude-opus-4-8", Stream: true, IsAction: true}
+
+	frames := [][]byte{
+		[]byte(`{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","usage":{"input_tokens":25,"output_tokens":1}}}`),
+		[]byte(`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`),
+		[]byte(`{"type":"ping"}`),
+		[]byte(`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}`),
+		[]byte(`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" world"}}`),
+		[]byte(`{"type":"content_block_stop","index":0}`),
+		[]byte(`{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":15}}`),
+		[]byte(`{"type":"message_stop"}`),
+	}
+	for _, f := range frames {
+		if action := p.OnResponseFrame(context.Background(), pctx, f, false); action.Type != pipeline.Continue {
+			t.Fatalf("frame action = %v, want Continue", action.Type)
+		}
+	}
+	// Mid-stream: not finalized yet.
+	if pctx.Extensions.Inference.Completion != "" {
+		t.Errorf("Completion populated mid-stream = %q", pctx.Extensions.Inference.Completion)
+	}
+	// Finalize.
+	p.OnResponseFrame(context.Background(), pctx, nil, true)
+
+	ext := pctx.Extensions.Inference
+	if ext.Completion != "Hello world" {
+		t.Errorf("Completion = %q, want \"Hello world\"", ext.Completion)
+	}
+	if ext.FinishReason != "end_turn" {
+		t.Errorf("FinishReason = %q, want end_turn", ext.FinishReason)
+	}
+	// input_tokens from message_start; cumulative output_tokens from message_delta.
+	if ext.PromptTokens != 25 || ext.CompletionTokens != 15 || ext.TotalTokens != 40 {
+		t.Errorf("tokens = prompt %d / completion %d / total %d, want 25/15/40",
+			ext.PromptTokens, ext.CompletionTokens, ext.TotalTokens)
+	}
+}

--- a/authbridge/authlib/plugins/inferenceparser/plugin.go
+++ b/authbridge/authlib/plugins/inferenceparser/plugin.go
@@ -32,57 +32,22 @@ func (p *InferenceParser) Capabilities() pipeline.PluginCapabilities {
 }
 
 func (p *InferenceParser) OnRequest(_ context.Context, pctx *pipeline.Context) pipeline.Action {
-	// No Invocation recorded when the parser doesn't apply to this
-	// message — wrong path (anything other than OpenAI chat/completion
-	// endpoints), empty body, or non-JSON body. Operators infer
-	// "inference-parser exists in this pipeline" from config, not per-
-	// event rows.
-	if pctx.Path != "/v1/chat/completions" && pctx.Path != "/v1/completions" {
+	// Dispatch by endpoint dialect: OpenAI chat/completions vs Anthropic
+	// Messages. No Invocation is recorded when the parser doesn't apply
+	// (unrecognized path, empty body, or non-JSON body) — operators infer
+	// "inference-parser is in this pipeline" from config, not per-event rows.
+	var ext *pipeline.InferenceExtension
+	switch pctx.Path {
+	case "/v1/chat/completions", "/v1/completions":
+		ext = parseOpenAIRequest(pctx.Body)
+	case anthropicMessagesPath:
+		ext = parseAnthropicRequest(pctx.Body)
+	default:
 		return pipeline.Action{Type: pipeline.Continue}
 	}
-
-	if len(pctx.Body) == 0 {
-		slog.Debug("inference-parser: no body, skipping")
+	if ext == nil {
+		slog.Debug("inference-parser: no/invalid body, skipping", "path", pctx.Path)
 		return pipeline.Action{Type: pipeline.Continue}
-	}
-
-	var req inferenceRequest
-	if err := json.Unmarshal(pctx.Body, &req); err != nil {
-		slog.Debug("inference-parser: invalid JSON", "error", err)
-		return pipeline.Action{Type: pipeline.Continue}
-	}
-
-	ext := &pipeline.InferenceExtension{
-		Model:       req.Model,
-		Temperature: req.Temperature,
-		MaxTokens:   req.MaxTokens,
-		TopP:        req.TopP,
-		Stream:      req.Stream,
-		ToolChoice:  req.ToolChoice,
-		// Every populated InferenceExtension is an outbound LLM call —
-		// the agent making a real action. The "don't judge inference
-		// by default" choice is operator policy, lives in IBAC's
-		// judge_inference config; the classification verdict here is
-		// independent of that policy.
-		IsAction: true,
-	}
-
-	for _, msg := range req.Messages {
-		ext.Messages = append(ext.Messages, pipeline.InferenceMessage{
-			Role:    msg.Role,
-			Content: msg.Content,
-		})
-	}
-
-	for _, tool := range req.Tools {
-		if tool.Function.Name == "" {
-			continue
-		}
-		ext.Tools = append(ext.Tools, pipeline.InferenceTool{
-			Name:        tool.Function.Name,
-			Description: tool.Function.Description,
-			Parameters:  tool.Function.paramsMap(),
-		})
 	}
 
 	pctx.Extensions.Inference = ext
@@ -95,6 +60,47 @@ func (p *InferenceParser) OnRequest(_ context.Context, pctx *pipeline.Context) p
 
 	pctx.Observe("matched_" + ext.Model)
 	return pipeline.Action{Type: pipeline.Continue}
+}
+
+// parseOpenAIRequest builds an InferenceExtension from an OpenAI
+// chat/completions (or completions) request body. Returns nil for an empty or
+// non-JSON body. Every populated extension is an outbound LLM call — an agent
+// action (IsAction); the "don't judge inference by default" choice is operator
+// policy in IBAC, independent of this classification.
+func parseOpenAIRequest(body []byte) *pipeline.InferenceExtension {
+	if len(body) == 0 {
+		return nil
+	}
+	var req inferenceRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil
+	}
+	ext := &pipeline.InferenceExtension{
+		Model:       req.Model,
+		Temperature: req.Temperature,
+		MaxTokens:   req.MaxTokens,
+		TopP:        req.TopP,
+		Stream:      req.Stream,
+		ToolChoice:  req.ToolChoice,
+		IsAction:    true,
+	}
+	for _, msg := range req.Messages {
+		ext.Messages = append(ext.Messages, pipeline.InferenceMessage{
+			Role:    msg.Role,
+			Content: msg.Content,
+		})
+	}
+	for _, tool := range req.Tools {
+		if tool.Function.Name == "" {
+			continue
+		}
+		ext.Tools = append(ext.Tools, pipeline.InferenceTool{
+			Name:        tool.Function.Name,
+			Description: tool.Function.Description,
+			Parameters:  tool.Function.paramsMap(),
+		})
+	}
+	return ext
 }
 
 // OnResponse is the legacy buffered-path response hook. Because this
@@ -118,9 +124,17 @@ func (p *InferenceParser) OnResponse(_ context.Context, pctx *pipeline.Context) 
 	}
 
 	if ext.Stream {
-		parseInferenceSSE(pctx.ResponseBody, ext)
+		if pctx.Path == anthropicMessagesPath {
+			parseAnthropicSSE(pctx.ResponseBody, ext)
+		} else {
+			parseInferenceSSE(pctx.ResponseBody, ext)
+		}
 	} else {
-		parseInferenceJSON(pctx.ResponseBody, ext)
+		if pctx.Path == anthropicMessagesPath {
+			parseAnthropicJSON(pctx.ResponseBody, ext)
+		} else {
+			parseInferenceJSON(pctx.ResponseBody, ext)
+		}
 	}
 
 	logInferenceFinalized(ext)
@@ -165,35 +179,25 @@ func (p *InferenceParser) OnResponseFrame(_ context.Context, pctx *pipeline.Cont
 			pctx.Skip("no_response_body")
 			return pipeline.Action{Type: pipeline.Continue}
 		}
-		parseInferenceJSON(frame, ext)
+		if pctx.Path == anthropicMessagesPath {
+			parseAnthropicJSON(frame, ext)
+		} else {
+			parseInferenceJSON(frame, ext)
+		}
 		logInferenceFinalized(ext)
 		pctx.Observe("matched_" + ext.Model + "_response")
 		return pipeline.Action{Type: pipeline.Continue}
 	}
 
-	// Streaming path. Lazily allocate the per-stream scratch.
+	// Streaming path. Lazily allocate the per-stream scratch, then fold this
+	// frame into it via the dialect-specific handler.
 	state := getOrCreateStreamState(pctx)
 
 	if len(frame) > 0 {
-		// Each frame is one OpenAI streaming chunk: data: { choices: [...], usage: ... }
-		// or the literal sentinel "[DONE]". Skip the sentinel.
-		if !bytes.Equal(bytes.TrimSpace(frame), []byte("[DONE]")) {
-			var chunk inferenceStreamChunk
-			if err := json.Unmarshal(frame, &chunk); err != nil {
-				slog.Debug("inference-parser: malformed streaming chunk, skipping", "error", err)
-			} else {
-				for _, c := range chunk.Choices {
-					if c.Delta.Content != "" {
-						state.completion.WriteString(c.Delta.Content)
-					}
-					if c.FinishReason != "" {
-						ext.FinishReason = c.FinishReason
-					}
-				}
-				if chunk.Usage.TotalTokens > 0 {
-					state.usage = chunk.Usage
-				}
-			}
+		if pctx.Path == anthropicMessagesPath {
+			foldAnthropicFrame(frame, state, ext)
+		} else {
+			foldOpenAIFrame(frame, state, ext)
 		}
 	}
 
@@ -214,6 +218,32 @@ func (p *InferenceParser) OnResponseFrame(_ context.Context, pctx *pipeline.Cont
 		pctx.Observe("matched_" + ext.Model + "_response")
 	}
 	return pipeline.Action{Type: pipeline.Continue}
+}
+
+// foldOpenAIFrame folds one OpenAI streaming chunk (data: {choices,usage}) into
+// the running stream state. The "[DONE]" sentinel and malformed chunks are
+// skipped. Usage arrives (cumulative) when the client set
+// stream_options.include_usage.
+func foldOpenAIFrame(frame []byte, state *inferenceStreamState, ext *pipeline.InferenceExtension) {
+	if bytes.Equal(bytes.TrimSpace(frame), []byte("[DONE]")) {
+		return
+	}
+	var chunk inferenceStreamChunk
+	if err := json.Unmarshal(frame, &chunk); err != nil {
+		slog.Debug("inference-parser: malformed streaming chunk, skipping", "error", err)
+		return
+	}
+	for _, c := range chunk.Choices {
+		if c.Delta.Content != "" {
+			state.completion.WriteString(c.Delta.Content)
+		}
+		if c.FinishReason != "" {
+			ext.FinishReason = c.FinishReason
+		}
+	}
+	if chunk.Usage.TotalTokens > 0 {
+		state.usage = chunk.Usage
+	}
 }
 
 func getOrCreateStreamState(pctx *pipeline.Context) *inferenceStreamState {


### PR DESCRIPTION
## Summary

The `inference-parser` only recognized the **OpenAI** chat/completions API (`/v1/chat/completions`, `/v1/completions`). Anthropic **Messages** traffic (`POST /v1/messages` — what claude-code and Anthropic SDK clients use) hit the path check and was silently skipped, so it produced **no inference session events** even when the TLS bridge had already decrypted the request.

This adds Anthropic Messages as a second dialect, dispatched by request path. The OpenAI path is behavior-identical — its logic was extracted verbatim into `parseOpenAIRequest` / `foldOpenAIFrame`.

### Mapping
- **Request** → `InferenceExtension`: `model`, `max_tokens`, `temperature`, `top_p`, `stream`, `tool_choice`; the top-level `system` prompt is surfaced as a leading `role:"system"` message (Anthropic has no system role); message content blocks flattened to text (reuses the existing `flattenContent` — Anthropic text blocks share OpenAI's `{type:"text","text":…}` shape); `tools[].input_schema` → tool `Parameters`.
- **Non-streaming response**: `content` text blocks → completion, `tool_use` blocks → tool calls, `stop_reason` → finish reason.
- **Streaming SSE**: `message_start` → `input_tokens`; `content_block_delta` / `text_delta` → completion; `message_delta` → `stop_reason` + **cumulative** `output_tokens`; `message_stop` / `ping` / `content_block_*` ignored.
- **Tokens**: `PromptTokens = input_tokens + cache_creation_input_tokens + cache_read_input_tokens` (cached context still counts as input); `CompletionTokens = output_tokens`. No `InferenceExtension` schema change — reuses the existing fields.

### Test plan
- `go test ./authlib/plugins/inferenceparser/...` — new `anthropic_test.go` covers request parse, content-block flattening, non-streaming response, and the full streaming event fold; existing OpenAI tests unchanged. `go build ./...` + `golangci-lint run` clean.
- Verified live on Kind: a claude-code agent's `/v1/messages` calls (via a LiteLLM Anthropic-compatible gateway) — previously invisible — now appear as parsed inference events on the session API (`model`, prompt/completion tokens, `finish_reason`) once the TLS bridge decrypts them.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Anthropic's Messages API alongside existing OpenAI integration.

* **Refactor**
  * Restructured the inference parser plugin to support multiple AI provider dialects with improved request/response dispatch logic.

* **Tests**
  * Added comprehensive test coverage for Anthropic API request/response parsing and streaming functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->