### PR TITLE
Fix: Forward-proxy inference SSE event: lines + outbound session pinning

### DIFF
--- a/authbridge/authlib/listener/forwardproxy/server.go
+++ b/authbridge/authlib/listener/forwardproxy/server.go
@@ -972,23 +972,41 @@ func writeSSEFrame(w io.Writer, frame []byte) bool {
 }
 
 // sseEventName returns the SSE `event:` name to emit for an SSE data
-// payload, or "" when none should be emitted. Anthropic Messages
-// stream events carry a top-level JSON "type" (message_start,
-// content_block_start, content_block_delta, content_block_stop,
-// message_delta, message_stop, ping, error) that equals the SSE event
-// name the upstream sent; reconstructing it keeps the relayed stream
-// byte-faithful Anthropic SSE. Non-JSON frames ("[DONE]") and
-// data-only protocols (MCP/A2A JSON-RPC with "jsonrpc"/"kind", OpenAI
-// chat chunks with "object") have no top-level string "type" and
-// return "", so their data-only framing is preserved unchanged.
+// payload, or "" when none should be emitted. It maps a frame to one of
+// the known Anthropic Messages stream events via the payload's top-level
+// JSON "type"; reconstructing that `event:` line keeps the relayed stream
+// byte-faithful Anthropic SSE (the sseframe reader drops it).
+//
+// Two deliberate constraints:
+//   - Fast path: skip the JSON parse entirely for frames that cannot carry
+//     a top-level "type" (data-only JSON-RPC / OpenAI chat chunks with
+//     "object" / "[DONE]"), so high-rate token streams stay allocation-free
+//     on the proxy's hot data path.
+//   - Allowlist: emit only the fixed set of Anthropic stream event names.
+//     The "type" comes from an upstream the bridge does not trust, so
+//     echoing it verbatim would let a crafted value inject SSE fields (a
+//     CRLF in "type") or steer the client's event dispatch with an
+//     arbitrary name. Exact-matching a constant set makes both impossible
+//     and scopes reconstruction to Anthropic — a future data-only protocol
+//     that happens to carry a top-level "type" (e.g. the OpenAI Responses
+//     API) is left untouched.
 func sseEventName(frame []byte) string {
+	if !bytes.Contains(frame, []byte(`"type"`)) {
+		return ""
+	}
 	var probe struct {
 		Type string `json:"type"`
 	}
 	if err := json.Unmarshal(frame, &probe); err != nil {
 		return ""
 	}
-	return probe.Type
+	switch probe.Type {
+	case "message_start", "content_block_start", "content_block_delta",
+		"content_block_stop", "message_delta", "message_stop", "ping", "error":
+		return probe.Type
+	default:
+		return ""
+	}
 }
 
 // idleReader wraps r so each Read enforces an idle deadline. The

