### PR TITLE
Fix(bypass): add /metrics to default JWT bypass paths

### DIFF
--- a/authbridge/authlib/bypass/matcher.go
+++ b/authbridge/authlib/bypass/matcher.go
@@ -9,7 +9,7 @@ import (
 )
 
 // DefaultPatterns are paths that skip inbound JWT validation by default.
-var DefaultPatterns = []string{"/.well-known/*", "/healthz", "/readyz", "/livez"}
+var DefaultPatterns = []string{"/.well-known/*", "/healthz", "/readyz", "/livez", "/metrics"}
 
 // Matcher checks request paths against a set of bypass patterns.
 // Patterns use Go's path.Match syntax (e.g., "/.well-known/*").

--- a/authbridge/authlib/bypass/matcher_test.go
+++ b/authbridge/authlib/bypass/matcher_test.go
@@ -34,6 +34,7 @@ func TestMatch(t *testing.T) {
 		{"/healthz", true},
 		{"/readyz", true},
 		{"/livez", true},
+		{"/metrics", true},
 
 		// Non-bypass paths
 		{"/test", false},
@@ -43,11 +44,15 @@ func TestMatch(t *testing.T) {
 		// Query string stripping
 		{"/healthz?verbose=true", true},
 		{"/.well-known/agent.json?format=json", true},
+		{"/metrics?format=prometheus", true},
 
 		// Path normalization (security)
 		{"//healthz", true},
 		{"/./healthz", true},
 		{"/foo/../healthz", true},
+
+		// Sub-paths of /metrics are NOT bypassed (exact match only)
+		{"/metrics/cadvisor", false},
 
 		// Well-known does NOT match nested paths (path.Match * doesn't cross /)
 		{"/.well-known/foo/bar", false},

--- a/authbridge/authlib/plugins/jwtvalidation/plugin.go
+++ b/authbridge/authlib/plugins/jwtvalidation/plugin.go
@@ -100,7 +100,7 @@ type jwtValidationConfig struct {
 
 	// BypassPaths are URL path globs (see authlib/bypass) that skip
 	// validation entirely.
-	BypassPaths []string `json:"bypass_paths" description:"Path globs (path.Match) skipped without JWT validation. Defaults: /healthz /readyz /livez /.well-known/*."`
+	BypassPaths []string `json:"bypass_paths" description:"Path globs (path.Match) skipped without JWT validation. Defaults: /healthz /readyz /livez /metrics /.well-known/*."`
 
 	PlaceholderMode bool   `json:"placeholder_mode" default:"false" description:"After validating the inbound token, replace it with an opaque placeholder before forwarding to the agent; the real token is held in the shared store for the outbound path to resolve. Requires a shared store and token-exchange resolve_placeholders downstream."`
 	PlaceholderTTL  string `json:"placeholder_ttl" default:"1h" description:"How long the real token is retained for outbound resolution (Go duration, e.g. 30m). Default 1h."`


### PR DESCRIPTION
## Summary

- Adds `/metrics` to `DefaultPatterns` in `authbridge/authlib/bypass/matcher.go` so Prometheus scraping is not blocked by JWT validation when authbridge is injected as a sidecar.
- Adds test coverage: exact match, query-string stripping, and sub-path exclusion (`/metrics/cadvisor` is NOT bypassed).

## Rationale

- `/metrics` endpoints are infrastructure-only, consumed exclusively by the monitoring stack (Prometheus).
- Access control is handled at the network layer via NetworkPolicies (FedRAMP AC-3/SC-7).
- Consistent with how `/healthz`, `/readyz`, and `/livez` are already treated.

## Test plan

- [x] `go test ./authlib/bypass/ -v` — all pass
- [x] Dependent packages (`auth`, `jwtvalidation`, `extproc`, `reverseproxy`) — all pass

Fixes #524

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `/metrics` endpoint is now properly excluded from authentication requirements when using default bypass patterns, allowing metrics collection without authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->