### PR TITLE
Docs: Quote curl command so that link is not rendered

### DIFF
--- a/authbridge/demos/github-issue/demo-aiac.md
+++ b/authbridge/demos/github-issue/demo-aiac.md
@@ -509,17 +509,21 @@ Verify $ADMIN_TOKEN is not empty (Keycloak reachable?) and that setup_keycloak.p
 
 <sub><span style="color: gray; font-size: 0.9em;">
 You can also list all clients with: \
-curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "http://keycloak-service.keycloak.svc:8080/admin/realms/kagenti/clients" | jq '.[].clientId'
+`curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "http://keycloak-service.keycloak.svc:8080/admin/realms/kagenti/clients" | jq '.[].clientId'`
 </span></sub>
 
 <sub><span style="color: gray; font-size: 0.9em;">
-if ALICE_TOKEN (or BOB_TOKEN) is null or empty run \
+if ALICE_TOKEN (or BOB_TOKEN) is null or empty run
+
+```bash
 curl -s -X POST "http://keycloak-service.keycloak.svc:8080/realms/${REALM_NAME}/protocol/openid-connect/token" \
    -d "grant_type=password" \
    -d "username=alice" \
    -d "password=alice123" \
    --data-urlencode "client_id=$CLIENT_ID" \
-   --data-urlencode "client_secret=$CLIENT_SECRET" \
+   --data-urlencode "client_secret=$CLIENT_SECRET"
+```
+
 Look for error message e.g. "Invalid user credentials" will require updating user credentials in keycloak
 </span></sub>
 


### PR DESCRIPTION
## Summary

Resolves #532

Some commands the user is intended to type were not backtick-escaped, and render URLs that are meant to be executed by code, not visited by documentation readers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the GitHub issue demo walkthrough with clearer troubleshooting steps.
  * Added guidance for listing Keycloak clients and viewing their client IDs.
  * Refined instructions for regenerating access tokens when values are missing or empty.
  * Improved the formatting of the token request example for easier copy/paste.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->