--- a/authbridge/authlib/listener/forwardproxy/server.go
+++ b/authbridge/authlib/listener/forwardproxy/server.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	cryptotls "crypto/tls"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -914,7 +915,23 @@ func (s *Server) handleConnect(w http.ResponseWriter, r *http.Request) {
 // boundaries the upstream produced. Returns true when every byte
 // was written; false on any write error so the caller can stop
 // forwarding without re-checking each Write.
+//
+// The sseframe reader drops the SSE `event:` field (it surfaces only
+// data payloads), which is correct for data-only streams (MCP/A2A
+// JSON-RPC, OpenAI chat chunks). But Anthropic's Messages streaming
+// REQUIRES a typed `event:` line before each `data:` — without it the
+// Anthropic client can't finalize the stream and falls back to a
+// non-streaming retry, doubling the upstream call. Reconstruct the
+// `event:` line from the payload's top-level "type" (which, for an
+// Anthropic stream event, is exactly the SSE event name). Frames
+// without a top-level string "type" get no event line, preserving the
+// data-only shape the other protocols expect.
 func writeSSEFrame(w io.Writer, frame []byte) bool {
+	if ev := sseEventName(frame); ev != "" {
+		if _, err := io.WriteString(w, "event: "+ev+"\n"); err != nil {
+			return false
+		}
+	}
 	for len(frame) > 0 {
 		nl := bytes.IndexByte(frame, '\n')
 		var line []byte
@@ -939,6 +956,26 @@ func writeSSEFrame(w io.Writer, frame []byte) bool {
 		return false
 	}
 	return true
+}
+
+// sseEventName returns the SSE `event:` name to emit for an SSE data
+// payload, or "" when none should be emitted. Anthropic Messages
+// stream events carry a top-level JSON "type" (message_start,
+// content_block_start, content_block_delta, content_block_stop,
+// message_delta, message_stop, ping, error) that equals the SSE event
+// name the upstream sent; reconstructing it keeps the relayed stream
+// byte-faithful Anthropic SSE. Non-JSON frames ("[DONE]") and
+// data-only protocols (MCP/A2A JSON-RPC with "jsonrpc"/"kind", OpenAI
+// chat chunks with "object") have no top-level string "type" and
+// return "", so their data-only framing is preserved unchanged.
+func sseEventName(frame []byte) string {
+	var probe struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(frame, &probe); err != nil {
+		return ""
+	}
+	return probe.Type
 }
 
 // idleReader wraps r so each Read enforces an idle deadline. The

--- a/authbridge/authlib/listener/forwardproxy/server.go
+++ b/authbridge/authlib/listener/forwardproxy/server.go
@@ -293,6 +293,12 @@ func (s *Server) serveOutbound(w http.ResponseWriter, r *http.Request, isBridge 
 		if sid == "" {
 			sid = session.DefaultSessionID
 		}
+		// Pin this session so the paired response event records into the
+		// same bucket. Without it, recordOutboundResponseEvent re-resolves
+		// ActiveSession() at response time, which interleaving traffic (a
+		// health probe under "default") can flip mid-stream — mis-filing a
+		// streaming inference response away from its request's session.
+		pctx.OutboundSessionID = sid
 		// Snapshot-copy the protocol extension so the request event
 		// doesn't see response-phase mutations on the same MCP/Inference
 		// struct (e.g. token counts assigned in OnResponse).
@@ -499,7 +505,14 @@ func (s *Server) recordOutboundResponseEvent(pctx *pipeline.Context, statusCode 
 	if s.Sessions == nil {
 		return
 	}
-	sid := s.Sessions.ActiveSession()
+	// Prefer the session pinned when the request event was recorded so the
+	// response lands in the same bucket. Fall back to ActiveSession() only
+	// when nothing was pinned (defensive — a response-only path), then to
+	// the default bucket. See Context.OutboundSessionID.
+	sid := pctx.OutboundSessionID
+	if sid == "" {
+		sid = s.Sessions.ActiveSession()
+	}
 	if sid == "" {
 		sid = session.DefaultSessionID
 	}

--- a/authbridge/authlib/listener/forwardproxy/session_pin_test.go
+++ b/authbridge/authlib/listener/forwardproxy/session_pin_test.go
@@ -1,0 +1,94 @@
+package forwardproxy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kagenti/kagenti-extensions/authbridge/authlib/pipeline"
+	"github.com/kagenti/kagenti-extensions/authbridge/authlib/session"
+)
+
+// TestRecordOutboundResponse_PinsRequestSession is the regression guard for
+// the streaming-response session-correlation bug: an outbound response must
+// record into the SAME session as its request, even when interleaving traffic
+// (e.g. a health probe bucketed under "default") flips the global
+// ActiveSession() between the request and the stream-end response.
+func TestRecordOutboundResponse_PinsRequestSession(t *testing.T) {
+	store := session.New(5*time.Minute, 100, 0)
+	defer store.Close()
+
+	// The inbound A2A turn's request event landed under "conv-A".
+	store.Append("conv-A", pipeline.SessionEvent{
+		At:        time.Now().Add(-3 * time.Second),
+		Direction: pipeline.Inbound,
+		Phase:     pipeline.SessionRequest,
+		A2A:       &pipeline.A2AExtension{Method: "message/stream", SessionID: "conv-A"},
+	})
+	s := &Server{Sessions: store}
+
+	// The outbound inference REQUEST pinned conv-A on the context.
+	pctx := &pipeline.Context{
+		Direction:         pipeline.Outbound,
+		Host:              "ete-litellm.example",
+		StartedAt:         time.Now().Add(-3 * time.Second),
+		OutboundSessionID: "conv-A",
+	}
+
+	// A health probe (no A2A contextId) lands under "default" mid-stream,
+	// flipping the global most-recently-updated session.
+	store.Append(session.DefaultSessionID, pipeline.SessionEvent{
+		At:        time.Now(),
+		Direction: pipeline.Inbound,
+		Phase:     pipeline.SessionRequest,
+		Host:      "claude-agent.team1.svc",
+	})
+	if got := store.ActiveSession(); got != session.DefaultSessionID {
+		t.Fatalf("precondition: ActiveSession() = %q, want %q", got, session.DefaultSessionID)
+	}
+
+	// Record the streaming response — must land in the pinned conv-A.
+	s.recordOutboundResponseEvent(pctx, 200)
+
+	countResp := func(id string) int {
+		v := store.View(id)
+		if v == nil {
+			return 0
+		}
+		n := 0
+		for _, e := range v.Events {
+			if e.Direction == pipeline.Outbound && e.Phase == pipeline.SessionResponse {
+				n++
+			}
+		}
+		return n
+	}
+	if got := countResp("conv-A"); got != 1 {
+		t.Fatalf("response not recorded in pinned session conv-A: got %d, want 1", got)
+	}
+	if got := countResp(session.DefaultSessionID); got != 0 {
+		t.Fatalf("response leaked into default (the bug): got %d, want 0", got)
+	}
+}
+
+// TestRecordOutboundResponse_FallsBackToActiveSession confirms the defensive
+// fallback: with no pinned id, recording uses ActiveSession() as before.
+func TestRecordOutboundResponse_FallsBackToActiveSession(t *testing.T) {
+	store := session.New(5*time.Minute, 100, 0)
+	defer store.Close()
+	store.Append("conv-B", pipeline.SessionEvent{
+		At:        time.Now(),
+		Direction: pipeline.Inbound,
+		Phase:     pipeline.SessionRequest,
+		A2A:       &pipeline.A2AExtension{Method: "message/stream", SessionID: "conv-B"},
+	})
+	s := &Server{Sessions: store}
+	// No OutboundSessionID set.
+	pctx := &pipeline.Context{Direction: pipeline.Outbound, Host: "x.example", StartedAt: time.Now()}
+
+	s.recordOutboundResponseEvent(pctx, 200)
+
+	v := store.View("conv-B")
+	if v == nil || len(v.Events) != 2 {
+		t.Fatalf("expected response recorded under ActiveSession conv-B (2 events), got %+v", v)
+	}
+}

--- a/authbridge/authlib/listener/forwardproxy/writesse_test.go
+++ b/authbridge/authlib/listener/forwardproxy/writesse_test.go
@@ -1,0 +1,88 @@
+package forwardproxy
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestSSEEventName verifies the event-name derivation: Anthropic stream
+// frames (top-level JSON "type") yield the SSE event name; data-only
+// protocol frames (MCP/A2A JSON-RPC, OpenAI chat chunks) and non-JSON
+// frames yield "" so no event: line is emitted for them.
+func TestSSEEventName(t *testing.T) {
+	cases := []struct {
+		name  string
+		frame string
+		want  string
+	}{
+		{"anthropic message_start", `{"type":"message_start","message":{}}`, "message_start"},
+		{"anthropic content_block_delta", `{"type":"content_block_delta","delta":{"type":"text_delta","text":"hi"}}`, "content_block_delta"},
+		{"anthropic message_stop", `{"type":"message_stop"}`, "message_stop"},
+		{"anthropic ping", `{"type":"ping"}`, "ping"},
+		{"mcp/a2a jsonrpc data-only", `{"jsonrpc":"2.0","id":1,"result":{}}`, ""},
+		{"openai chat chunk", `{"id":"x","object":"chat.completion.chunk","choices":[]}`, ""},
+		{"a2a kind not type", `{"kind":"status-update","taskId":"t1"}`, ""},
+		{"non-json [DONE]", `[DONE]`, ""},
+		{"empty", ``, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sseEventName([]byte(tc.frame)); got != tc.want {
+				t.Fatalf("sseEventName(%q) = %q, want %q", tc.frame, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestWriteSSEFrameAnthropicAddsEventLine is the regression guard for the
+// duplicate-call bug: the sseframe reader strips the SSE event: line, and
+// the Anthropic client needs it to finalize the stream — without it the
+// CLI falls back to a second, non-streaming request (doubling the call).
+// writeSSEFrame must reconstruct event: <type> before the data: line.
+func TestWriteSSEFrameAnthropicAddsEventLine(t *testing.T) {
+	var buf bytes.Buffer
+	frame := []byte(`{"type":"message_start","message":{"id":"msg_1"}}`)
+	if !writeSSEFrame(&buf, frame) {
+		t.Fatal("writeSSEFrame returned false")
+	}
+	want := "event: message_start\n" +
+		`data: {"type":"message_start","message":{"id":"msg_1"}}` + "\n\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("anthropic frame:\n got %q\nwant %q", got, want)
+	}
+}
+
+// TestWriteSSEFrameDataOnlyHasNoEventLine guards the other direction:
+// data-only protocols must keep their data-only framing (no event: line),
+// otherwise we'd corrupt MCP/A2A/OpenAI streams.
+func TestWriteSSEFrameDataOnlyHasNoEventLine(t *testing.T) {
+	var buf bytes.Buffer
+	frame := []byte(`{"jsonrpc":"2.0","id":1,"result":{"ok":true}}`)
+	if !writeSSEFrame(&buf, frame) {
+		t.Fatal("writeSSEFrame returned false")
+	}
+	got := buf.String()
+	if strings.Contains(got, "event:") {
+		t.Fatalf("data-only frame must not get an event: line, got %q", got)
+	}
+	want := `data: {"jsonrpc":"2.0","id":1,"result":{"ok":true}}` + "\n\n"
+	if got != want {
+		t.Fatalf("jsonrpc frame:\n got %q\nwant %q", got, want)
+	}
+}
+
+// TestWriteSSEFrameMultiLineData ensures the event: line is not emitted for
+// a multi-line (non-JSON) folded data payload, and that each data line is
+// re-prefixed.
+func TestWriteSSEFrameMultiLineData(t *testing.T) {
+	var buf bytes.Buffer
+	frame := []byte("line-a\nline-b")
+	if !writeSSEFrame(&buf, frame) {
+		t.Fatal("writeSSEFrame returned false")
+	}
+	want := "data: line-a\ndata: line-b\n\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("multi-line frame:\n got %q\nwant %q", got, want)
+	}
+}

--- a/authbridge/authlib/listener/forwardproxy/writesse_test.go
+++ b/authbridge/authlib/listener/forwardproxy/writesse_test.go
@@ -25,6 +25,13 @@ func TestSSEEventName(t *testing.T) {
 		{"a2a kind not type", `{"kind":"status-update","taskId":"t1"}`, ""},
 		{"non-json [DONE]", `[DONE]`, ""},
 		{"empty", ``, ""},
+		// Allowlist guards: the "type" comes from an untrusted upstream, so
+		// unknown / non-Anthropic / injection-bearing values must NOT become
+		// event names.
+		{"unknown type not allowlisted", `{"type":"foo"}`, ""},
+		{"openai responses top-level type", `{"type":"response.output_text.delta"}`, ""},
+		{"crlf injection in type rejected", "{\"type\":\"message_start\\nid: 1\"}", ""},
+		{"crlf injection bare rejected", "{\"type\":\"x\\r\\nevent: injected\"}", ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -84,5 +91,33 @@ func TestWriteSSEFrameMultiLineData(t *testing.T) {
 	want := "data: line-a\ndata: line-b\n\n"
 	if got := buf.String(); got != want {
 		t.Fatalf("multi-line frame:\n got %q\nwant %q", got, want)
+	}
+}
+
+// TestWriteSSEFrameRejectsUnknownAndInjection is the end-to-end guard for the
+// allowlist: a frame whose top-level "type" is unknown, non-Anthropic, or
+// carries injection bytes (CRLF) must be relayed data-only — never an
+// attacker-controlled event: line.
+func TestWriteSSEFrameRejectsUnknownAndInjection(t *testing.T) {
+	for _, frame := range []string{
+		`{"type":"foo"}`,
+		`{"type":"response.output_text.delta"}`,
+		"{\"type\":\"message_start\\nid: 1\"}",
+		"{\"type\":\"x\\r\\nevent: injected\"}",
+	} {
+		var buf bytes.Buffer
+		if !writeSSEFrame(&buf, []byte(frame)) {
+			t.Fatalf("writeSSEFrame returned false for %q", frame)
+		}
+		// The security property is "no SSE event: FIELD line was emitted".
+		// A literal "event:" inside a data payload is harmless — every body
+		// line is written with a "data: " prefix, so only a reconstructed
+		// name from sseEventName could produce a bare event: line.
+		got := buf.String()
+		for _, line := range strings.Split(got, "\n") {
+			if strings.HasPrefix(line, "event:") {
+				t.Fatalf("emitted an event: line for %q:\n%q", frame, got)
+			}
+		}
 	}
 }

--- a/authbridge/authlib/pipeline/context.go
+++ b/authbridge/authlib/pipeline/context.go
@@ -119,6 +119,18 @@ type Context struct {
 	Identity Identity     // nil before an auth plugin runs
 	Session  *SessionView // nil unless session tracking is enabled
 
+	// OutboundSessionID pins the session bucket resolved when the
+	// outbound REQUEST event was recorded, so the paired RESPONSE event
+	// lands in the same session. recordOutboundResponseEvent reuses it
+	// instead of re-resolving Store.ActiveSession() at response time:
+	// ActiveSession() returns the global "most-recently-updated session",
+	// which interleaving traffic (e.g. a health probe bucketed under
+	// "default") can flip between a streaming request and its response,
+	// mis-filing the response into the wrong session. Empty when no
+	// request event was recorded (skip_hosts, sessions disabled), in
+	// which case the response recorder falls back to ActiveSession().
+	OutboundSessionID string
+
 	// TLS is the connection state of the inbound TLS handshake when
 	// the request arrived over TLS, nil otherwise. Populated by the
 	// reverse-proxy listener; nil for plaintext callers (UI, curl,


### PR DESCRIPTION
Two forward-proxy fixes for inference traffic fidelity, both verified end-to-end on a Kind cluster.

## Fix 1 — Preserve SSE `event:` lines when relaying inference responses

**Problem.** The forward proxy doubles every upstream inference call when an agent talks to an Anthropic Messages endpoint (e.g. litellm). A single agent turn — even a no-tool `"hello"` — issues **two** identical upstream calls instead of one, roughly doubling inference token cost.

**Root cause.** `sseframe.Reader` surfaces only the `data:` payload of each SSE event and intentionally drops the `event:` field — correct for the data-only streams it was built for (MCP/A2A JSON-RPC, OpenAI chat chunks). `writeSSEFrame` then relays frames as `data:`-only. But Anthropic Messages streaming **requires** a typed `event:` line before each `data:`; without it the Anthropic client (the `claude` CLI's bundled SDK) can't finalize the stream and **falls back to a non-streaming retry** — a second, identical request. (Invisible to `num_turns`, which counts logical turns, not HTTP calls.)

**Fix.** Reconstruct the `event:` line in `writeSSEFrame` from the payload's top-level JSON `"type"`, which for an Anthropic stream event is exactly the SSE event name (`message_start` … `message_stop`, `ping`, `error`). Frames with no top-level string `"type"` (JSON-RPC, OpenAI chat chunks, `[DONE]`) get no event line, so data-only protocols are unchanged. Self-gating; no plugin/pipeline changes.

## Fix 2 — Pin outbound session so streaming responses pair with their request

**Problem.** In the session trace, an inference request and its response can land in **different** sessions: the request under the A2A conversation, the response under `default`. abctl then shows a request row with no paired response.

**Root cause.** `recordOutboundResponseEvent` re-resolved `Store.ActiveSession()` at response time. `ActiveSession()` is the global most-recently-updated session, so interleaving traffic (e.g. an inbound health probe bucketed under `default`) flips it between an outbound request and its seconds-later streaming response. The inbound path already abandoned `ActiveSession()` for exactly this cross-conversation contamination (`reverseproxy.inboundSessionID`); the outbound path still used it.

**Fix.** Pin the session id resolved when the request event is recorded onto `pipeline.Context` (`OutboundSessionID`) and reuse it for the paired response; fall back to `ActiveSession()` only when nothing was pinned. The same `pctx` flows through the buffered, streaming, and buffered-fallback response paths, so one change covers all three.

## Tests

- `writesse_test.go` — `event:` reconstruction for Anthropic frames; absence for JSON-RPC / data-only / non-JSON.
- `session_pin_test.go` — response records into the pinned session even after `ActiveSession()` flips to `default`; fallback still uses `ActiveSession()` when nothing is pinned.

## Verification (Kind, proxy-sidecar)

- Patched proxy relays canonical Anthropic SSE again (regained its `event:` lines; previously 0).
- A no-tool `claude "hello"` dropped from **2 litellm round-trips to 1** (via the `:9094` session API).
- The same litellm endpoint returns canonical `event:`-framed SSE when hit directly — confirming the stripping was in the proxy, not the upstream.

## Follow-ups (not in this PR)

- The reverse proxy's streaming re-framing (`streamingResponseBody`) and the envoy-sidecar path (`extproc`) drop `event:` the same way — harmless for data-only A2A today, but worth the same treatment for full Anthropic SSE fidelity.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSE forwarding so Anthropic-style JSON stream chunks are relayed with the correct `event:` line when available, while preserving data-only behavior for other protocols.
  * Fixed outbound response session correlation by ensuring responses are recorded under the session used for the initiating outbound request.

* **Tests**
  * Added regression coverage for SSE framing and event-name derivation, including allowlist/injection handling and multi-line payloads.
  * Added regression tests to verify outbound response recording with pinned session IDs and fallback behavior when none is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->